### PR TITLE
feat(scrollup): custom target

### DIFF
--- a/js/tests/unit/o-scroll-up.js
+++ b/js/tests/unit/o-scroll-up.js
@@ -32,4 +32,15 @@ $(function () {
     assert.ok($scrollup instanceof $, 'returns jquery collection')
     assert.strictEqual($scrollup[0], $el[0], 'collection contains element')
   })
+
+  QUnit.test('should throw explicit error on undefined method', function (assert) {
+    assert.expect(1)
+    var $el = $('<div/>').appendTo('#qunit-fixture')
+    $el.bootstrapScrollup()
+    try {
+      $el.bootstrapScrollup('noMethod')
+    } catch (err) {
+      assert.strictEqual(err.message, 'No method named "noMethod"')
+    }
+  })
 })

--- a/site/docs/4.3/components/scroll-up.md
+++ b/site/docs/4.3/components/scroll-up.md
@@ -33,3 +33,25 @@ You can let the text `.o-scroll-up-text` display on all devices.
 </a>
 {% endcapture %} {% include example.html content=example %}
 
+## Options
+
+Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-`, as in `data-target="#anchor"`.
+
+<table class="table table-bordered table-striped">
+  <thead>
+    <tr>
+      <th style="width: 100px;">Name</th>
+      <th style="width: 100px;">Type</th>
+      <th style="width: 50px;">Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>target</td>
+      <td>string</td>
+      <td>null</td>
+      <td>Allow you to specify a query selector of the custom top of the page. If it's set the go back to top action will scroll into the view to this anchor instead of positionning the offset top to 0</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
add an option to scrollup component to allow passing an anchor to replace the top of the page

Usage : add `data-target="#myAnchor"` to the o-scroll-up component

Fixes #175 