### PR TITLE
fix(custom-checkbox): remove unnecessary code #134

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -96,7 +96,6 @@
     display: block;
     width: $custom-control-indicator-size;
     height: $custom-control-indicator-size;
-    pointer-events: auto;
     content: "";
     background-color: $custom-control-indicator-bg;
     border: $custom-control-indicator-border-color solid $custom-control-indicator-border-width;


### PR DESCRIPTION
Enabling the click on the orange background of a custom checkbox.