### PR TITLE
fix some broken links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,6 +79,7 @@ social_logo_path:   /docs/4.5/assets/brand/orange-logo.png
 
 # Custom variables
 current_version:      4.5.0
+bootstrap_current_version:      v4.5.0
 current_ruby_version: 4.5.0
 docs_version:         4.5
 github_org:           "https://github.com/Orange-OpenSource"

--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -10,7 +10,7 @@
         <a href="https://github.com/twbs/bootstrap/graphs/contributors">our contributors</a>.
       </p>
       <p class="m-0">Orange modified code licensed
-        <a rel="license noopener" href="https://github.com/twbs/bootstrap/blob/master/LICENSE" target="_blank">MIT</a>, Original code licensed
+        <a rel="license noopener" href="{{ site.repo }}/blob/v{{ site.current_version }}/LICENSE" target="_blank">MIT</a>, Original code licensed
         <a rel="license noopener" href="https://github.com/twbs/bootstrap/blob/{{ site.bootstrap_current_version }}/LICENSE" target="_blank">MIT</a>, docs
         <a rel="license noopener" href="https://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.
       </p>

--- a/site/docs/4.5/about/boosted-license.md
+++ b/site/docs/4.5/about/boosted-license.md
@@ -30,4 +30,4 @@ Boosted is released under the MIT license and is copyright {{ site.time | date: 
 - Include the source of Bootstrap itself, or of any modifications you may have made to it, in any redistribution you may assemble that includes it
 - Submit changes that you make to Boosted or Bootstrap back to the projects (though such feedback is encouraged)
 
-The full Boosted license is located [in the project repository]({{ site.repo }}/blob/master/LICENSE) for more information.
+The full Boosted license is located [in the project repository]({{ site.repo }}/blob/v{{ site.current_version }}/LICENSE) for more information.


### PR DESCRIPTION
put back bootstrap_current_version value
/!\ bootstrap rename master branch so all license header link refering to bootstrap master license file are invalid