### PR TITLE
`:focus-visible` polyfill

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/boosted.bundle.js",
-      "maxSize": "51 kB"
+      "maxSize": "53.25 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.min.js",
@@ -42,15 +42,15 @@
     },
     {
       "path": "./dist/js/boosted.esm.js",
-      "maxSize": "28 kB"
+      "maxSize": "30.25 kB"
     },
     {
       "path": "./dist/js/boosted.esm.min.js",
-      "maxSize": "19 kB"
+      "maxSize": "19.5 kB"
     },
     {
       "path": "./dist/js/boosted.js",
-      "maxSize": "29 kB"
+      "maxSize": "31 kB"
     },
     {
       "path": "./dist/js/boosted.min.js",

--- a/js/index.esm.js
+++ b/js/index.esm.js
@@ -16,6 +16,7 @@ import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
 import Tooltip from './src/tooltip'
+import '../node_modules/focus-visible/dist/focus-visible.js' // Boosted mod
 
 export {
   Alert,

--- a/js/index.esm.js
+++ b/js/index.esm.js
@@ -16,7 +16,7 @@ import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
 import Tooltip from './src/tooltip'
-import '../node_modules/focus-visible/dist/focus-visible.js' // Boosted mod
+import 'focus-visible' // Boosted mod
 
 export {
   Alert,

--- a/js/index.umd.js
+++ b/js/index.umd.js
@@ -16,7 +16,7 @@ import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
 import Tooltip from './src/tooltip'
-import '../node_modules/focus-visible/dist/focus-visible.js' // Boosted mod
+import 'focus-visible' // Boosted mod
 
 export default {
   Alert,

--- a/js/index.umd.js
+++ b/js/index.umd.js
@@ -16,6 +16,7 @@ import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
 import Tooltip from './src/tooltip'
+import '../node_modules/focus-visible/dist/focus-visible.js' // Boosted mod
 
 export default {
   Alert,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5566,6 +5566,12 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "focus-visible": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.1.0.tgz",
+      "integrity": "sha512-nPer0rjtzdZ7csVIu233P2cUm/ks/4aVSI+5KUkYrYpgA7ujgC3p6J7FtFU+AIMWwnwYQOB/yeiOITxFeYIXiw==",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-unicorn": "^20.0.0",
     "find-unused-sass-variables": "^2.0.0",
+    "focus-visible": "^5.1.0",
     "glob": "^7.1.6",
     "hammer-simulator": "0.0.1",
     "hugo-bin": "^0.59.0",

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -201,11 +201,15 @@
       border-color: $gray-500;
     }
 
-    &:active {
+    // stylelint-disable selector-max-class
+    &:active,
+    &.active.focus {
       color: $white;
       background-color: $primary;
       border-color: $primary;
+      outline-color: $primary;
     }
+    // stylelint-enable selector-max-class
 
     &.active {
       color: $white;

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -201,22 +201,22 @@
       border-color: $gray-500;
     }
 
-    // stylelint-disable selector-max-class
+    // stylelint-disable selector-max-class, declaration-no-important
     &:active,
     &.active.focus {
       color: $white;
       background-color: $primary;
       border-color: $primary;
-      outline-color: $primary;
+      outline: $btn-border-width solid $primary !important;
     }
-    // stylelint-enable selector-max-class
 
     &.active {
       color: $white;
       background-color: $black;
       border-color: $black;
-      outline-color: $black;
+      outline-color: $black !important;
     }
+    // stylelint-enable selector-max-class, declaration-no-important
     // End mod
 
     input[type="radio"],

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -17,6 +17,7 @@
   user-select: none;
   background-color: transparent;
   border: $btn-border-width solid transparent;
+  outline-offset: map-get($spacers, 1); // Boosted mod
   @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-border-radius);
   @include transition($btn-transition);
 
@@ -27,6 +28,7 @@
 
   &:focus,
   &.focus {
+    outline-offset: $btn-border-width; // Boosted mod
     box-shadow: $btn-focus-box-shadow;
   }
 

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -28,8 +28,13 @@
 
   &:focus,
   &.focus {
-    outline-offset: $btn-border-width; // Boosted mod
-    box-shadow: $btn-focus-box-shadow;
+    // Boosted mod
+    outline-offset: $btn-border-width;
+
+    &[data-focus-visible-added] {
+      box-shadow: $btn-focus-box-shadow;
+    }
+    // End mod
   }
 
   &:active,

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -27,7 +27,6 @@
 
   &:focus,
   &.focus {
-    outline: 0;
     box-shadow: $btn-focus-box-shadow;
   }
 

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -248,6 +248,7 @@
       border: 0;
 
       .btn {
+        position: relative;
         width: add(100%, $accordion-spacer * 2);
         padding: $card-cap-padding-y;
         margin: 0 -#{$accordion-spacer};

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -106,7 +106,6 @@
   &:focus {
     color: $carousel-control-color;
     text-decoration: none;
-    outline: 0;
     opacity: $carousel-control-hover-opacity;
   }
 }

--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -21,6 +21,12 @@
     outline-offset: -#{$border-width};
   }
 
+  // Boosted mod
+  &:focus {
+    @include transition($transition-focus);
+  }
+  // End mod
+
   &:disabled,
   &.disabled {
     pointer-events: none;

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -152,6 +152,7 @@
   &:focus {
     color: $dropdown-link-hover-color;
     text-decoration: if($link-hover-decoration == underline, none, null);
+    outline-color: $dropdown-link-hover-bg; // Boosted mod
     @include gradient-bg($dropdown-link-hover-bg);
   }
 

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -22,6 +22,8 @@
   width: 100%; // For `<button>`s (anchors become 100% by default though)
   color: $list-group-action-color;
   text-align: inherit; // For `<button>`s (anchors inherit)
+  outline-offset: $spacer; // Boosted mod
+  @include transition($transition-focus); // Boosted mod
 
   // Hover state
   &:hover,
@@ -29,6 +31,8 @@
     z-index: 1; // Place hover/focus items above their siblings for proper border styling
     color: $list-group-action-hover-color;
     text-decoration: none;
+    outline-color: $list-group-action-color; // Boosted mod
+    outline-offset: $list-group-border-width; // Boosted mod
     // Boosted mod: no background change
   }
 

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -24,9 +24,6 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  // Prevent Chrome on Windows from adding a focus outline. For details, see
-  // https://github.com/twbs/bootstrap/pull/10951.
-  outline: 0;
   // We deliberately don't use `-webkit-overflow-scrolling: touch;` due to a
   // gnarly iOS Safari bug: https://bugs.webkit.org/show_bug.cgi?id=158342
   // See also https://github.com/twbs/bootstrap/issues/17695
@@ -88,8 +85,6 @@
   border: if($modal-content-border-color == null, null, $modal-content-border-width solid $modal-content-border-color); // Boosted mod
   @include border-radius($modal-content-border-radius);
   @include box-shadow($modal-content-box-shadow-xs);
-  // Remove focus outline from opened modal
-  outline: 0;
 }
 
 // Modal background

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -63,6 +63,9 @@
       color: color-contrast($nav-tabs-link-hover-border-color); // Boosted mod
       background-color: $nav-tabs-link-hover-border-color; // Boosted mod
       border-color: $nav-tabs-link-hover-border-color;
+      outline-color: $nav-tabs-link-hover-border-color; // Boosted mod
+      // stylelint-disable-next-line function-blacklist
+      outline-offset: var(--bs-tabs-spacing); // Boosted mod
     }
 
     &.disabled {
@@ -77,6 +80,7 @@
     color: $nav-tabs-link-active-color;
     background-color: $nav-tabs-link-active-bg;
     border-color: $nav-tabs-link-active-border-color;
+    outline-color: $nav-tabs-link-active-border-color; // Boosted mod
   }
 
   .dropdown-menu {
@@ -102,6 +106,7 @@
       color: $primary;
       background: none;
       border-color: transparent;
+      outline-color: currentColor;
     }
 
     &.active {
@@ -123,6 +128,7 @@
   .nav-link.active,
   .show > .nav-link {
     color: $nav-pills-link-active-color;
+    outline-color: $nav-pills-link-active-bg; // Boosted mod
     @include gradient-bg($nav-pills-link-active-bg);
   }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -205,7 +205,6 @@
 
   &:focus {
     text-decoration: none;
-    outline: 0;
     box-shadow: 0 0 0 $navbar-toggler-focus-width;
   }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -136,6 +136,10 @@
     outline-offset: $spacer;
     @include transition($navbar-transition);
 
+    &:focus {
+      outline-offset: 0;
+    }
+
     &.active::before {
       position: absolute;
       right: $nav-link-padding-y / 2;
@@ -196,6 +200,7 @@
   line-height: 1;
   background-color: transparent; // remove default button style
   border: $border-width solid transparent; // remove default button style
+  outline-offset: $spacer; // Boosted mod
   @include border-radius($navbar-toggler-border-radius);
   @include transition($navbar-toggler-transition);
 
@@ -205,6 +210,7 @@
 
   &:focus {
     text-decoration: none;
+    outline-offset: -$border-width; // Boosted mod
     box-shadow: 0 0 0 $navbar-toggler-focus-width;
   }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -29,6 +29,7 @@
 
   &:focus {
     z-index: 3;
+    color: $pagination-focus-color; // Boosted mod
     outline: $pagination-focus-outline;
     box-shadow: $pagination-focus-box-shadow;
   }
@@ -37,6 +38,7 @@
     color: $pagination-active-color;
     background-color: $pagination-active-item-bg;
     border-color: $pagination-active-item-border-color;
+    outline-color: $pagination-active-item-border-color; // Boosted mod
   }
 
   // Boosted mod
@@ -57,6 +59,7 @@
     color: $pagination-active-color;
     @include gradient-bg($pagination-active-bg);
     border-color: $pagination-active-border-color;
+    outline-color: $pagination-active-bg; // Boosted mod
   }
 
   &.disabled .page-link {
@@ -89,6 +92,7 @@
       color: $pagination-hover-bg;
       background-color: $pagination-hover-color;
       border-color: $pagination-hover-color;
+      outline-color: $pagination-hover-color; // Boosted mod
     }
 
     &:active {

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -309,6 +309,7 @@ sup { top: -.5em; }
 // Links
 
 a {
+  display: inline-block; // Boosted mod: To make `outline` wrap multiple lines
   color: $link-color;
   text-decoration: $link-decoration;
   // Boosted mod
@@ -483,14 +484,7 @@ button {
   border-radius: 0;
 }
 
-// Work around a Firefox bug where the transparent `button` background
-// results in a loss of the default `button` focus styles.
-// Credit https://github.com/suitcss/base/
-
-button:focus {
-  outline: 1px dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-}
+// Boosted mod: we customized focus, no need to restore defaults
 
 // 1. Remove the margin in Firefox and Safari
 

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -70,11 +70,18 @@ body {
   outline: 0 !important;
 }
 
-// Boosted mod
-// Using the :focus-visible polyfill to hide outline defensively
+// Boosted mod: focus state
+//
+// 1. Default focus state
+// 2. Using the :focus-visible polyfill to hide outline defensively
 // See https://github.com/WICG/focus-visible
+
+:focus {
+  outline: $outline-width solid; // 1
+}
+
 .js-focus-visible :focus:not([data-focus-visible-added]),
-.js-focus-visible .focus:not([data-focus-visible-added]) {
+.js-focus-visible .focus:not([data-focus-visible-added]) { // 2
   outline: 0 !important;
 }
 // End mod
@@ -207,13 +214,14 @@ ul {
 
 // Future-proof markers' color
 // See https://developer.mozilla.org/fr/docs/Web/CSS/::marker
+// stylelint-disable selector-max-type
 li::marker {
   color: $primary;
   vertical-align: middle;
 }
 
 li li::marker { color: $gray-600; }
-// stylelint-disable-next-line selector-max-type
+
 li li li::marker { color: $gray-500; }
 
 // Bullet-proof markers' color
@@ -225,8 +233,9 @@ li::before {
 }
 
 li li::before { color: $gray-600; }
-// stylelint-disable-next-line selector-max-type
+
 li li li::before { color: $gray-500; }
+// stylelint-enable selector-max-type
 // End mod
 
 dt {
@@ -253,6 +262,7 @@ blockquote {
 // Add the correct font weight in Chrome, Edge, and Safari
 
 b,
+em, // Boosted mod
 strong {
   font-weight: $font-weight-bold; // Boosted mod: ensure 700
 }
@@ -301,6 +311,15 @@ sup { top: -.5em; }
 a {
   color: $link-color;
   text-decoration: $link-decoration;
+  // Boosted mod
+  outline-offset: $outline-offset * 4;
+  @include transition($transition-focus);
+
+  &:focus {
+    color: $link-hover-color;
+    outline-offset: $outline-offset;
+  }
+  // End mod
 
   &:hover {
     color: $link-hover-color;
@@ -606,7 +625,7 @@ legend {
 //    https://github.com/twbs/bootstrap/issues/11586.
 
 [type="search"] {
-  outline-offset: -2px; // 1
+  outline-offset: -#{$outline-offset}; // 1 // Boosted mod
   -webkit-appearance: textfield; // 2
 }
 

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -309,7 +309,7 @@ sup { top: -.5em; }
 // Links
 
 a {
-  display: inline-block; // Boosted mod: To make `outline` wrap multiple lines
+  display: inline-block; // Boosted mod: to make `outline` wrap multiple lines
   color: $link-color;
   text-decoration: $link-decoration;
   // Boosted mod

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -70,6 +70,15 @@ body {
   outline: 0 !important;
 }
 
+// Boosted mod
+// Using the :focus-visible polyfill to hide outline defensively
+// See https://github.com/WICG/focus-visible
+.js-focus-visible :focus:not([data-focus-visible-added]),
+.js-focus-visible .focus:not([data-focus-visible-added]) {
+  outline: 0 !important;
+}
+// End mod
+
 
 // Content grouping
 //

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -388,14 +388,8 @@ $utilities: map-merge(
         "light": $light,
         "white": $white,
         "body": $body-color,
+        "muted": $gray-700,
         "reset": inherit,
-      )
-    ),
-    "muted": (
-      property: opacity,
-      class: text,
-      values: (
-        "muted": .6
       )
     ),
     "line-height": (

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -386,10 +386,12 @@ $caret-width:                 add($spacer / 4, $border-width) !default;
 $caret-vertical-align:        center !default;
 $caret-spacing:               $spacer / 2 !default;
 
-$transition-base:             all .2s ease-in-out !default;
-$transition-fade:             opacity .15s linear !default;
-$transition-collapse:         height .35s ease !default;
-$transition-focus:            outline-offset .2s ease-in-out !default; // Boosted mod
+$transition-duration: .2s !default; // Boosted mod
+$transition-timing:   ease-in-out !default; // Boosted mod
+$transition-base:     all $transition-duration $transition-timing !default;
+$transition-fade:     opacity $transition-timing linear !default;
+$transition-collapse: height .35s ease !default;
+$transition-focus:    outline-offset $transition-duration $transition-timing !default; // Boosted mod
 
 // scss-docs-start embed-responsive-aspect-ratios
 $embed-responsive-aspect-ratios: (
@@ -627,7 +629,7 @@ $btn-border-radius:           $border-radius !default;
 $btn-border-radius-sm:        $border-radius-sm !default;
 $btn-border-radius-lg:        $border-radius-lg !default;
 
-$btn-transition:              color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
+$btn-transition:              color $transition-duration $transition-timing, background-color $transition-duration $transition-timing, border-color $transition-duration $transition-timing, $transition-focus !default;
 
 
 // Forms
@@ -688,7 +690,7 @@ $input-height:                          add($input-line-height * 1em, add($input
 // Boosted mod: no input-sm
 $input-height-lg:                       add($input-line-height * (20 / 18) * 1em, add($input-padding-y-lg * 2, $input-height-border, false)) !default;
 
-$input-transition:                      border-color .15s ease-in-out !default;
+$input-transition:                      border-color $transition-duration $transition-timing, $transition-focus !default;
 
 
 $form-check-input-width:                  1.25em !default;
@@ -697,7 +699,7 @@ $form-check-padding-left:                 $form-check-input-width + .5em !defaul
 $form-check-margin-bottom:                .125rem !default;
 $form-check-label-color:                  null !default;
 $form-check-label-cursor:                 null !default;
-$form-check-transition:                   background-color .15s ease-in-out, background-position .15s ease-in-out, border-color .15s ease-in-out !default;
+$form-check-transition:                   background-color $transition-duration $transition-timing, background-position $transition-duration $transition-timing, border-color $transition-duration $transition-timing !default;
 
 $form-check-input-active-filter:          null !default;
 $form-check-input-active-bg-color:        $component-active-bg !default; // Boosted mod
@@ -706,7 +708,7 @@ $form-check-input-bg:                     $body-bg !default;
 $form-check-input-border:                 $border-width solid $input-border-color !default;
 $form-check-input-border-radius:          null !default;
 $form-check-radio-border-radius:          50% !default;
-$form-check-input-focus-border:           $input-focus-border-color !default;
+$form-check-input-focus-border:           null !default;
 $form-check-input-focus-box-shadow:       $input-btn-focus-box-shadow !default;
 
 $form-check-input-checked-color:          $component-active-color !default;
@@ -794,7 +796,7 @@ $form-range-thumb-focus-box-shadow-width:  $input-focus-width !default; // For f
 $form-range-thumb-active-bg:               null !default;
 $form-range-thumb-active-border:           $component-active-bg !default; // Boosted mod
 $form-range-thumb-disabled-bg:             $gray-500 !default;
-$form-range-thumb-transition:              background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
+$form-range-thumb-transition:              background-color $transition-duration $transition-timing, border-color $transition-duration $transition-timing, box-shadow $transition-duration $transition-timing !default;
 
 $form-file-height:                $input-height !default;
 $form-file-focus-border-color:    $input-focus-border-color !default;
@@ -901,10 +903,10 @@ $navbar-brand-logo-minimized-height:   $spacer * 1.5 !default;
 $navbar-brand-name-margin:             0 $spacer 0 add($spacer / 2, $spacer / 4) !default;
 //$navbar-supra-padding-y:               $navbar-brand-logo-height / 10 !default;
 //$navbar-supra-padding-x:               $spacer / 4 * 1.5 !default;
-$navbar-transition-duration:           .2s !default;
-$navbar-transition-timing-function:    ease-in-out !default;
-$navbar-transition:                    padding $navbar-transition-duration $navbar-transition-timing-function !default;
-$navbar-brand-transition:              margin $navbar-transition-duration $navbar-transition-timing-function !default;
+$navbar-transition-duration:           $transition-duration !default;
+$navbar-transition-timing-function:    $transition-timing !default;
+$navbar-transition:                    padding $navbar-transition-duration $navbar-transition-timing-function, $transition-focus !default;
+$navbar-brand-transition:              margin $navbar-transition-duration $navbar-transition-timing-function, $transition-focus !default;
 $navbar-brand-logo-transition:         width $navbar-transition-duration $navbar-transition-timing-function, height $navbar-transition-duration $navbar-transition-timing-function !default;
 $navbar-active-transition:             bottom $navbar-transition-duration $navbar-transition-timing-function !default;
 // End mod
@@ -919,7 +921,7 @@ $navbar-toggler-padding-x:          .5rem !default;
 $navbar-toggler-font-size:          $font-size-base !default;
 $navbar-toggler-border-radius:      $btn-border-radius !default;
 $navbar-toggler-focus-width:        null !default;
-$navbar-toggler-transition:         null !default;
+$navbar-toggler-transition:         $transition-focus !default;
 
 $navbar-dark-color:                 $white !default;
 $navbar-dark-hover-color:           $orange-2 !default;
@@ -990,7 +992,8 @@ $pagination-margin-left:            $spacer / 2 !default;
 $pagination-border-color:           transparent !default;
 
 $pagination-focus-box-shadow:       $input-btn-focus-box-shadow !default;
-$pagination-focus-outline:          $pagination-border-width solid $gray-500 !default;
+$pagination-focus-color:            $primary !default; // Boosted mod
+$pagination-focus-outline:          $pagination-border-width solid $pagination-focus-color !default;
 
 $pagination-hover-color:            $black !default;
 $pagination-hover-bg:               $white !default;
@@ -1259,7 +1262,7 @@ $carousel-control-color:             $black !default;
 $carousel-control-width:             $spacer * 1.5 !default;
 $carousel-control-opacity:           null !default;
 $carousel-control-hover-opacity:     null !default;
-$carousel-control-transition:        outline-offset .2s ease-in-out !default;
+$carousel-control-transition:        $transition-focus !default;
 $carousel-control-offset:            $spacer / 2 !default; // Boosted mod
 
 $carousel-indicator-width:           $spacer / 2 !default;
@@ -1281,7 +1284,7 @@ $carousel-control-icon-size:         $spacer * 1.5 !default; // Boosted mod
 $carousel-control-prev-icon-bg:      $chevron-icon !default;
 
 $carousel-transition-duration:       .6s !default;
-$carousel-transition:                transform $carousel-transition-duration ease-in-out !default; // Define transform transition first if using multiple transitions (e.g., `transform 2s ease, opacity .5s ease-out`)
+$carousel-transition:                transform $carousel-transition-duration $transition-timing !default; // Define transform transition first if using multiple transitions (e.g., `transform 2s ease, opacity .5s ease-out`)
 
 
 // Spinners

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -827,7 +827,7 @@ $form-file-height-lg:             $input-height-lg !default;
 // Form validation
 
 $form-feedback-margin-top:          $form-text-margin-top !default;
-$form-feedback-font-size:           $form-text-font-size !default;
+$form-feedback-font-size:           $small-font-size !default;
 $form-feedback-font-style:          null !default;
 $form-feedback-valid-color:         $success !default;
 $form-feedback-invalid-color:       $danger !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -370,6 +370,9 @@ $border-radius:               null !default;
 $border-radius-sm:            null !default;
 $border-radius-lg:            null !default;
 
+$outline-width:               $border-width !default;  // Boosted mod
+$outline-offset:              $outline-width !default; // Boosted mod
+
 $rounded-pill:                50rem !default;
 
 $box-shadow:                  null !default;
@@ -386,7 +389,7 @@ $caret-spacing:               $spacer / 2 !default;
 $transition-base:             all .2s ease-in-out !default;
 $transition-fade:             opacity .15s linear !default;
 $transition-collapse:         height .35s ease !default;
-//$transition-focus:            null !default;
+$transition-focus:            outline-offset .2s ease-in-out !default; // Boosted mod
 
 // scss-docs-start embed-responsive-aspect-ratios
 $embed-responsive-aspect-ratios: (

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -613,8 +613,8 @@ $btn-border-width:            $input-btn-border-width !default;
 
 $btn-font-weight:             $font-weight-bold !default;
 $btn-box-shadow:              null !default;
-$btn-focus-width:             null !default;
-$btn-focus-box-shadow:        $input-btn-focus-box-shadow !default;
+$btn-focus-width:             $border-width !default;
+$btn-focus-box-shadow:        0 0 0 $btn-focus-width $white !default;
 $btn-disabled-opacity:        1 !default;
 $btn-active-box-shadow:       null !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -992,7 +992,7 @@ $pagination-margin-left:            $spacer / 2 !default;
 $pagination-border-color:           transparent !default;
 
 $pagination-focus-box-shadow:       $input-btn-focus-box-shadow !default;
-$pagination-focus-color:            $primary !default; // Boosted mod
+$pagination-focus-color:            $black !default; // Boosted mod
 $pagination-focus-outline:          $pagination-border-width solid $pagination-focus-color !default;
 
 $pagination-hover-color:            $black !default;

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -39,7 +39,6 @@
 
   &:focus {
     border-color: $form-check-input-focus-border;
-    outline: 0;
     box-shadow: $form-check-input-focus-box-shadow;
   }
 
@@ -166,7 +165,7 @@
     }
 
     &:focus {
-      outline: 0; // @TODO: custom focus
+      // @TODO: custom focus
     }
 
     &:active {

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -129,7 +129,7 @@
 
 .form-switch {
   // Boosted mod
-  --o-switch-gradient: linear-gradient(to right, $white $form-switch-bg-square-size, transparent);
+  --o-switch-gradient: #{linear-gradient(to right, $white $form-switch-bg-square-size, transparent)};
   min-height: $form-switch-width / 2;
   padding-left: $form-switch-padding-left;
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -73,7 +73,6 @@
   border: solid transparent;
   border-width: $input-border-width 0;
 
-  &.form-control-sm,
   &.form-control-lg {
     padding-right: 0;
     padding-left: 0;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -28,7 +28,6 @@
     color: $input-focus-color;
     background-color: $input-focus-bg;
     border-color: $input-focus-border-color;
-    outline: 0;
     @if $enable-shadows {
       @include box-shadow($input-box-shadow, $input-focus-box-shadow);
     } @else {

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -27,7 +27,8 @@
   &:focus {
     color: $input-focus-color;
     background-color: $input-focus-bg;
-    border-color: $input-focus-border-color;
+    border-color: $input-focus-border-color !important; // stylelint-disable-line declaration-no-important
+    outline: 0;
     @if $enable-shadows {
       @include box-shadow($input-box-shadow, $input-focus-box-shadow);
     } @else {

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -13,8 +13,6 @@
 
   &:focus {
     // Boosted mod: better focus visibility
-    outline: none;
-
     // Pseudo-elements must be split across multiple rulesets to have an effect.
     // No box-shadow() mixin for focus accessibility.
     &::-webkit-slider-thumb {

--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -25,7 +25,7 @@
   appearance: none;
 
   &:focus {
-    border-color: $form-select-focus-border-color;
+    border-color: $form-select-focus-border-color !important; // stylelint-disable-line declaration-no-important
     @if $enable-shadows {
       @include box-shadow($form-select-box-shadow, $form-select-focus-box-shadow);
     } @else {

--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -26,7 +26,6 @@
 
   &:focus {
     border-color: $form-select-focus-border-color;
-    outline: 0;
     @if $enable-shadows {
       @include box-shadow($form-select-box-shadow, $form-select-focus-box-shadow);
     } @else {

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -33,6 +33,7 @@
     color: $hover-color;
     @include gradient-bg($hover-background);
     border-color: $hover-border;
+    outline-color: $hover-border; // Boosted mod
     @if $enable-shadows {
       @include box-shadow($btn-box-shadow, 0 0 0 $btn-focus-width rgba(mix($color, $border, 15%), .5));
     } @else {
@@ -49,6 +50,7 @@
     // Remove CSS gradients if they're enabled
     background-image: if($enable-gradients, none, null);
     border-color: $active-border;
+    outline-color: $active-border; // Boosted mod
 
     &:focus {
       @if $enable-shadows {

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -34,12 +34,7 @@
     @include gradient-bg($hover-background);
     border-color: $hover-border;
     outline-color: $hover-border; // Boosted mod
-    @if $enable-shadows {
-      @include box-shadow($btn-box-shadow, 0 0 0 $btn-focus-width rgba(mix($color, $border, 15%), .5));
-    } @else {
-      // Avoid using mixin so we can pass custom focus shadow properly
-      box-shadow: 0 0 0 $btn-focus-width rgba(mix($color, $border, 15%), .5);
-    }
+    // Boosted mod: buttons share the same `box-shadow` on `:focus`
   }
 
   &:active,
@@ -52,14 +47,7 @@
     border-color: $active-border;
     outline-color: $active-border; // Boosted mod
 
-    &:focus {
-      @if $enable-shadows {
-        @include box-shadow($btn-active-box-shadow, 0 0 0 $btn-focus-width rgba($color, .5));
-      } @else {
-        // Avoid using mixin so we can pass custom focus shadow properly
-        box-shadow: 0 0 0 $btn-focus-width rgba($color, .5);
-      }
-    }
+    // Boosted mod: buttons share the same `box-shadow` on `:focus`
   }
 
   &:disabled,

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -67,9 +67,8 @@
         // Boosted mod: validation icon in .*-feedback
 
         // Boosted mod: no box-shadow
-        &:focus {
-          border-color: $color;
-        }
+
+        // Boosted mod: focus styles don't match validation state
       }
     }
 
@@ -82,9 +81,8 @@
         // Boosted mod: no icon in background
 
         // Boosted mod: no box-shadow
-        &:focus {
-          border-color: $color;
-        }
+
+        // Boosted mod: focus styles don't match validation state
       }
     }
 
@@ -117,7 +115,8 @@
 
         &:focus {
           ~ .form-file-label {
-            border-color: $color;
+            // Boosted mod: focus styles don't match validation state
+
             // Boosted mod: no box-shadow
           }
         }

--- a/site/assets/scss/_anchor.scss
+++ b/site/assets/scss/_anchor.scss
@@ -1,10 +1,18 @@
 .anchorjs-link {
+  // stylelint-disable-next-line declaration-no-important
+  padding: 0 map-get($spacers, 1) !important; // Boosted mod
   font-weight: 400;
   color: rgba($link-color, .5);
-  @include transition(color .15s ease-in-out);
+  @include transition(color .15s ease-in-out, $transition-focus); // Boosted mod
 
   &:hover {
     color: $link-color;
     text-decoration: none;
   }
+
+  // Boosted mod
+  &:focus {
+    outline-offset: 0;
+  }
+  // End mod
 }

--- a/site/assets/scss/_colors.scss
+++ b/site/assets/scss/_colors.scss
@@ -154,3 +154,60 @@
 
 .bd-white { color: color-contrast($white); background-color: $white; }
 .bd-black { color: color-contrast($black); background-color: $black; }
+
+// Boosted mod
+.bd-orange-2 { color: color-contrast($orange-2); background-color: $orange-2; }
+.bd-yellow-2 { color: color-contrast($yellow-2); background-color: $yellow-2; }
+
+@function wcag-level($contrast-ratio) {
+  $level: "FAIL";
+
+  @if $contrast-ratio > 3 {
+    $level: "AA Large text";
+  }
+
+  @if $contrast-ratio > 4.5 {
+    $level: "AA";
+  }
+
+  @if $contrast-ratio > 7 {
+    $level: "AAA";
+  }
+
+  @return $level;
+}
+
+@each $color, $value in map-merge($colors, map-merge($grays, ("yellow-2": $yellow-2, "orange-2": $orange-2, "black": $black))) {
+  .a11y-swatch-#{$color} {
+    color: color-contrast($value);
+    background-color: #{$value};
+
+    &::after {
+      $against-white: contrast-ratio($value, $white);
+      $against-black: contrast-ratio($value, $black);
+      position: absolute;
+      top: 1.5rem;
+      right: 1rem;
+      padding-left: 1rem;
+      font-size: .75rem;
+      line-height: 1.35;
+      white-space: pre;
+      content:
+        wcag-level($against-white) "\A"
+        wcag-level($against-black);
+      background-color: $value;
+      background-image:
+        linear-gradient(
+          to bottom,
+          transparent .25rem,
+          $white .25rem .75rem,
+          transparent .75rem 1.25rem,
+          $black 1.25rem 1.75rem,
+          transparent 1.75rem 2.25rem
+        );
+      background-repeat: no-repeat;
+      background-size: .5rem 100%;
+    }
+  }
+}
+// End mod

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -253,7 +253,8 @@
   // Boosted mod
   pre .language-sh { color: $gray-900; }
 
-  &:hover .language-html {
+  pre:hover .language-html,
+  pre:focus .language-html {
     color: $black;
   }
   // End mod

--- a/site/content/docs/5.0/components/collapse.md
+++ b/site/content/docs/5.0/components/collapse.md
@@ -127,7 +127,7 @@ You may use [buttons' sizes utilities]({{< docsref "/components/buttons" >}}#siz
 
 {{< example >}}
 <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-6 col-lg-5">
         <div class="accordion" id="accordionExample-3">
           <div class="card">
             <div class="card-header" id="headingOne-3">
@@ -139,7 +139,7 @@ You may use [buttons' sizes utilities]({{< docsref "/components/buttons" >}}#siz
             </div>
             <div id="collapseOne-3" class="collapse show" aria-labelledby="headingOne-3" data-parent="#accordionExample-3">
               <div class="card-body">
-                Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.
+                Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident.
               </div>
             </div>
           </div>
@@ -153,7 +153,7 @@ You may use [buttons' sizes utilities]({{< docsref "/components/buttons" >}}#siz
             </div>
             <div id="collapseTwo-3" class="collapse" aria-labelledby="headingTwo-3" data-parent="#accordionExample-3">
               <div class="card-body">
-                Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.
+                Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident.
               </div>
             </div>
           </div>
@@ -167,13 +167,13 @@ You may use [buttons' sizes utilities]({{< docsref "/components/buttons" >}}#siz
             </div>
             <div id="collapseThree-3" class="collapse" aria-labelledby="headingThree-3" data-parent="#accordionExample-3">
               <div class="card-body">
-                Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.
+                Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident.
               </div>
             </div>
           </div>
         </div>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6 col-lg-7">
     <div class="accordion" id="accordionExample-4">
       <div class="card">
         <div class="card-header" id="headingOne-4">

--- a/site/content/docs/5.0/content/tables.md
+++ b/site/content/docs/5.0/content/tables.md
@@ -16,7 +16,8 @@ Using the most basic table markup, here's how `.table`-based tables look in Boos
 
 ## Variants
 
-Use contextual classes to color tables, table rows or individual cells.
+<!-- Boosted mod: only .table-dark is allowed -->
+Use contextual class to color tables, table rows or individual cells.
 
 <div class="bd-example">
   <table class="table">
@@ -33,38 +34,25 @@ Use contextual classes to color tables, table rows or individual cells.
         <td>Cell</td>
         <td>Cell</td>
       </tr>
-      {{< table.inline >}}
-      {{- range (index $.Site.Data "theme-colors") }}
-        <tr class="table-{{ .name }}">
-          <th scope="row">{{ .name | title }}</th>
-          <td>Cell</td>
-          <td>Cell</td>
-        </tr>
-      {{- end -}}
-      {{< /table.inline >}}
+    <tr class="table-dark">
+      <th scope="row">Dark</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
     </tbody>
   </table>
 </div>
 
 {{< highlight html >}}
-<!-- On tables -->{{< table.inline >}}
-{{- range (index $.Site.Data "theme-colors") }}
-<table class="table-{{ .name }}">...</table>
-{{- end -}}
-{{< /table.inline >}}
+<!-- On tables -->
+<table class="table-dark">...</table>
 
-<!-- On rows -->{{< table.inline >}}
-{{- range (index $.Site.Data "theme-colors") }}
-<tr class="table-{{ .name }}">...</tr>
-{{- end -}}
-{{< /table.inline >}}
+<!-- On rows -->
+<tr class="table-dark">...</tr>
 
 <!-- On cells (`td` or `th`) -->
-<tr>{{< table.inline >}}
-{{- range (index $.Site.Data "theme-colors") }}
-  <td class="table-{{ .name }}">...</td>
-{{- end -}}
-{{< /table.inline >}}
+<tr>
+  <td class="table-dark">...</td>
 </tr>
 {{< /highlight >}}
 

--- a/site/content/docs/5.0/customize/color.md
+++ b/site/content/docs/5.0/customize/color.md
@@ -14,7 +14,7 @@ We use a subset of all colors to create a smaller color palette for generating c
   {{< theme-colors.inline >}}
   {{- range (index $.Site.Data "theme-colors") }}
     <div class="col-md-4">
-      <div class="p-3 mb-3 bg-{{ .name }}">{{ .name | title }}</div>
+      <div class="p-3 mb-3 font-weight-bold bg-{{ .name }}">{{ .name | title }}</div>
     </div>
   {{ end -}}
   {{< /theme-colors.inline >}}
@@ -35,7 +35,7 @@ Be sure to monitor contrast ratios as you customize colors. As shown below, we'v
 <div class="row font-monospace">
   {{< theme-colors.inline >}}
   {{- range $color := $.Site.Data.colors }}
-    {{- if (and (not (eq $color.name "white")) (not (eq $color.name "gray")) (not (eq $color.name "gray-dark"))) }}
+    {{- if (and (not (eq $color.name "white")) (not (eq $color.name "gray")) (not (eq $color.name "gray-dark")) (not (eq $color.name "indigo"))) }}
     <div class="col-md-4 mb-3">
       <div class="p-3 mb-2 position-relative swatch-{{ $color.name }}">
         <strong class="d-block">${{ $color.name }}</strong>
@@ -60,6 +60,14 @@ Be sure to monitor contrast ratios as you customize colors. As shown below, we'v
   {{< /theme-colors.inline >}}
 
   <div class="col-md-4 mb-3">
+    <div class="p-3 mb-2 bd-orange-2">
+      <strong class="d-block">$orange-2</strong>
+      #ff7900
+    </div>
+    <div class="p-3 mb-2 bd-yellow-2">
+      <strong class="d-block">$yellow-2</strong>
+      #fc0
+    </div>
     <div class="p-3 mb-2 bd-black text-white">
       <strong class="d-block">$black</strong>
       #000

--- a/site/content/docs/5.0/getting-started/accessibility.md
+++ b/site/content/docs/5.0/getting-started/accessibility.md
@@ -24,206 +24,31 @@ Because Boosted's components are purposely designed to be fairly generic, author
 
 ### Color contrast
 
-Most colors that currently make up Boosted's default palette—used throughout the framework for things such as button variations, alert variations, form validation indicators—lead to *insufficient* color contrast (below the recommended [WCAG 2.0 color contrast ratio of 4.5:1](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)) when used against a light background. Authors will need to manually modify/extend these default colors to ensure adequate color contrast ratios.
-
 <!-- Boosted mod -->
+Most colors that currently make up Boosted's default palette—used throughout the framework for things such as button variations, alert variations, form validation indicators—lead to sufficient color contrast (above the recommended [WCAG 2.0 color contrast ratio of 4.5:1](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)) — *with the noticeable exception of our main color, when used against a light background*.
+
 #### Ensuring contrasts
 
 Each of the text colors shown are combined with background colors from the Orange digital palette in order to meet [WCAG 2.0 accessibility standards for color contrast](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html).
-Please note that contrasts are locked when using [`.text-*` and `.bg-*` utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/colors/), to ensure sufficient contrasts.
+**Please note that contrasts are locked when using [`.text-*` and `.bg-*` utilities]({{< docsref "/utilities/colors" >}})**, to ensure sufficient contrasts.
 
-<div class="container">
-    <div class="row">
-        <div class="col-lg">
-            <table class="table table-contrast">
-                <caption class="sr-only">Core colors contrasts</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Core colors</th>
-                        <th scope="col">Text color</th>
-                        <th scope="col">Pass level</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr class="table-dark">
-                        <th scope="row" rowspan="3">#000</th>
-                        <td class="text-primary">#ff7900</td>
-                        <td class="text-primary">AAA</td>
-                    </tr>
-                    <tr class="table-dark">
-                        <td class="pl-0">#fff</td>
-                        <td>AAA</td>
-                    </tr>
-                    <tr class="table-dark" style="color: #999">
-                        <td class="pl-0">#999</td>
-                        <td>AAA</td>
-                    </tr>
-                    <tr class="aa-large-text">
-                        <th scope="row" rowspan="3">#fff</th>
-                        <td class="text-primary">#f16e00</td>
-                        <td class="text-primary">AA Large text</td>
-                    </tr>
-                    <tr>
-                        <td class="pl-0">#000</td>
-                        <td>AAA</td>
-                    </tr>
-                    <tr style="color: #666">
-                        <td class="pl-0 align-top">#666</td>
-                        <td>
-                            AA<br>
-                            <span class="aa-large-text">AAA Large text</span>
-                        </td>
-                    </tr>
-                    <tr style="background-color:#ff7900">
-                        <th scope="row">#ff7900</th>
-                        <td>#000</td>
-                        <td>AAA</td>
-                    </tr>
-                    <tr class="table-primary aa-large-text">
-                        <th scope="row">#f16e00</th>
-                        <td>#fff</td>
-                        <td>AA Large text</td>
-                    </tr>
-                    <tr style="background-color:#595959;color: #fff">
-                        <th scope="row">#595959</th>
-                        <td>#fff</td>
-                        <td>AAA</td>
-                    </tr>
-                </tbody>
-            </table>
-            <table class="table table-contrast">
-                <caption class="sr-only">Functional greys contrasts</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Functional greys</th>
-                        <th scope="col">Text color</th>
-                        <th scope="col">Pass level</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr style="background-color:#333;color: #fff">
-                        <th scope="row">#333</th>
-                        <td>#fff</td>
-                        <td>AAA</td>
-                    </tr>
-                    <tr style="background-color:#666;color: #fff">
-                        <th scope="row" class="align-top">#666</th>
-                        <td class="align-top">#fff</td>
-                        <td>
-                            AA<br>
-                            <span class="aa-large-text">AAA Large text</span>
-                         </td>
-                    </tr>
-                    <tr style="background-color:#999">
-                        <th scope="row">#999</th>
-                        <td>#000</td>
-                        <td>AAA</td>
-                    </tr>
-                    <tr style="background-color:#ccc">
-                        <th scope="row">#ccc</th>
-                        <td>#000</td>
-                        <td>AAA</td>
-                    </tr>
-                    <tr class="table-light">
-                        <th scope="row">#ddd</th>
-                        <td>#000</td>
-                        <td>AAA</td>
-                    </tr>
-                    <tr style="background-color:#eee">
-                        <th scope="row">#eee</th>
-                        <td>#000</td>
-                        <td>AAA</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="col-lg">
-            <table class="table table-contrast">
-                <caption class="sr-only">Supporting colors contrasts</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Supporting colors</th>
-                        <th scope="col">Text color</th>
-                        <th scope="col">Pass level</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr style="background-color:#4bb4e6">
-                        <th scope="row">#4bb4e6</th>
-                        <td>#000</td>
-                        <td>AAA</td>
-                    </tr>
-                   <tr style="background-color:#50beb7">
-                       <th scope="row">#50beb7</th>
-                       <td>#000</td>
-                       <td>AAA</td>
-                   </tr>
-                   <tr style="background-color:#ffb4e6">
-                       <th scope="row">#ffb4e6</th>
-                       <td>#000</td>
-                       <td>AAA</td>
-                   </tr>
-                   <tr style="background-color:#a885d8">
-                       <th scope="row">#a885d8</th>
-                       <td>#000</td>
-                       <td>AAA</td>
-                   </tr>
-                   <tr style="background-color:#ffd200">
-                       <th scope="row">#ffd200</th>
-                       <td>#000</td>
-                       <td>AAA</td>
-                   </tr>
-                </tbody>
-            </table>
-            <table class="table table-contrast">
-                <caption class="sr-only">Functional colors contrasts</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Functional colors</th>
-                        <th scope="col">Text color</th>
-                        <th scope="col">Pass level</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr class="table-success">
-                        <th scope="row">#32c832</th>
-                        <td>#000</td>
-                        <td>AAA</td>
-                    </tr>
-                   <tr class="table-info">
-                       <th scope="row" rowspan="2">#527edb</th>
-                       <td class="align-top">#000</td>
-                       <td>
-                            AA<br>
-                            <span class="aa-large-text">AAA Large text</span>
-                        </td>
-                   </tr>
-                   <tr class="table-info aa-large-text">
-                       <td class="pl-0" style="color: #fff">#fff</td>
-                       <td style="color: #fff">AA Large text</td>
-                   </tr>
-                   <tr class="table-warning">
-                       <th scope="row">#fc0</th>
-                       <td>#000</td>
-                       <td>AAA</td>
-                   </tr>
-                   <tr class="table-danger">
-                       <th scope="row" rowspan="2">#cd3c14</th>
-                       <td class="aa-large-text text-dark">#000</td>
-                       <td class="aa-large-text text-dark">AA Large text</td>
-                   </tr>
-                   <tr class="table-danger">
-                        <td class="pl-0 align-top">#fff</td>
-                        <td>
-                            AA<br>
-                            <span class="aa-large-text">AAA Large text</span>
-                        </td>
-                   </tr>
-                </tbody>
-            </table>
-        </div>
+As shown below, we’ve added reached WCAG level to each of the palette colors—one for against white, and one for against black.
+
+{{< palette.inline >}}
+{{- range $category := $.Site.Data.palette }}
+  <h5 class="h4 col-12">{{ $category.name }}</h5>
+  <div class="row font-monospace">
+    {{- range $color := $category.colors }}
+    <div class="col-md-4 mb-2">
+      <div class="p-3 mb-2 position-relative a11y-swatch-{{ $color.class }}{{ if (eq $color.class "white") }} border{{ end }}">
+        <strong class="d-block">{{ $color.name }}</strong>
+        {{ $color.hex }}
+      </div>
     </div>
-</div>
+    {{ end -}}
+  </div>
+{{ end -}}
+{{< /palette.inline >}}
 <!-- End mod -->
 
 ### Visually hidden content

--- a/site/content/docs/5.0/getting-started/accessibility.md
+++ b/site/content/docs/5.0/getting-started/accessibility.md
@@ -247,6 +247,10 @@ For visually hidden interactive controls, such as traditional "skip" links, use 
 
 Boosted includes support for the [`prefers-reduced-motion` media feature](https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-motion). In browsers/environments that allow the user to specify their preference for reduced motion, most CSS transition effects in Boosted (for instance, when a modal dialog is opened or closed, or the sliding animation in carousels) will be disabled.
 
+### Focus visibility
+
+Boosted includes [WICG's `:focus-visible` polyfill](https://github.com/WICG/focus-visible) to ensure an enhanced focus visibility for keyboard users while shutting down focus styles on active state.
+
 ## Additional resources
 
 - [Web Content Accessibility Guidelines (WCAG) 2.0](https://www.w3.org/TR/WCAG20/)
@@ -256,3 +260,4 @@ Boosted includes support for the [`prefers-reduced-motion` media feature](https:
 - [Color Contrast Analyser (CCA)](https://developer.paciellogroup.com/resources/contrastanalyser/)
 - ["HTML Codesniffer" bookmarklet for identifying accessibility issues](https://github.com/squizlabs/HTML_CodeSniffer)
 - [Orange accessibility guidelines](http://a11y-guidelines.orange.com/)
+- [`:focus-visible` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible)

--- a/site/content/docs/5.0/utilities/colors.md
+++ b/site/content/docs/5.0/utilities/colors.md
@@ -6,6 +6,10 @@ group: utilities
 toc: true
 ---
 
+## Accessibility
+
+When using `.text-*` and `.bg-*` utilities, **contrasts are locked to ensure they meet [WCAG 2.0 accessibility standards for color contrast](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)**, by defining `color` and `background-color` altogether. Please refer to [accessibility’s "Color contrast" section]({{< docsref "/getting-started/accessibility" >}}#color-contrast) to have a full preview of Boosted color palette’s reached WCAG level.
+
 ## Color
 
 Colorize text with color utilities. If you want to colorize links, you can use the [`.link-*` helper classes]({{< docsref "/helpers/colored-links" >}}) which have `:hover` and `:focus` states.
@@ -23,17 +27,17 @@ Colorize text with color utilities. If you want to colorize links, you can use t
 
 ## Background color
 
-Similar to the contextual text color classes, easily set the background of an element to any contextual class. Background utilities **do not set `color`**, so in some cases you'll want to use `.text-*` utilities.
+Similar to the contextual text color classes, easily set the background of an element to any contextual class. Background utilities **do set `color`** to ensure contrasts.
 
 {{< example >}}
 {{< colors.inline >}}
 {{- range (index $.Site.Data "theme-colors") }}
-<div class="p-3 mb-2 bg-{{ .name }}">.bg-{{ .name }}</div>
+<div class="p-3 mb-2 font-weight-bold bg-{{ .name }}">.bg-{{ .name }}</div>
 {{- end -}}
 {{< /colors.inline >}}
-<div class="p-3 mb-2 bg-pink">.bg-pink</div>
-<div class="p-3 mb-2 bg-white">.bg-white or .bg-body</div>
-<div class="p-3 mb-2 bg-transparent">.bg-transparent</div>
+<div class="p-3 mb-2 font-weight-bold bg-pink">.bg-pink</div>
+<div class="p-3 mb-2 font-weight-bold bg-white">.bg-white or .bg-body</div>
+<div class="p-3 mb-2 font-weight-bold bg-transparent">.bg-transparent</div>
 {{< /example >}}
 
 <!-- Boosted mod: no background gradient -->

--- a/site/data/palette.yml
+++ b/site/data/palette.yml
@@ -5,28 +5,28 @@
       class: white
       hex: "#fff"
     - name: Black
-      class: dark
+      class: black
       hex: "#000"
-    - name: Digital Orange 1
+    - name: Orange 1
       class: orange-2
       hex: "#ff7900"
-    - name: Digital Orange 2
-      class: primary
+    - name: Orange 2
+      class: orange
       hex: "#f16e00"
 - category: Functionnal colors
   name: "Functionnal colors"
   colors:
     - name: Green
-      class: success
+      class: green
       hex: "#32c832"
     - name: Blue
-      class: info
+      class: blue
       hex: "#527edb"
     - name: Yellow
-      class: warning
+      class: yellow
       hex: "#fc0"
     - name: Red
-      class: danger
+      class: red
       hex: "#cd3c14"
 - category: Supporting colors
   name: "Supporting colors"
@@ -35,7 +35,7 @@
       class: cyan
       hex: "#4bb4e6"
     - name: Yellow
-      class: yellow
+      class: yellow-2
       hex: "#ffd200"
     - name: Green
       class: teal
@@ -46,8 +46,8 @@
     - name: Pink
       class: pink
       hex: "#ffb4e6"
-- category: Greys
-  name: "Greys"
+- category: Grays
+  name: "Grays"
   colors:
     - name: 100
       class: 100


### PR DESCRIPTION
Fixes #139 

- [x] [PR on Bootstrap](https://github.com/twbs/bootstrap/pull/30872) ~~to contribute back~~: **won't be merged** :/
- [x] `focus-visible` polyfill and styles to match v4
  - [x] apply `outline` globally
  - [x] check and customize focus for each component
- [x] check for contrasts and improvements as suggested by @Aniort: 
  1. size is `2px` everywhere, with an offset to ensure spacing;
  2. contrasts should be good since we're using a single color scheme.
- [x] ensure visibility by using `box-shadow` alongside `outline` to have two colors displayed: done for `button`s, inspired by [a comment in Bootstrap "Text and Non-text Contrast" issue — #29422](https://github.com/twbs/bootstrap/issues/29422#issuecomment-570641382)
- [x] document (mostly get docs back from `v4-dev`)

Anything else?

## Questions

- [x] ~~Should form inputs use transitionned `outline`s too? For now they're stuck with `border-color`; and FWIW, `.form-check`s currently use both, which feels quite wrong…~~ **Edit**: impossible, since `:focus-visible` specification understanding by browsers are that **`input`s should always show `outline`s.** It won't sepearate `:focus` and `:focus-visible`, that's why they're still using `border-color` only.