### PR TITLE
fix(docs): some English typos

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -12,7 +12,7 @@
 </license>
 <copyright><![CDATA[Copyright © 2014 Monotype Imaging Inc. All rights reserved.]]></copyright>
 <trademark><![CDATA[Neue Helvetica is a trademark of Monotype Imaging Inc. registered in the U.S. Patent and Trademark Office and may be registered in certain other jurisdictions.]]></trademark>
-Orange Company had buy the right for used Helvetica onto digital applications. 
+Orange Company had bought the right for used Helvetica onto digital applications. 
 Don't use and distribute Helvetica font family if you're not explicitly authorized by Monotype Imaging Inc 
 Parts list under Monotype Imaging Inc Copyright
 fonts/HelvNeue55_W1G.woff2

--- a/scss/orangeHelvetica.scss
+++ b/scss/orangeHelvetica.scss
@@ -11,7 +11,7 @@
 // </license>
 // <copyright>Copyright © 2014 Monotype Imaging Inc. All rights reserved.
 // <trademark>Neue Helvetica is a trademark of Monotype Imaging Inc. registered in the U.S. Patent and Trademark Office and may be registered in certain other jurisdictions.
-// Orange Company had buy the right for used Helvetica onto digital applications.
+// Orange Company had bought the right for used Helvetica onto digital applications.
 // Don't use and distribute Helvetica font family if you're not explicitly authorized by Monotype Imaging Inc
 
 // 1. To use local() Helvetica Neue:

--- a/scss/orangeIcons.scss
+++ b/scss/orangeIcons.scss
@@ -2,7 +2,7 @@
 //  Orange Boosted with Bootstrap
 //         Orange Icons
 //         Copyright (C) 2016 Orange SA All rights reserved
-//         See NOTICE.txt for more informations
+//         See NOTICE.txt for more information
 
 @import "functions";
 @import "variables";

--- a/site/docs/4.5/assets/js/vendor/tarteaucitron.services.js
+++ b/site/docs/4.5/assets/js/vendor/tarteaucitron.services.js
@@ -2374,7 +2374,7 @@ tarteaucitron.services.koban = {
     (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
 
     3. HTML
-    You don't need to add any html code, if the service is autorized, the javascript is added. otherwise no.
+    You don't need to add any html code, if the service is authorized, the javascript is added. otherwise no.
  */
 tarteaucitron.services.matomo = {
     "key": "matomo",
@@ -2422,7 +2422,7 @@ tarteaucitron.services.matomo = {
      2. Push the service :
      (tarteaucitron.job = tarteaucitron.job || []).push('hotjar');
      3. HTML
-    You don't need to add any html code, if the service is autorized, the javascript is added. otherwise no.
+    You don't need to add any html code, if the service is authorized, the javascript is added. otherwise no.
   */
 tarteaucitron.services.hotjar = {
     "key": "hotjar",

--- a/site/docs/4.5/getting-started/introduction.md
+++ b/site/docs/4.5/getting-started/introduction.md
@@ -95,9 +95,9 @@ Be sure to have your pages set up with the latest design and development standar
       Neue Helvetica is a trademark of Monotype Imaging Inc. registered in the U.S.
       Patent and Trademark Office and may be registered in certain other jurisdictions.
       Copyright © 2014 Monotype Imaging Inc. All rights reserved.
-      Orange Company had buy the right for used Helvetica onto digital applications.
-      If you are not autorized to used it, don't include the orangeHelvetica.css
-      See NOTICE.txt for more informations.
+      Orange Company had bought the right for used Helvetica onto digital applications.
+      If you are not authorized to used it, don't include the orangeHelvetica.css.
+      See NOTICE.txt for more information.
     -->
     <link rel="preload" href="fonts/HelvNeue55_W1G.woff2" as="font" type="font/woff2" crossorigin="anonymous">
     <link rel="preload" href="fonts/HelvNeue75_W1G.woff2" as="font" type="font/woff2" crossorigin="anonymous">
@@ -105,7 +105,7 @@ Be sure to have your pages set up with the latest design and development standar
     <!--
       Orange Icons
       Copyright (C) 2016 - 2019 Orange SA All rights reserved
-      See NOTICE.txt for more informations.
+      See NOTICE.txt for more information.
     -->
     <link rel="stylesheet" href="css/orangeIcons.min.css" />
 

--- a/site/docs/4.5/getting-started/rtl.md
+++ b/site/docs/4.5/getting-started/rtl.md
@@ -32,9 +32,9 @@ Also please ensure to add attribute `dir="rtl"` to your `<html>` tag.
       Neue Helvetica is a trademark of Monotype Imaging Inc. registered in the U.S.
       Patent and Trademark Office and may be registered in certain other jurisdictions.
       Copyright © 2014 Monotype Imaging Inc. All rights reserved.
-      Orange Company had buy the right for used Helvetica onto digital applications.
-      If you are not autorized to used it, don't include the orangeHelvetica.css
-      See NOTICE.txt for more informations.
+      Orange Company had bought the right for used Helvetica onto digital applications.
+      If you are not authorized to used it, don't include the orangeHelvetica.css.
+      See NOTICE.txt for more information.
     -->
     <link rel="preload" href="fonts/HelvNeue55_W1G.woff2" as="font" type="font/woff2" crossorigin="anonymous">
     <link rel="preload" href="fonts/HelvNeue75_W1G.woff2" as="font" type="font/woff2" crossorigin="anonymous">
@@ -42,7 +42,7 @@ Also please ensure to add attribute `dir="rtl"` to your `<html>` tag.
     <!--
       Orange Icons
       Copyright (C) 2016 - 2019 Orange SA All rights reserved
-      See NOTICE.txt for more informations.
+      See NOTICE.txt for more information.
     -->
     <link rel="stylesheet" href="css/orangeIcons.min.css" />
 


### PR DESCRIPTION
Possibly found some English typos.

I haven't changed the content of _orangeHelvetica.css.map_ nor _orangeHelvetica.min.css.map_ because I suppose they are generated automatically ; but I don't know exactly how to do that 😃 