### PR TITLE
Fix dropdown menu alignment

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -484,7 +484,7 @@
             border: 0;
 
             &.dropdown {
-              align-self: flex-end;
+              align-self: center;
             }
           }
           // end mod


### PR DESCRIPTION
In _navbar.scss, line 487, replace align-self: flex-end by align-self: flex-end

Fix #343