### PR TITLE
Fix build error : PropertySortOrder: Properties should be ordered pad…

### DIFF
--- a/assets/scss/_boosted-docs.scss
+++ b/assets/scss/_boosted-docs.scss
@@ -103,8 +103,8 @@
   margin-top: 0;
 
   .o-footer-body {
-    font-size: $font-size-base !important;
     padding: 1.25rem 0;
+    font-size: $font-size-base !important;
 
     p {
       margin: 0;


### PR DESCRIPTION
Fix PropertySortOrder: Properties should be ordered padding, font-size

Related to : https://travis-ci.org/Orange-OpenSource/Orange-Boosted-Bootstrap/jobs/287489245#L605 on #71