### PR TITLE
fix node_modules path in `scss/_functions.scss`

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -1,7 +1,7 @@
 // Bootstrap functions
 //
 // Utility mixins and functions for evalutating source code across our variables, maps, and mixins.
-@import "../node_modules/sass-math-pow/sass/math-pow";
+@import "node_modules/sass-math-pow/sass/math-pow";
 // Ascending
 // Used to evaluate Sass maps like our grid breakpoints.
 @mixin _assert-ascending($map, $map-name) {


### PR DESCRIPTION
If you install `boosted: 4.0.0` as npm dependency, path `../node_modules/` in `scss/_functions.scss` do not exists in npm >= 3 environments. 
