### PR TITLE
fix(italic): em & .font-italic now render as bold to match the brand …

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -209,6 +209,7 @@ blockquote {
 }
 
 b,
+em, // Boosted mod
 strong {
   font-weight: $font-weight-bolder; // Add the correct font weight in Chrome, Edge, and Safari
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -338,7 +338,7 @@ $font-weight-lighter:         lighter !default;
 $font-weight-light:           300 !default;
 $font-weight-normal:          400 !default;
 $font-weight-bold:            700 !default;
-$font-weight-bolder:          bolder !default;
+$font-weight-bolder:          $font-weight-bold !default;
 
 $font-weight-base:            $font-weight-normal !default;
 $line-height-base:            1.25 !default; // 20px

--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -40,7 +40,7 @@
 .font-weight-normal  { font-weight: $font-weight-normal !important; }
 .font-weight-bold    { font-weight: $font-weight-bold !important; }
 //.font-weight-bolder  { font-weight: $font-weight-bolder !important; }
-//.font-italic         { font-style: italic !important; }
+.font-italic         { font-weight: $font-weight-bold !important; }
 // end mod
 
 // Contextual colors

--- a/site/docs/4.4/content/typography.md
+++ b/site/docs/4.4/content/typography.md
@@ -301,7 +301,7 @@ Styling for common inline HTML5 elements.
 <p><u>This line of text will render as underlined</u></p>
 <p><small>This line of text is meant to be treated as fine print.</small></p>
 <p><strong>This line rendered as bold text.</strong></p>
-<p><em>This line rendered as italicized text.</em></p>
+<p><em>This line rendered as bold text too,</em> but would natively be italicized</p>
 {% endcapture %}
 {% include example.html content=example %}
 

--- a/site/docs/4.4/utilities/text.md
+++ b/site/docs/4.4/utilities/text.md
@@ -103,6 +103,7 @@ Orange Brand — thus Boosted — does not allow italic styles, and light, light
 {% capture example %}
 <p class="font-weight-bold">Bold text.</p>
 <p class="font-weight-normal">Normal weight text.</p>
+<p class="font-italic">Bold text, too.</p>
 {% endcapture %}
 {% include example.html content=example %}
 


### PR DESCRIPTION
…and improve retro-compatibility with Bootstrap.

Fixes #365 