### PR TITLE
o-tab - move tab to accordions on `sm` display

### DIFF
--- a/scss/_o-nav.scss
+++ b/scss/_o-nav.scss
@@ -124,7 +124,7 @@
     }
   }
 
-  @include media-breakpoint-down(xs) {
+  @include media-breakpoint-down(sm) {
     .o-tab-heading {
       flex-grow: 1;
       margin-left: 0;


### PR DESCRIPTION
fix(o-tab): update mediaquery size for switching from tab to accordions also on small view like tablet

Related to https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/131