### PR TITLE
test(js): fix unit test for android mobile 

### DIFF
--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -764,7 +764,7 @@ $(function () {
 
     var $modalBody = $('.modal-body')
     $modalBody.scrollTop(100)
-    assert.strictEqual($modalBody.scrollTop(), 100)
+    assert.strictEqual(Math.ceil($modalBody.scrollTop()), 100)
 
     $modal.on('shown.bs.modal', function () {
       assert.strictEqual($modalBody.scrollTop(), 0, 'modal body scrollTop should be 0 when opened')

--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -604,7 +604,7 @@ $(function () {
 
     var testElementIsActiveAfterScroll = function (element, target) {
       var deferred = $.Deferred()
-      var scrollHeight = Math.ceil($content.scrollTop() + $(target).position().top)
+      var scrollHeight = Math.ceil($content.scrollTop() + $(target).position().top + 1)
       $content.one('scroll', function () {
         assert.ok($(element).hasClass('active'), 'target:' + target + ', element: ' + element)
         deferred.resolve()


### PR DESCRIPTION
following turned on zoom for DSF the scroll offsets can return fractional parts in chromium https://bugs.chromium.org/p/chromium/issues/detail?id=737777

There's a failed in unit tests