### PR TITLE
Harmonize links underline over the codebase

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -16,7 +16,7 @@
   // Boosted mod
   a {
     color: inherit;
-    text-decoration: underline; // Boosted mod: links are perceivable globally
+    text-decoration: if($link-decoration == underline, null, underline); // Boosted mod: links are perceivable globally
 
     &:hover {
       color: theme-color("primary");

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -16,6 +16,8 @@
   @include transition($badge-transition);
 
   @at-root a#{&} {
+    text-decoration: if($link-decoration == none, null, none); // Boosted mod: links are perceivable globally
+
     @include hover-focus() {
       text-decoration: none;
     }

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -17,7 +17,7 @@
   display: flex;
 
   a {
-    text-decoration: underline;
+    text-decoration: if($link-decoration == underline, null, underline); // Boosted mod: links are perceivable globally
   }
 
   // The separator between breadcrumbs (by default, a forward-slash: "/")

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -65,12 +65,6 @@
   // end mod
 }
 
-// Boosted mod remove underline for a.btn
-a.btn {
-  text-decoration: none;
-}
-// End mod
-
 // Future-proof disabling of clicks on `<a>` elements
 a.btn.disabled,
 fieldset:disabled a.btn {

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -84,6 +84,7 @@
   @include font-size($navbar-brand-font-size);
   font-weight: $font-weight-bold; // Boosted mod
   line-height: .75; // Boosted mod
+  text-decoration: if($link-decoration == none, null, none);
   letter-spacing: inherit; // Boosted mod
   white-space: nowrap;
   outline-offset: $spacer; // Boosted mod
@@ -97,7 +98,7 @@
   // end mod
 
   @include hover-focus() {
-    text-decoration: none;
+    text-decoration: if($link-hover-decoration == none, null, none); // Boosted mod
   }
 
   // Boosted mod

--- a/scss/_o-scroll-up.scss
+++ b/scss/_o-scroll-up.scss
@@ -12,7 +12,12 @@
   align-items: center;
   padding-left: map-get($spacers, 2);
   font-weight: $font-weight-bold;
+  text-decoration: if($link-decoration == none, null, none);
   background-color: rgba($white, .8);
+
+  &:hover {
+    text-decoration: if($link-hover-decoration == none, null, none);
+  }
 
   @each $breakpoint, $container-margin in $container-fluid-margin-widths {
     @include media-breakpoint-up($breakpoint) {

--- a/scss/_o-step-bar.scss
+++ b/scss/_o-step-bar.scss
@@ -46,6 +46,7 @@
   margin: auto;
   overflow: hidden;
   color: $white;
+  text-decoration: if($link-decoration == none, null, none);
   white-space: nowrap;
   outline-offset: map-get($spacers, 3);
 
@@ -60,7 +61,7 @@
   }
 
   &:hover {
-    text-decoration: underline;
+    text-decoration: if($link-hover-decoration == underline, null, underline);
   }
 
   &:focus {

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -28,7 +28,7 @@
   &:focus {
     z-index: 2;
     color: $pagination-hover-color;
-    text-decoration: $link-hover-decoration; // Boosted mod
+    text-decoration: if($link-hover-decoration == none, null, none); // Boosted mod
     background-color: $pagination-hover-bg;
     border-color: $pagination-hover-border; // Boosted mod
   }

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -260,28 +260,11 @@ a {
   }
 }
 
-// Boosted mod
-// stylelint-disable selector-max-type
-main a:not([class]) {
-  &,
-  &:hover {
-    text-decoration: underline;
-  }
-
-  &:focus {
-    text-decoration: underline;
-    outline-offset: $border-width;
-  }
-}
-// stylelint-enable selector-max-type
-// end mod
-
 // And undo these styles for placeholder links/named anchors (without href)
 // which have not been made explicitly keyboard-focusable (without tabindex).
 // It would be more straightforward to just use a[href] in previous block, but that
 // causes specificity issues in many other styles that are too complex to fix.
 // See https://github.com/twbs/bootstrap/issues/19402
-// Boosted mod: adding tabindex, since dismissable popovers use <a tabindex> without href
 a:not([href]):not([class]) {
   color: inherit;
   text-decoration: none;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -206,9 +206,9 @@ $body-color:                $black !default;
 // Style anchor elements.
 
 $link-color:                              theme-color("dark") !default;
-$link-decoration:                         none !default;
+$link-decoration:                         underline !default;
 $link-hover-color:                        theme-color("primary") !default;
-$link-hover-decoration:                   none !default;
+$link-hover-decoration:                   underline !default;
 // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 $emphasized-link-hover-darken-percentage: 15% !default;
 

--- a/site/docs/4.5/assets/scss/_sidebar.scss
+++ b/site/docs/4.5/assets/scss/_sidebar.scss
@@ -147,6 +147,7 @@
   padding: .25rem 1.5rem;
   @include font-size(90%);
   color: $gray-700; // Boosted mod
+  text-decoration: if($link-decoration == none, null, none); // Boosted mod
 }
 
 .bd-sidebar .nav > li > a:hover {
@@ -165,6 +166,8 @@
 // Boosted mod
 .bd-links a,
 .bd-toc a {
+  text-decoration: if($link-decoration == none, null, none); // Boosted mod
+
   &:focus {
     outline-offset: -1px;
   }

--- a/site/docs/4.5/content/typography.md
+++ b/site/docs/4.5/content/typography.md
@@ -450,18 +450,10 @@ You may add `o-square-list` class to the root element of a list (`<ul>`) to get 
 
 ## Links
 
-By default, links are black, and not underlined
+By default, links are black and underlined.
 
 {% capture example %}
 <a href="#">This is a sample default link</a>
-{% endcapture %} {% include example.html content=example %}
-
-### Underlined
-
-A link into a `p` tag become underlined, to be clearly identified.
-
-{% capture example %}
-<p>Some text in a paragraph, and so <a href="#">the link are underline</a></p>
 {% endcapture %} {% include example.html content=example %}
 
 ### With arrow


### PR DESCRIPTION
Fixes #413 

Bootstrap introduced a new way to handle `text-decoration` in [#30262](https://github.com/twbs/bootstrap/pull/30262) and we somehow missed to update a few occurrences, as well as to remove our very own pseudo-fix targetting links in `main`.