### PR TITLE
chore(build): random commit to kill build

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Compile dist
         run: npm run dist
 
-      - name: Build docs
+      - name: Test docs
         run: npm run docs-build
 
       - name: Run accessibility tests
@@ -57,7 +57,7 @@ jobs:
         if: failure()
 
       - name: Upload accessibility results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: pa11y-ci-results

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -4,12 +4,14 @@ on:
     paths:
       - 'js/**'
       - 'scss/**'
+      - 'site/content/docs/**/guidelines'
     branches:
       - v5-dev
   pull_request:
     paths:
       - 'js/**'
       - 'scss/**'
+      - 'site/content/docs/**/guidelines'
     branches:
       - v5-dev
 env:

--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -4,9 +4,9 @@
   "concurrency": 4,
   "defaults": {
     "wait": 3000,
-    "threshold": 500,
     "runners": [
       "axe"
-    ]
+    ],
+    "hideElements": ".bd-search, .active, [aria-current], pre *"
   }
 }

--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -7,6 +7,9 @@
     "runners": [
       "axe"
     ],
-    "hideElements": ".bd-search, .active, [aria-current], pre *"
+    "hideElements": ".bd-search, .active, [aria-current], [disabled], .modal, #TableOfContents, .bd-example nav",
+    "ignore": [
+      "heading-order"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "docs-lint": "npm-run-all --parallel docs-vnu docs-linkinator",
     "docs-pa11y": "delay 3 && pa11y-ci --config build/.pa11yci.json --sitemap http://localhost:9001/sitemap.xml --sitemap-find https://boosted.orange.com --sitemap-replace http://localhost:9001 --json > pa11y-ci-results.json",
     "docs-pa11y-html": "pa11y-ci-reporter-html -d .pa11y",
-    "docs-accessibility": "npm-run-all --parallel --race \"docs-serve-only -- -n\" docs-pa11y",
+    "docs-accessibility": "npm-run-all --parallel --race docs-serve-only docs-pa11y",
     "docs-serve": "hugo server --port 9001 --disableFastRender",
     "docs-serve-only": "sirv _gh_pages --port 9001",
     "lockfile-lint": "lockfile-lint --allowed-hosts npm --allowed-schemes https: --empty-hostname false --type npm --path package-lock.json",

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -43,7 +43,7 @@
         @each $property in $properties {
           #{$property}: $value if($enable-important-utilities, !important, null);
           // Boosted mod: ensure contrasts in color utilities
-          @if "background-color" == $property and "transparent" != inspect($value) and $primary != $value {
+          @if "background-color" == $property and "transparent" != inspect($value) {
             color: color-contrast($value);
           } @else if "color" == $property and "inherit" != inspect($value) and $accessible-orange != $value {
             background-color: color-contrast($value);

--- a/site/assets/scss/_boosted.scss
+++ b/site/assets/scss/_boosted.scss
@@ -106,4 +106,7 @@ body {
     text-decoration: none;
   }
 }
-// End mod
+
+.bd-intro {
+  margin-bottom: $spacer + $font-size-base;
+}

--- a/site/assets/scss/_callouts.scss
+++ b/site/assets/scss/_callouts.scss
@@ -32,7 +32,7 @@
   background-color: tint-color($color, 11); // Boosted mod
   border-left-color: $color; // Boosted mod
 
-  h4 { color: $color; }
+  h4 { color: shade-color($color, 2); }
 }
 
 .bd-callout-info { @include bs-callout-variant($bd-info); }

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -252,6 +252,8 @@
   // Boosted mod
   pre .language-sh { color: $gray-900; }
 
+  pre:hover .language-js,
+  pre:focus .language-js,
   pre:hover .language-html,
   pre:focus .language-html {
     color: $black;

--- a/site/assets/scss/_syntax.scss
+++ b/site/assets/scss/_syntax.scss
@@ -27,7 +27,7 @@
 /* GenericStrong */ .chroma .gs { font-weight: 700; } /* NEW */
 /* GenericTraceback */ .chroma .gt { color: tint-color($success, 2); }
 /* GenericSubheading */ .chroma .gu { color: shade-color($success, 2); }
-/* LiteralNumberIntegerLong */ .chroma .il { color: shade-color($primary, 3); }
+/* LiteralNumberIntegerLong */ .chroma .il { color: shade-color($primary, 4); }
 /* Keyword */ .chroma .k { color: shade-color($cyan, 4); }
 /* KeywordConstant */ .chroma .kc { color: shade-color($cyan, 4); }
 /* KeywordDeclaration */ .chroma .kd { color: shade-color($cyan, 4); }
@@ -35,12 +35,12 @@
 /* KeywordPseudo */ .chroma .kp { color: shade-color($cyan, 4); }
 /* KeywordReserved */ .chroma .kr { color: shade-color($cyan, 4); }
 /* KeywordType */ .chroma .kt { color: shade-color($teal, 4); }
-/* LiteralNumber */ .chroma .m { color: shade-color($primary, 3); }
-/* LiteralNumberFloat */ .chroma .mf { color: shade-color($primary, 3); }
+/* LiteralNumber */ .chroma .m { color: shade-color($primary, 4); }
+/* LiteralNumberFloat */ .chroma .mf { color: shade-color($primary, 4); }
 /* LiteralNumberBin */ .chroma .mb { color: shade-color($teal, 4); } /* NEW */
-/* LiteralNumberHex */ .chroma .mh { color: shade-color($primary, 3); }
-/* LiteralNumberInteger */ .chroma .mi { color: shade-color($primary, 3); }
-/* LiteralNumberOct */ .chroma .mo { color: shade-color($primary, 3); }
+/* LiteralNumberHex */ .chroma .mh { color: shade-color($primary, 4); }
+/* LiteralNumberInteger */ .chroma .mi { color: shade-color($primary, 4); }
+/* LiteralNumberOct */ .chroma .mo { color: shade-color($primary, 4); }
 /* NameAttribute */ .chroma .na { color: shade-color($success, 4); }
 /* NameBuiltin */ .chroma .nb { color: shade-color($teal, 4); }
 /* NameClass */ .chroma .nc { color: shade-color($success, 4); }
@@ -56,18 +56,18 @@
 /* Operator */ .chroma .o { color: $gray-800; }
 /* OperatorWord */ .chroma .ow { color: $black; }
 /* LiteralString */ .chroma .s { color: shade-color($cyan, 4); }
-/* LiteralStringSingle */ .chroma .s1 { color: shade-color($primary, 3); }
-/* LiteralStringDouble */ .chroma .s2 { color: shade-color($primary, 3); }
+/* LiteralStringSingle */ .chroma .s1 { color: shade-color($primary, 4); }
+/* LiteralStringDouble */ .chroma .s2 { color: shade-color($primary, 4); }
 /* LiteralStringAffix */ .chroma .sa { color: shade-color($cyan, 4); } /* NEW */
-/* LiteralStringBacktick */ .chroma .sb { color: shade-color($primary, 3); }
-/* LiteralStringChar */ .chroma .sc { color: shade-color($primary, 3); }
-/* LiteralStringDoc */ .chroma .sd { font-style: italic; color: shade-color($primary, 3); }
-/* LiteralStringEscape */ .chroma .se { color: shade-color($primary, 3); }
-/* LiteralStringHeredoc */ .chroma .sh { color: shade-color($primary, 3); }
+/* LiteralStringBacktick */ .chroma .sb { color: shade-color($primary, 4); }
+/* LiteralStringChar */ .chroma .sc { color: shade-color($primary, 4); }
+/* LiteralStringDoc */ .chroma .sd { font-style: italic; color: shade-color($primary, 4); }
+/* LiteralStringEscape */ .chroma .se { color: shade-color($primary, 4); }
+/* LiteralStringHeredoc */ .chroma .sh { color: shade-color($primary, 4); }
 /* LiteralStringInterpol */ .chroma .si { color: shade-color($danger, 4); }
 /* LiteralStringRegex */ .chroma .sr { color: shade-color($teal, 4); }
 /* LiteralStringSymbol */ .chroma .ss { color: shade-color($warning, 4); }
-/* LiteralStringOther */ .chroma .sx { color: shade-color($primary, 3); }
+/* LiteralStringOther */ .chroma .sx { color: shade-color($primary, 4); }
 /* TextWhitespace */ .chroma .w { color: $gray-500; }
 
 .chroma {

--- a/site/content/docs/5.0/components/scrollspy.md
+++ b/site/content/docs/5.0/components/scrollspy.md
@@ -12,7 +12,7 @@ Scrollspy has a few requirements to function properly:
 
 - It must be used on a Boosted [nav component]({{< docsref "/components/navs" >}}) or [list group]({{< docsref "/components/list-group" >}}).
 - Scrollspy requires `position: relative;` on the element you're spying on, usually the `<body>`.
-- When spying on elements other than the `<body>`, be sure to have a `height` set and `overflow-y: scroll;` applied.
+- When spying on elements other than the `<body>`, be sure to have a `height` set and `overflow-y: scroll;` applied—alongside a `tabindex="0"` to ensure keyboard access.
 - Anchors (`<a>`) are required and must point to an element with that `id`.
 
 When successfully implemented, your nav or list group will update accordingly, moving the `.active` class from one item to the next based on their associated targets.
@@ -44,7 +44,7 @@ Scroll the area below the navbar and watch the active class change. The dropdown
       </li>
     </ul>
   </nav>
-  <div data-spy="scroll" data-target="#navbar-example2" data-offset="0" class="scrollspy-example">
+  <div data-spy="scroll" data-target="#navbar-example2" data-offset="0" class="scrollspy-example" tabindex="0">
     <h4 id="fat">@fat</h4>
     <p>Ad leggings keytar, brunch id art party dolor labore. Pitchfork yr enim lo-fi before they sold out qui. Tumblr farm-to-table bicycle rights whatever. Anim keffiyeh carles cardigan. Velit seitan mcsweeney's photo booth 3 wolf moon irure. Cosby sweater lomo jean shorts, williamsburg hoodie minim qui you probably haven't heard of them et cardigan trust fund culpa biodiesel wes anderson aesthetic. Nihil tattooed accusamus, cred irony biodiesel keffiyeh artisan ullamco consequat.</p>
     <h4 id="mdo">@mdo</h4>
@@ -83,7 +83,7 @@ Scroll the area below the navbar and watch the active class change. The dropdown
     </li>
   </ul>
 </nav>
-<div data-spy="scroll" data-target="#navbar-example2" data-offset="0">
+<div data-spy="scroll" data-target="#navbar-example2" data-offset="0" tabindex="0">
   <h4 id="fat">@fat</h4>
   <p>...</p>
   <h4 id="mdo">@mdo</h4>
@@ -124,7 +124,7 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
       </nav>
     </div>
     <div class="col-8 col-lg-10">
-      <div data-spy="scroll" data-target="#navbar-example3" data-offset="0" class="scrollspy-example-2">
+      <div data-spy="scroll" data-target="#navbar-example3" data-offset="0" class="scrollspy-example-2" tabindex="0">
         <h4 id="item-1">Item 1</h4>
         <p>Ex consequat commodo adipisicing exercitation aute excepteur occaecat ullamco duis aliqua id magna ullamco eu. Do aute ipsum ipsum ullamco cillum consectetur ut et aute consectetur labore. Fugiat laborum incididunt tempor eu consequat enim dolore proident. Qui laborum do non excepteur nulla magna eiusmod consectetur in. Aliqua et aliqua officia quis et incididunt voluptate non anim reprehenderit adipisicing dolore ut consequat deserunt mollit dolore. Aliquip nulla enim veniam non fugiat id cupidatat nulla elit cupidatat commodo velit ut eiusmod cupidatat elit dolore.</p>
         <h5 id="item-1-1">Item 1-1</h5>
@@ -164,7 +164,7 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
   </nav>
 </nav>
 
-<div data-spy="scroll" data-target="#navbar-example3" data-offset="0">
+<div data-spy="scroll" data-target="#navbar-example3" data-offset="0" tabindex="0">
   <h4 id="item-1">Item 1</h4>
   <p>...</p>
   <h5 id="item-1-1">Item 1-1</h5>
@@ -197,7 +197,7 @@ Scrollspy also works with `.list-group`s. Scroll the area next to the list group
       </div>
     </div>
     <div class="col-8">
-      <div data-spy="scroll" data-target="#list-example" data-offset="0" class="scrollspy-example">
+      <div data-spy="scroll" data-target="#list-example" data-offset="0" class="scrollspy-example" tabindex="0">
         <h4 id="list-item-1">Item 1</h4>
         <p>Ex consequat commodo adipisicing exercitation aute excepteur occaecat ullamco duis aliqua id magna ullamco eu. Do aute ipsum ipsum ullamco cillum consectetur ut et aute consectetur labore. Fugiat laborum incididunt tempor eu consequat enim dolore proident. Qui laborum do non excepteur nulla magna eiusmod consectetur in. Aliqua et aliqua officia quis et incididunt voluptate non anim reprehenderit adipisicing dolore ut consequat deserunt mollit dolore. Aliquip nulla enim veniam non fugiat id cupidatat nulla elit cupidatat commodo velit ut eiusmod cupidatat elit dolore.</p>
         <h4 id="list-item-2">Item 2</h4>
@@ -218,7 +218,7 @@ Scrollspy also works with `.list-group`s. Scroll the area next to the list group
   <a class="list-group-item list-group-item-action" href="#list-item-3">Item 3</a>
   <a class="list-group-item list-group-item-action" href="#list-item-4">Item 4</a>
 </div>
-<div data-spy="scroll" data-target="#list-example" data-offset="0" class="scrollspy-example">
+<div data-spy="scroll" data-target="#list-example" data-offset="0" class="scrollspy-example" tabindex="0">
   <h4 id="list-item-1">Item 1</h4>
   <p>...</p>
   <h4 id="list-item-2">Item 2</h4>

--- a/site/content/docs/5.0/examples/blog/index.html
+++ b/site/content/docs/5.0/examples/blog/index.html
@@ -41,7 +41,9 @@ include_js: false
       <a class="p-2 link-secondary" href="#">Travel</a>
     </nav>
   </div>
+</div>
 
+<main class="container">
   <div class="p-4 p-md-5 mb-4 text-white rounded bg-dark">
     <div class="col-md-6 px-0">
       <h1 class="display-4 font-italic">Title of a longer featured blog post</h1>
@@ -80,16 +82,14 @@ include_js: false
       </div>
     </div>
   </div>
-</div>
 
-<main class="container">
   <div class="row">
     <div class="col-md-8">
       <h3 class="pb-4 mb-4 font-italic border-bottom">
         From the Firehose
       </h3>
 
-      <div class="blog-post">
+      <article class="blog-post">
         <h2 class="blog-post-title">Sample blog post</h2>
         <p class="blog-post-meta">January 1, 2014 by <a href="#">Mark</a></p>
 
@@ -120,9 +120,9 @@ include_js: false
           <li>Maecenas sed diam eget risus varius blandit sit amet non magna.</li>
         </ol>
         <p>Cras mattis consectetur purus sit amet fermentum. Sed posuere consectetur est at lobortis.</p>
-      </div><!-- /.blog-post -->
+      </article><!-- /.blog-post -->
 
-      <div class="blog-post">
+      <article class="blog-post">
         <h2 class="blog-post-title">Another blog post</h2>
         <p class="blog-post-meta">December 23, 2013 by <a href="#">Jacob</a></p>
 
@@ -132,9 +132,9 @@ include_js: false
         </blockquote>
         <p>Etiam porta <em>sem malesuada magna</em> mollis euismod. Cras mattis consectetur purus sit amet fermentum. Aenean lacinia bibendum nulla sed consectetur.</p>
         <p>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-      </div><!-- /.blog-post -->
+      </article><!-- /.blog-post -->
 
-      <div class="blog-post">
+      <article class="blog-post">
         <h2 class="blog-post-title">New feature</h2>
         <p class="blog-post-meta">December 14, 2013 by <a href="#">Chris</a></p>
 
@@ -146,16 +146,16 @@ include_js: false
         </ul>
         <p>Etiam porta <em>sem malesuada magna</em> mollis euismod. Cras mattis consectetur purus sit amet fermentum. Aenean lacinia bibendum nulla sed consectetur.</p>
         <p>Donec ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue.</p>
-      </div><!-- /.blog-post -->
+      </article><!-- /.blog-post -->
 
-      <nav class="blog-pagination">
+      <nav class="blog-pagination" aria-label="Pagination">
         <a class="btn btn-outline-primary" href="#">Older</a>
         <a class="btn btn-outline-secondary disabled" href="#" tabindex="-1" aria-disabled="true">Newer</a>
       </nav>
 
     </div>
 
-    <aside class="col-md-4">
+    <div class="col-md-4">
       <div class="p-4 mb-3 bg-light rounded">
         <h4 class="font-italic">About</h4>
         <p class="mb-0">Etiam porta <em>sem malesuada magna</em> mollis euismod. Cras mattis consectetur purus sit amet fermentum. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -187,7 +187,7 @@ include_js: false
           <li><a href="#">Facebook</a></li>
         </ol>
       </div>
-    </aside>
+    </div>
 
   </div><!-- /.row -->
 

--- a/site/content/docs/5.0/examples/checkout/index.html
+++ b/site/content/docs/5.0/examples/checkout/index.html
@@ -9,215 +9,218 @@ body_class: "bg-light"
 ---
 
 <div class="container">
-  <div class="py-5 text-center">
-    <img class="d-block mx-auto mb-4" src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" alt="" width="50" height="50">
-    <h2>Checkout form</h2>
-    <p class="lead">Below is an example form built entirely with Bootstrap’s form controls. Each required form group has a validation state that can be triggered by attempting to submit the form without completing it.</p>
-  </div>
-
-  <div class="row g-3">
-    <div class="col-md-5 col-lg-4 order-md-last">
-      <h4 class="d-flex justify-content-between align-items-center mb-3">
-        <span class="text-muted">Your cart</span>
-        <span class="badge bg-secondary rounded-pill">3</span>
-      </h4>
-      <ul class="list-group mb-3">
-        <li class="list-group-item d-flex justify-content-between lh-sm">
-          <div>
-            <h6 class="my-0">Product name</h6>
-            <small class="text-muted">Brief description</small>
-          </div>
-          <span class="text-muted">$12</span>
-        </li>
-        <li class="list-group-item d-flex justify-content-between lh-sm">
-          <div>
-            <h6 class="my-0">Second product</h6>
-            <small class="text-muted">Brief description</small>
-          </div>
-          <span class="text-muted">$8</span>
-        </li>
-        <li class="list-group-item d-flex justify-content-between lh-sm">
-          <div>
-            <h6 class="my-0">Third item</h6>
-            <small class="text-muted">Brief description</small>
-          </div>
-          <span class="text-muted">$5</span>
-        </li>
-        <li class="list-group-item d-flex justify-content-between bg-light">
-          <div class="text-success">
-            <h6 class="my-0">Promo code</h6>
-            <small>EXAMPLECODE</small>
-          </div>
-          <span class="text-success">−$5</span>
-        </li>
-        <li class="list-group-item d-flex justify-content-between">
-          <span>Total (USD)</span>
-          <strong>$20</strong>
-        </li>
-      </ul>
-
-      <form class="card p-2">
-        <div class="input-group">
-          <input type="text" class="form-control" placeholder="Promo code">
-          <button type="submit" class="btn btn-secondary">Redeem</button>
-        </div>
-      </form>
+  <main>
+    <div class="py-5 text-center">
+      <img class="d-block mx-auto mb-4" src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" alt="" width="50" height="50">
+      <h1 class="h2">Checkout form</h1>
+      <p class="lead">Below is an example form built entirely with Bootstrap’s form controls. Each required form group has a validation state that can be triggered by attempting to submit the form without completing it.</p>
     </div>
-    <div class="col-md-7 col-lg-8">
-      <h4 class="mb-3">Billing address</h4>
-      <form class="needs-validation" novalidate>
-        <div class="row g-3">
-          <div class="col-sm-6">
-            <label for="firstName" class="form-label is-required">First name</label>
-            <input type="text" class="form-control" id="firstName" placeholder="" value="" required>
-            <div class="invalid-feedback">
-              Valid first name is required.
-            </div>
-          </div>
 
-          <div class="col-sm-6">
-            <label for="lastName" class="form-label is-required">Last name</label>
-            <input type="text" class="form-control" id="lastName" placeholder="" value="" required>
-            <div class="invalid-feedback">
-              Valid last name is required.
+    <div class="row g-3">
+      <div class="col-md-5 col-lg-4 order-md-last">
+        <h2 class="h4 d-flex justify-content-between align-items-center mb-3">
+          <span class="text-muted">Your cart</span>
+          <span class="badge bg-secondary rounded-pill">3</span>
+        </h2>
+        <ul class="list-group mb-3">
+          <li class="list-group-item d-flex justify-content-between lh-sm">
+            <div>
+              <h3 class="h6 my-0">Product name</h3>
+              <small class="text-muted">Brief description</small>
             </div>
-          </div>
+            <span class="text-muted">$12</span>
+          </li>
+          <li class="list-group-item d-flex justify-content-between lh-sm">
+            <div>
+              <h3 class="h6 my-0">Second product</h3>
+              <small class="text-muted">Brief description</small>
+            </div>
+            <span class="text-muted">$8</span>
+          </li>
+          <li class="list-group-item d-flex justify-content-between lh-sm">
+            <div>
+              <h3 class="h6 my-0">Third item</h3>
+              <small class="text-muted">Brief description</small>
+            </div>
+            <span class="text-muted">$5</span>
+          </li>
+          <li class="list-group-item d-flex justify-content-between bg-light">
+            <div class="text-success">
+              <h3 class="h6 my-0">Promo code</h3>
+              <small>EXAMPLECODE</small>
+            </div>
+            <span class="text-success">−$5</span>
+          </li>
+          <li class="list-group-item d-flex justify-content-between">
+            <span>Total (USD)</span>
+            <strong>$20</strong>
+          </li>
+        </ul>
 
-          <div class="col-12">
-            <label for="username" class="form-label is-required">Username</label>
-            <div class="input-group">
-              <span class="input-group-text">@</span>
-              <input type="text" class="form-control" id="username" placeholder="Username" required>
-            <div class="invalid-feedback">
-                Your username is required.
+        <form class="card p-2">
+          <div class="input-group">
+            <label for="promo-code" class="sr-only">Promo code</label>
+            <input type="text" class="form-control" id="promo-code" placeholder="Promo code">
+            <button type="submit" class="btn btn-secondary">Redeem</button>
+          </div>
+        </form>
+      </div>
+      <div class="col-md-7 col-lg-8">
+        <h2 class="h4 mb-3">Billing address</h2>
+        <form class="needs-validation" novalidate>
+          <div class="row g-3">
+            <div class="col-sm-6">
+              <label for="firstName" class="form-label is-required">First name</label>
+              <input type="text" class="form-control" id="firstName" placeholder="" value="" required>
+              <div class="invalid-feedback">
+                Valid first name is required.
+              </div>
+            </div>
+
+            <div class="col-sm-6">
+              <label for="lastName" class="form-label is-required">Last name</label>
+              <input type="text" class="form-control" id="lastName" placeholder="" value="" required>
+              <div class="invalid-feedback">
+                Valid last name is required.
+              </div>
+            </div>
+
+            <div class="col-12">
+              <label for="username" class="form-label is-required">Username</label>
+              <div class="input-group">
+                <span class="input-group-text">@</span>
+                <input type="text" class="form-control" id="username" placeholder="Username" required>
+              <div class="invalid-feedback">
+                  Your username is required.
+                </div>
+              </div>
+            </div>
+
+            <div class="col-12">
+              <label for="email" class="form-label">Email <span class="text-muted">(Optional)</span></label>
+              <input type="email" class="form-control" id="email" placeholder="you@example.com">
+              <div class="invalid-feedback">
+                Please enter a valid email address for shipping updates.
+              </div>
+            </div>
+
+            <div class="col-12">
+              <label for="address" class="form-label is-required">Address</label>
+              <input type="text" class="form-control" id="address" placeholder="1234 Main St" required>
+              <div class="invalid-feedback">
+                Please enter your shipping address.
+              </div>
+            </div>
+
+            <div class="col-12">
+              <label for="address2" class="form-label">Address 2 <span class="text-muted">(Optional)</span></label>
+              <input type="text" class="form-control" id="address2" placeholder="Apartment or suite">
+            </div>
+
+            <div class="col-md-5">
+              <label for="country" class="form-label is-required">Country</label>
+              <select class="form-select" id="country" required>
+                <option value="">Choose...</option>
+                <option>United States</option>
+              </select>
+              <div class="invalid-feedback">
+                Please select a valid country.
+              </div>
+            </div>
+
+            <div class="col-md-4">
+              <label for="state" class="form-label is-required">State</label>
+              <select class="form-select" id="state" required>
+                <option value="">Choose...</option>
+                <option>California</option>
+              </select>
+              <div class="invalid-feedback">
+                Please provide a valid state.
+              </div>
+            </div>
+
+            <div class="col-md-3">
+              <label for="zip" class="form-label is-required">Zip</label>
+              <input type="text" class="form-control" id="zip" placeholder="" required>
+              <div class="invalid-feedback">
+                Zip code required.
               </div>
             </div>
           </div>
 
-          <div class="col-12">
-            <label for="email" class="form-label">Email <span class="text-muted">(Optional)</span></label>
-            <input type="email" class="form-control" id="email" placeholder="you@example.com">
-            <div class="invalid-feedback">
-              Please enter a valid email address for shipping updates.
-            </div>
-          </div>
+          <hr class="my-4">
 
-          <div class="col-12">
-            <label for="address" class="form-label is-required">Address</label>
-            <input type="text" class="form-control" id="address" placeholder="1234 Main St" required>
-            <div class="invalid-feedback">
-              Please enter your shipping address.
-            </div>
-          </div>
-
-          <div class="col-12">
-            <label for="address2" class="form-label">Address 2 <span class="text-muted">(Optional)</span></label>
-            <input type="text" class="form-control" id="address2" placeholder="Apartment or suite">
-          </div>
-
-          <div class="col-md-5">
-            <label for="country" class="form-label is-required">Country</label>
-            <select class="form-select" id="country" required>
-              <option value="">Choose...</option>
-              <option>United States</option>
-            </select>
-            <div class="invalid-feedback">
-              Please select a valid country.
-            </div>
-          </div>
-
-          <div class="col-md-4">
-            <label for="state" class="form-label is-required">State</label>
-            <select class="form-select" id="state" required>
-              <option value="">Choose...</option>
-              <option>California</option>
-            </select>
-            <div class="invalid-feedback">
-              Please provide a valid state.
-            </div>
-          </div>
-
-          <div class="col-md-3">
-            <label for="zip" class="form-label is-required">Zip</label>
-            <input type="text" class="form-control" id="zip" placeholder="" required>
-            <div class="invalid-feedback">
-              Zip code required.
-            </div>
-          </div>
-        </div>
-
-        <hr class="my-4">
-
-        <div class="form-check">
-          <input type="checkbox" class="form-check-input" id="same-address">
-          <label class="form-check-label" for="same-address">Shipping address is the same as my billing address</label>
-        </div>
-
-        <div class="form-check">
-          <input type="checkbox" class="form-check-input" id="save-info">
-          <label class="form-check-label" for="save-info">Save this information for next time</label>
-        </div>
-
-        <hr class="my-4">
-
-        <h4 class="mb-3">Payment</h4>
-
-        <div class="my-3">
           <div class="form-check">
-            <input id="credit" name="paymentMethod" type="radio" class="form-check-input" checked required>
-            <label class="form-check-label" for="credit">Credit card</label>
+            <input type="checkbox" class="form-check-input" id="same-address">
+            <label class="form-check-label" for="same-address">Shipping address is the same as my billing address</label>
           </div>
+
           <div class="form-check">
-            <input id="debit" name="paymentMethod" type="radio" class="form-check-input" required>
-            <label class="form-check-label" for="debit">Debit card</label>
+            <input type="checkbox" class="form-check-input" id="save-info">
+            <label class="form-check-label" for="save-info">Save this information for next time</label>
           </div>
-          <div class="form-check">
-            <input id="paypal" name="paymentMethod" type="radio" class="form-check-input" required>
-            <label class="form-check-label" for="paypal">PayPal</label>
-          </div>
-        </div>
 
-        <div class="row gy-3">
-          <div class="col-md-6">
-            <label for="cc-name" class="form-label is-required">Name on card</label>
-            <input type="text" class="form-control" id="cc-name" placeholder="" required>
-            <small class="text-muted">Full name as displayed on card</small>
-            <div class="invalid-feedback">
-              Name on card is required
+          <hr class="my-4">
+
+          <h2 class="h4 mb-3">Payment</h2>
+
+          <div class="my-3">
+            <div class="form-check">
+              <input id="credit" name="paymentMethod" type="radio" class="form-check-input" checked required>
+              <label class="form-check-label" for="credit">Credit card</label>
+            </div>
+            <div class="form-check">
+              <input id="debit" name="paymentMethod" type="radio" class="form-check-input" required>
+              <label class="form-check-label" for="debit">Debit card</label>
+            </div>
+            <div class="form-check">
+              <input id="paypal" name="paymentMethod" type="radio" class="form-check-input" required>
+              <label class="form-check-label" for="paypal">PayPal</label>
             </div>
           </div>
 
-          <div class="col-md-6">
-            <label for="cc-number" class="form-label is-required">Credit card number</label>
-            <input type="text" class="form-control" id="cc-number" placeholder="" required>
-            <div class="invalid-feedback">
-              Credit card number is required
+          <div class="row gy-3">
+            <div class="col-md-6">
+              <label for="cc-name" class="form-label is-required">Name on card</label>
+              <input type="text" class="form-control" id="cc-name" placeholder="" required>
+              <small class="text-muted">Full name as displayed on card</small>
+              <div class="invalid-feedback">
+                Name on card is required
+              </div>
+            </div>
+
+            <div class="col-md-6">
+              <label for="cc-number" class="form-label is-required">Credit card number</label>
+              <input type="text" class="form-control" id="cc-number" placeholder="" required>
+              <div class="invalid-feedback">
+                Credit card number is required
+              </div>
+            </div>
+
+            <div class="col-md-3">
+              <label for="cc-expiration" class="form-label is-required">Expiration</label>
+              <input type="text" class="form-control" id="cc-expiration" placeholder="" required>
+              <div class="invalid-feedback">
+                Expiration date required
+              </div>
+            </div>
+
+            <div class="col-md-3">
+              <label for="cc-cvv" class="form-label is-required">CVV</label>
+              <input type="text" class="form-control" id="cc-cvv" placeholder="" required>
+              <div class="invalid-feedback">
+                Security code required
+              </div>
             </div>
           </div>
 
-          <div class="col-md-3">
-            <label for="cc-expiration" class="form-label is-required">Expiration</label>
-            <input type="text" class="form-control" id="cc-expiration" placeholder="" required>
-            <div class="invalid-feedback">
-              Expiration date required
-            </div>
-          </div>
+          <hr class="my-4">
 
-          <div class="col-md-3">
-            <label for="cc-cvv" class="form-label is-required">CVV</label>
-            <input type="text" class="form-control" id="cc-cvv" placeholder="" required>
-            <div class="invalid-feedback">
-              Security code required
-            </div>
-          </div>
-        </div>
-
-        <hr class="my-4">
-
-        <button class="btn btn-primary btn-lg btn-block" type="submit">Continue to checkout</button>
-      </form>
+          <button class="btn btn-primary btn-lg btn-block" type="submit">Continue to checkout</button>
+        </form>
+      </div>
     </div>
-  </div>
+  </main>
 
   <footer class="my-5 pt-5 text-muted text-center text-small">
     <p class="mb-1">&copy; 2017–{{< year >}} Company Name</p>

--- a/site/content/docs/5.0/examples/dashboard/index.html
+++ b/site/content/docs/5.0/examples/dashboard/index.html
@@ -11,7 +11,7 @@ extra_js:
   - src: "dashboard.js"
 ---
 
-<nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0 shadow">
+<header class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0 shadow">
   <a class="navbar-brand col-md-3 col-lg-2 mr-0 px-3" href="#">Company name</a>
   <button class="navbar-toggler position-absolute d-md-none collapsed" type="button" data-toggle="collapse" data-target="#sidebarMenu" aria-controls="sidebarMenu" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
@@ -22,7 +22,7 @@ extra_js:
       <a class="nav-link" href="#">Sign out</a>
     </li>
   </ul>
-</nav>
+</header>
 
 <div class="container-fluid">
   <div class="row">

--- a/site/content/docs/5.0/examples/floating-labels/index.html
+++ b/site/content/docs/5.0/examples/floating-labels/index.html
@@ -6,28 +6,31 @@ extra_css:
 include_js: false
 ---
 
-<form class="form-signin">
-  <div class="text-center mb-4">
-    <img class="mb-4" src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" alt="" width="50" height="50">
-    <h1 class="h3 mb-3 font-weight-normal">Floating labels</h1>
-    <p>Build form controls with floating labels via the <code>:placeholder-shown</code> pseudo-element. <a href="https://caniuse.com/#feat=css-placeholder-shown">Works in latest Chrome, Safari, and Firefox.</a></p>
-  </div>
 
-  <div class="form-label-group">
-    <input type="email" id="inputEmail" class="form-control" placeholder="Email address" required autofocus>
-    <label for="inputEmail">Email address</label>
-  </div>
+<main class="form-signin">
+  <form>
+    <div class="text-center mb-4">
+      <img class="mb-4" src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" alt="" width="50" height="50">
+      <h1 class="h3 mb-3 font-weight-normal">Floating labels</h1>
+      <p>Build form controls with floating labels via the <code>:placeholder-shown</code> pseudo-element. <a href="https://caniuse.com/#feat=css-placeholder-shown">Works in latest Chrome, Safari, and Firefox.</a></p>
+    </div>
 
-  <div class="form-label-group">
-    <input type="password" id="inputPassword" class="form-control" placeholder="Password" required>
-    <label for="inputPassword">Password</label>
-  </div>
+    <div class="form-label-group">
+      <input type="email" id="inputEmail" class="form-control" placeholder="Email address" required autofocus>
+      <label for="inputEmail">Email address</label>
+    </div>
 
-  <div class="checkbox mb-3">
-    <label>
-      <input type="checkbox" value="remember-me"> Remember me
-    </label>
-  </div>
-  <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
-  <p class="mt-5 mb-3 text-muted text-center">&copy; 2017-{{< year >}}</p>
-</form>
+    <div class="form-label-group">
+      <input type="password" id="inputPassword" class="form-control" placeholder="Password" required>
+      <label for="inputPassword">Password</label>
+    </div>
+
+    <div class="checkbox mb-3">
+      <label>
+        <input type="checkbox" value="remember-me"> Remember me
+      </label>
+    </div>
+    <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
+    <p class="mt-5 mb-3 text-muted text-center">&copy; 2017-{{< year >}}</p>
+  </form>
+</main>

--- a/site/content/docs/5.0/examples/grid/index.html
+++ b/site/content/docs/5.0/examples/grid/index.html
@@ -7,180 +7,182 @@ body_class: "py-4"
 include_js: false
 ---
 
-<div class="container">
+<main>
+  <div class="container">
+    <h1>Bootstrap grid examples</h1>
+    <p class="lead">Basic grid layouts to get you familiar with building within the Bootstrap grid system.</p>
+    <p>In these examples the <code>.themed-grid-col</code> class is added to the columns to add some theming. This is not a class that is available in Bootstrap by default.</p>
 
-  <h1>Bootstrap grid examples</h1>
-  <p class="lead">Basic grid layouts to get you familiar with building within the Bootstrap grid system.</p>
-  <p>In these examples the <code>.themed-grid-col</code> class is added to the columns to add some theming. This is not a class that is available in Bootstrap by default.</p>
+    <h2 class="mt-4">Five grid tiers</h2>
+    <p>There are five tiers to the Bootstrap grid system, one for each range of devices we support. Each tier starts at a minimum viewport size and automatically applies to the larger devices unless overridden.</p>
 
-  <h2 class="mt-4">Five grid tiers</h2>
-  <p>There are five tiers to the Bootstrap grid system, one for each range of devices we support. Each tier starts at a minimum viewport size and automatically applies to the larger devices unless overridden.</p>
-
-  <div class="row mb-3">
-    <div class="col-4 themed-grid-col">.col-4</div>
-    <div class="col-4 themed-grid-col">.col-4</div>
-    <div class="col-4 themed-grid-col">.col-4</div>
-  </div>
-
-  <div class="row mb-3">
-    <div class="col-sm-4 themed-grid-col">.col-sm-4</div>
-    <div class="col-sm-4 themed-grid-col">.col-sm-4</div>
-    <div class="col-sm-4 themed-grid-col">.col-sm-4</div>
-  </div>
-
-  <div class="row mb-3">
-    <div class="col-md-4 themed-grid-col">.col-md-4</div>
-    <div class="col-md-4 themed-grid-col">.col-md-4</div>
-    <div class="col-md-4 themed-grid-col">.col-md-4</div>
-  </div>
-
-  <div class="row mb-3">
-    <div class="col-lg-4 themed-grid-col">.col-lg-4</div>
-    <div class="col-lg-4 themed-grid-col">.col-lg-4</div>
-    <div class="col-lg-4 themed-grid-col">.col-lg-4</div>
-  </div>
-
-  <div class="row mb-3">
-    <div class="col-xl-4 themed-grid-col">.col-xl-4</div>
-    <div class="col-xl-4 themed-grid-col">.col-xl-4</div>
-    <div class="col-xl-4 themed-grid-col">.col-xl-4</div>
-  </div>
-
-  <div class="row mb-3">
-    <div class="col-xxl-4 themed-grid-col">.col-xxl-4</div>
-    <div class="col-xxl-4 themed-grid-col">.col-xxl-4</div>
-    <div class="col-xxl-4 themed-grid-col">.col-xxl-4</div>
-  </div>
-
-  <h2 class="mt-4">Three equal columns</h2>
-  <p>Get three equal-width columns <strong>starting at desktops and scaling to large desktops</strong>. On mobile devices, tablets and below, the columns will automatically stack.</p>
-  <div class="row mb-3">
-    <div class="col-md-4 themed-grid-col">.col-md-4</div>
-    <div class="col-md-4 themed-grid-col">.col-md-4</div>
-    <div class="col-md-4 themed-grid-col">.col-md-4</div>
-  </div>
-
-  <h2 class="mt-4">Three equal columns alternative</h2>
-  <p>By using the <code>.row-cols-*</code> classes, you can easily create a grid with equal columns.</p>
-  <div class="row row-cols-md-3 mb-3">
-    <div class="col themed-grid-col"><code>.col</code> child of <code>.row-cols-md-3</code></div>
-    <div class="col themed-grid-col"><code>.col</code> child of <code>.row-cols-md-3</code></div>
-    <div class="col themed-grid-col"><code>.col</code> child of <code>.row-cols-md-3</code></div>
-  </div>
-
-  <h2 class="mt-4">Three unequal columns</h2>
-  <p>Get three columns <strong>starting at desktops and scaling to large desktops</strong> of various widths. Remember, grid columns should add up to twelve for a single horizontal block. More than that, and columns start stacking no matter the viewport.</p>
-  <div class="row mb-3">
-    <div class="col-md-3 themed-grid-col">.col-md-3</div>
-    <div class="col-md-6 themed-grid-col">.col-md-6</div>
-    <div class="col-md-3 themed-grid-col">.col-md-3</div>
-  </div>
-
-  <h2 class="mt-4">Two columns</h2>
-  <p>Get two columns <strong>starting at desktops and scaling to large desktops</strong>.</p>
-  <div class="row mb-3">
-    <div class="col-md-8 themed-grid-col">.col-md-8</div>
-    <div class="col-md-4 themed-grid-col">.col-md-4</div>
-  </div>
-
-  <h2 class="mt-4">Full width, single column</h2>
-  <p class="text-warning">
-    No grid classes are necessary for full-width elements.
-  </p>
-
-  <hr class="my-4">
-
-  <h2 class="mt-4">Two columns with two nested columns</h2>
-  <p>Per the documentation, nesting is easy—just put a row of columns within an existing column. This gives you two columns <strong>starting at desktops and scaling to large desktops</strong>, with another two (equal widths) within the larger column.</p>
-  <p>At mobile device sizes, tablets and down, these columns and their nested columns will stack.</p>
-  <div class="row mb-3">
-    <div class="col-md-8 themed-grid-col">
-      <div class="pb-3">
-        .col-md-8
-      </div>
-      <div class="row">
-        <div class="col-md-6 themed-grid-col">.col-md-6</div>
-        <div class="col-md-6 themed-grid-col">.col-md-6</div>
-      </div>
+    <div class="row mb-3">
+      <div class="col-4 themed-grid-col">.col-4</div>
+      <div class="col-4 themed-grid-col">.col-4</div>
+      <div class="col-4 themed-grid-col">.col-4</div>
     </div>
-    <div class="col-md-4 themed-grid-col">.col-md-4</div>
+
+    <div class="row mb-3">
+      <div class="col-sm-4 themed-grid-col">.col-sm-4</div>
+      <div class="col-sm-4 themed-grid-col">.col-sm-4</div>
+      <div class="col-sm-4 themed-grid-col">.col-sm-4</div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-md-4 themed-grid-col">.col-md-4</div>
+      <div class="col-md-4 themed-grid-col">.col-md-4</div>
+      <div class="col-md-4 themed-grid-col">.col-md-4</div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-lg-4 themed-grid-col">.col-lg-4</div>
+      <div class="col-lg-4 themed-grid-col">.col-lg-4</div>
+      <div class="col-lg-4 themed-grid-col">.col-lg-4</div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-xl-4 themed-grid-col">.col-xl-4</div>
+      <div class="col-xl-4 themed-grid-col">.col-xl-4</div>
+      <div class="col-xl-4 themed-grid-col">.col-xl-4</div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-xxl-4 themed-grid-col">.col-xxl-4</div>
+      <div class="col-xxl-4 themed-grid-col">.col-xxl-4</div>
+      <div class="col-xxl-4 themed-grid-col">.col-xxl-4</div>
+    </div>
+
+    <h2 class="mt-4">Three equal columns</h2>
+    <p>Get three equal-width columns <strong>starting at desktops and scaling to large desktops</strong>. On mobile devices, tablets and below, the columns will automatically stack.</p>
+    <div class="row mb-3">
+      <div class="col-md-4 themed-grid-col">.col-md-4</div>
+      <div class="col-md-4 themed-grid-col">.col-md-4</div>
+      <div class="col-md-4 themed-grid-col">.col-md-4</div>
+    </div>
+
+    <h2 class="mt-4">Three equal columns alternative</h2>
+    <p>By using the <code>.row-cols-*</code> classes, you can easily create a grid with equal columns.</p>
+    <div class="row row-cols-md-3 mb-3">
+      <div class="col themed-grid-col"><code>.col</code> child of <code>.row-cols-md-3</code></div>
+      <div class="col themed-grid-col"><code>.col</code> child of <code>.row-cols-md-3</code></div>
+      <div class="col themed-grid-col"><code>.col</code> child of <code>.row-cols-md-3</code></div>
+    </div>
+
+    <h2 class="mt-4">Three unequal columns</h2>
+    <p>Get three columns <strong>starting at desktops and scaling to large desktops</strong> of various widths. Remember, grid columns should add up to twelve for a single horizontal block. More than that, and columns start stacking no matter the viewport.</p>
+    <div class="row mb-3">
+      <div class="col-md-3 themed-grid-col">.col-md-3</div>
+      <div class="col-md-6 themed-grid-col">.col-md-6</div>
+      <div class="col-md-3 themed-grid-col">.col-md-3</div>
+    </div>
+
+    <h2 class="mt-4">Two columns</h2>
+    <p>Get two columns <strong>starting at desktops and scaling to large desktops</strong>.</p>
+    <div class="row mb-3">
+      <div class="col-md-8 themed-grid-col">.col-md-8</div>
+      <div class="col-md-4 themed-grid-col">.col-md-4</div>
+    </div>
+
+    <h2 class="mt-4">Full width, single column</h2>
+    <p class="text-warning">
+      No grid classes are necessary for full-width elements.
+    </p>
+
+    <hr class="my-4">
+
+    <h2 class="mt-4">Two columns with two nested columns</h2>
+    <p>Per the documentation, nesting is easy—just put a row of columns within an existing column. This gives you two columns <strong>starting at desktops and scaling to large desktops</strong>, with another two (equal widths) within the larger column.</p>
+    <p>At mobile device sizes, tablets and down, these columns and their nested columns will stack.</p>
+    <div class="row mb-3">
+      <div class="col-md-8 themed-grid-col">
+        <div class="pb-3">
+          .col-md-8
+        </div>
+        <div class="row">
+          <div class="col-md-6 themed-grid-col">.col-md-6</div>
+          <div class="col-md-6 themed-grid-col">.col-md-6</div>
+        </div>
+      </div>
+      <div class="col-md-4 themed-grid-col">.col-md-4</div>
+    </div>
+
+    <hr class="my-4">
+
+    <h2 class="mt-4">Mixed: mobile and desktop</h2>
+    <p>The Bootstrap v4 grid system has five tiers of classes: xs (extra small, this class infix is not used), sm (small), md (medium), lg (large), and xl (extra large). You can use nearly any combination of these classes to create more dynamic and flexible layouts.</p>
+    <p>Each tier of classes scales up, meaning if you plan on setting the same widths for md, lg and xl, you only need to specify md.</p>
+    <div class="row mb-3">
+      <div class="col-md-8 themed-grid-col">.col-md-8</div>
+      <div class="col-6 col-md-4 themed-grid-col">.col-6 .col-md-4</div>
+    </div>
+    <div class="row mb-3">
+      <div class="col-6 col-md-4 themed-grid-col">.col-6 .col-md-4</div>
+      <div class="col-6 col-md-4 themed-grid-col">.col-6 .col-md-4</div>
+      <div class="col-6 col-md-4 themed-grid-col">.col-6 .col-md-4</div>
+    </div>
+    <div class="row mb-3">
+      <div class="col-6 themed-grid-col">.col-6</div>
+      <div class="col-6 themed-grid-col">.col-6</div>
+    </div>
+
+    <hr class="my-4">
+
+    <h2 class="mt-4">Mixed: mobile, tablet, and desktop</h2>
+    <div class="row mb-3">
+      <div class="col-sm-6 col-lg-8 themed-grid-col">.col-sm-6 .col-lg-8</div>
+      <div class="col-6 col-lg-4 themed-grid-col">.col-6 .col-lg-4</div>
+    </div>
+    <div class="row mb-3">
+      <div class="col-6 col-sm-4 themed-grid-col">.col-6 .col-sm-4</div>
+      <div class="col-6 col-sm-4 themed-grid-col">.col-6 .col-sm-4</div>
+      <div class="col-6 col-sm-4 themed-grid-col">.col-6 .col-sm-4</div>
+    </div>
+
+    <hr class="my-4">
+
+    <h2 class="mt-4">Gutters</h2>
+    <p>With <code>.gx-*</code> classes, the horizontal gutters can be adjusted.</p>
+    <div class="row row-cols-1 row-cols-md-3 gx-4">
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
+    </div>
+    <p class="mt-4">Use the <code>.gy-*</code> classes to control the vertical gutters.</p>
+    <div class="row row-cols-1 row-cols-md-3 gy-4">
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
+    </div>
+    <p class="mt-4">With <code>.g-*</code> classes, the gutters in both directions can be adjusted.</p>
+    <div class="row row-cols-1 row-cols-md-3 g-3">
+      <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
+      <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
+    </div>
   </div>
 
-  <hr class="my-4">
 
-  <h2 class="mt-4">Mixed: mobile and desktop</h2>
-  <p>The Bootstrap v4 grid system has five tiers of classes: xs (extra small, this class infix is not used), sm (small), md (medium), lg (large), and xl (extra large). You can use nearly any combination of these classes to create more dynamic and flexible layouts.</p>
-  <p>Each tier of classes scales up, meaning if you plan on setting the same widths for md, lg and xl, you only need to specify md.</p>
-  <div class="row mb-3">
-    <div class="col-md-8 themed-grid-col">.col-md-8</div>
-    <div class="col-6 col-md-4 themed-grid-col">.col-6 .col-md-4</div>
-  </div>
-  <div class="row mb-3">
-    <div class="col-6 col-md-4 themed-grid-col">.col-6 .col-md-4</div>
-    <div class="col-6 col-md-4 themed-grid-col">.col-6 .col-md-4</div>
-    <div class="col-6 col-md-4 themed-grid-col">.col-6 .col-md-4</div>
-  </div>
-  <div class="row mb-3">
-    <div class="col-6 themed-grid-col">.col-6</div>
-    <div class="col-6 themed-grid-col">.col-6</div>
+  <div class="container" id="containers">
+    <hr class="my-4">
+
+    <h2 class="mt-4">Containers</h2>
+    <p>Additional classes added in Bootstrap v4.4 allow containers that are 100% wide until a particular breakpoint. v5 adds a new <code>xxl</code> breakpoint.</p>
   </div>
 
-  <hr class="my-4">
-
-  <h2 class="mt-4">Mixed: mobile, tablet, and desktop</h2>
-  <div class="row mb-3">
-    <div class="col-sm-6 col-lg-8 themed-grid-col">.col-sm-6 .col-lg-8</div>
-    <div class="col-6 col-lg-4 themed-grid-col">.col-6 .col-lg-4</div>
-  </div>
-  <div class="row mb-3">
-    <div class="col-6 col-sm-4 themed-grid-col">.col-6 .col-sm-4</div>
-    <div class="col-6 col-sm-4 themed-grid-col">.col-6 .col-sm-4</div>
-    <div class="col-6 col-sm-4 themed-grid-col">.col-6 .col-sm-4</div>
-  </div>
-
-  <hr class="my-4">
-
-  <h2 class="mt-4">Gutters</h2>
-  <p>With <code>.gx-*</code> classes, the horizontal gutters can be adjusted.</p>
-  <div class="row row-cols-1 row-cols-md-3 gx-4">
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gx-4</code> gutters</div>
-  </div>
-  <p class="mt-4">Use the <code>.gy-*</code> classes to control the vertical gutters.</p>
-  <div class="row row-cols-1 row-cols-md-3 gy-4">
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.gy-4</code> gutters</div>
-  </div>
-  <p class="mt-4">With <code>.g-*</code> classes, the gutters in both directions can be adjusted.</p>
-  <div class="row row-cols-1 row-cols-md-3 g-3">
-    <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
-    <div class="col themed-grid-col"><code>.col</code> with <code>.g-3</code> gutters</div>
-  </div>
-</div>
-
-<div class="container" id="containers">
-  <hr class="my-4">
-
-  <h2 class="mt-4">Containers</h2>
-  <p>Additional classes added in Bootstrap v4.4 allow containers that are 100% wide until a particular breakpoint. v5 adds a new <code>xxl</code> breakpoint.</p>
-</div>
-
-<div class="container themed-container">.container</div>
-<div class="container-sm themed-container">.container-sm</div>
-<div class="container-md themed-container">.container-md</div>
-<div class="container-lg themed-container">.container-lg</div>
-<div class="container-xl themed-container">.container-xl</div>
-<div class="container-xxl themed-container">.container-xxl</div>
-<div class="container-fluid themed-container">.container-fluid</div>
+  <div class="container themed-container">.container</div>
+  <div class="container-sm themed-container">.container-sm</div>
+  <div class="container-md themed-container">.container-md</div>
+  <div class="container-lg themed-container">.container-lg</div>
+  <div class="container-xl themed-container">.container-xl</div>
+  <div class="container-xxl themed-container">.container-xxl</div>
+  <div class="container-fluid themed-container">.container-fluid</div>
+</main>

--- a/site/content/docs/5.0/examples/masonry/index.html
+++ b/site/content/docs/5.0/examples/masonry/index.html
@@ -7,7 +7,7 @@ extra_js:
     async: true
 ---
 
-<div class="container py-5">
+<main class="container py-5">
   <h1>Bootstrap and Masonry</h1>
   <p class="lead">Integrate <a href="https://masonry.desandro.com/">Masonry</a> with the Bootstrap grid system and cards component.</p>
 
@@ -102,4 +102,4 @@ extra_js:
     </div>
   </div>
 
-</div>
+</main>

--- a/site/content/docs/5.0/examples/navbar-bottom/index.html
+++ b/site/content/docs/5.0/examples/navbar-bottom/index.html
@@ -3,13 +3,13 @@ layout: examples
 title: Bottom navbar example
 ---
 
-<div class="container">
+<main class="container">
   <div class="bg-light p-5 rounded mt-3">
     <h1>Bottom Navbar example</h1>
     <p class="lead">This example is a quick exercise to illustrate how the bottom navbar works.</p>
     <a class="btn btn-lg btn-primary" href="{{< docsref "/components/navbar" >}}" role="button">View navbar docs &raquo;</a>
   </div>
-</div>
+</main>
 <nav class="navbar fixed-bottom navbar-expand-sm navbar-dark bg-dark">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Bottom navbar</a>

--- a/site/content/docs/5.0/examples/navbars/index.html
+++ b/site/content/docs/5.0/examples/navbars/index.html
@@ -5,345 +5,16 @@ extra_css:
   - "navbar.css"
 ---
 
-<nav class="navbar navbar-dark bg-dark">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Never expand</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample01" aria-controls="navbarsExample01" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarsExample01">
-      <ul class="navbar-nav mr-auto mb-2">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Link</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="dropdown01" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-          <ul class="dropdown-menu" aria-labelledby="dropdown01">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </li>
-      </ul>
-      <form>
-        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
-      </form>
-    </div>
-  </div>
-</nav>
-
-<nav class="navbar navbar-expand navbar-dark bg-dark">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Always expand</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample02" aria-controls="navbarsExample02" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarsExample02">
-      <ul class="navbar-nav mr-auto">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Link</a>
-        </li>
-      </ul>
-      <form>
-        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
-      </form>
-    </div>
-  </div>
-</nav>
-
-<nav class="navbar navbar-expand-sm navbar-dark bg-dark">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Expand at sm</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample03" aria-controls="navbarsExample03" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarsExample03">
-      <ul class="navbar-nav mr-auto mb-2 mb-sm-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Link</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="dropdown03" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-          <ul class="dropdown-menu" aria-labelledby="dropdown03">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </li>
-      </ul>
-      <form>
-        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
-      </form>
-    </div>
-  </div>
-</nav>
-
-<nav class="navbar navbar-expand-md navbar-dark bg-dark">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Expand at md</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample04" aria-controls="navbarsExample04" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarsExample04">
-      <ul class="navbar-nav mr-auto mb-2 mb-md-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Link</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="dropdown04" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-          <ul class="dropdown-menu" aria-labelledby="dropdown04">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </li>
-      </ul>
-      <form>
-        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
-      </form>
-    </div>
-  </div>
-</nav>
-
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Expand at lg</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample05" aria-controls="navbarsExample05" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarsExample05">
-      <ul class="navbar-nav mr-auto mb-2 mb-lg-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Link</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="dropdown05" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-          <ul class="dropdown-menu" aria-labelledby="dropdown05">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </li>
-      </ul>
-      <form>
-        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
-      </form>
-    </div>
-  </div>
-</nav>
-
-<nav class="navbar navbar-expand-xl navbar-dark bg-dark">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Expand at xl</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample06" aria-controls="navbarsExample06" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarsExample06">
-      <ul class="navbar-nav mr-auto mb-2 mb-xl-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Link</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="dropdown06" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-          <ul class="dropdown-menu" aria-labelledby="dropdown06">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </li>
-      </ul>
-      <form>
-        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
-      </form>
-    </div>
-  </div>
-</nav>
-
-<nav class="navbar navbar-expand-xxl navbar-dark bg-dark">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Expand at xxl</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleXxl" aria-controls="navbarsExampleXxl" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarsExampleXxl">
-      <ul class="navbar-nav mr-auto mb-2 mb-xl-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Link</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="dropdownXxl" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-          <ul class="dropdown-menu" aria-labelledby="dropdownXxl">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </li>
-      </ul>
-      <form>
-        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
-      </form>
-    </div>
-  </div>
-</nav>
-
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-  <div class="container">
-    <a class="navbar-brand" href="#">Container</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample07" aria-controls="navbarsExample07" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarsExample07">
-      <ul class="navbar-nav mr-auto mb-2 mb-lg-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Link</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="dropdown07" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-          <ul class="dropdown-menu" aria-labelledby="dropdown07">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </li>
-      </ul>
-      <form>
-        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
-      </form>
-    </div>
-  </div>
-</nav>
-
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-  <div class="container-xl">
-    <a class="navbar-brand" href="#">Container XL</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample07XL" aria-controls="navbarsExample07XL" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarsExample07XL">
-      <ul class="navbar-nav mr-auto mb-2 mb-lg-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Link</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="dropdown07XL" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-          <ul class="dropdown-menu" aria-labelledby="dropdown07XL">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </li>
-      </ul>
-      <form>
-        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
-      </form>
-    </div>
-  </div>
-</nav>
-
-<div class="container-xl mb-4">
-  Matching .container-xl...
-</div>
-
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-  <div class="container-fluid">
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample08" aria-controls="navbarsExample08" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse justify-content-md-center" id="navbarsExample08">
-      <ul class="navbar-nav">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Centered nav only</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Link</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="dropdown08" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-          <ul class="dropdown-menu" aria-labelledby="dropdown08">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </li>
-      </ul>
-    </div>
-  </div>
-</nav>
-
-<div class="container">
-  <nav class="navbar navbar-expand-lg navbar-light bg-light rounded">
+<main>
+  <nav class="navbar navbar-dark bg-dark" aria-label="First navbar example">
     <div class="container-fluid">
-      <a class="navbar-brand" href="#">Navbar</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample09" aria-controls="navbarsExample09" aria-expanded="false" aria-label="Toggle navigation">
+      <a class="navbar-brand" href="#">Never expand</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample01" aria-controls="navbarsExample01" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarsExample09">
-        <ul class="navbar-nav mr-auto mb-2 mb-lg-0">
+      <div class="collapse navbar-collapse" id="navbarsExample01">
+        <ul class="navbar-nav mr-auto mb-2">
           <li class="nav-item active">
             <a class="nav-link" aria-current="page" href="#">Home</a>
           </li>
@@ -354,8 +25,8 @@ extra_css:
             <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
           </li>
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="dropdown09" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-            <ul class="dropdown-menu" aria-labelledby="dropdown09">
+            <a class="nav-link dropdown-toggle" href="#" id="dropdown01" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown01">
               <li><a class="dropdown-item" href="#">Action</a></li>
               <li><a class="dropdown-item" href="#">Another action</a></li>
               <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -369,13 +40,278 @@ extra_css:
     </div>
   </nav>
 
-  <nav class="navbar navbar-expand-lg navbar-light bg-light rounded">
+  <nav class="navbar navbar-expand navbar-dark bg-dark" aria-label="Second navbar example">
     <div class="container-fluid">
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample10" aria-controls="navbarsExample10" aria-expanded="false" aria-label="Toggle navigation">
+      <a class="navbar-brand" href="#">Always expand</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample02" aria-controls="navbarsExample02" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 
-      <div class="collapse navbar-collapse justify-content-md-center" id="navbarsExample10">
+      <div class="collapse navbar-collapse" id="navbarsExample02">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item active">
+            <a class="nav-link" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+        </ul>
+        <form>
+          <input class="form-control" type="text" placeholder="Search" aria-label="Search">
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <nav class="navbar navbar-expand-sm navbar-dark bg-dark" aria-label="Third navbar example">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Expand at sm</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample03" aria-controls="navbarsExample03" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarsExample03">
+        <ul class="navbar-nav mr-auto mb-2 mb-sm-0">
+          <li class="nav-item active">
+            <a class="nav-link" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="dropdown03" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown03">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form>
+          <input class="form-control" type="text" placeholder="Search" aria-label="Search">
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <nav class="navbar navbar-expand-md navbar-dark bg-dark" aria-label="Fourth navbar example">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Expand at md</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample04" aria-controls="navbarsExample04" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarsExample04">
+        <ul class="navbar-nav mr-auto mb-2 mb-md-0">
+          <li class="nav-item active">
+            <a class="nav-link" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="dropdown04" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown04">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form>
+          <input class="form-control" type="text" placeholder="Search" aria-label="Search">
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark" aria-label="Fifth navbar example">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Expand at lg</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample05" aria-controls="navbarsExample05" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarsExample05">
+        <ul class="navbar-nav mr-auto mb-2 mb-lg-0">
+          <li class="nav-item active">
+            <a class="nav-link" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="dropdown05" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown05">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form>
+          <input class="form-control" type="text" placeholder="Search" aria-label="Search">
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <nav class="navbar navbar-expand-xl navbar-dark bg-dark" aria-label="Sixth navbar example">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Expand at xl</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample06" aria-controls="navbarsExample06" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarsExample06">
+        <ul class="navbar-nav mr-auto mb-2 mb-xl-0">
+          <li class="nav-item active">
+            <a class="nav-link" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="dropdown06" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown06">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form>
+          <input class="form-control" type="text" placeholder="Search" aria-label="Search">
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <nav class="navbar navbar-expand-xxl navbar-dark bg-dark" aria-label="Seventh navbar example">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Expand at xxl</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleXxl" aria-controls="navbarsExampleXxl" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarsExampleXxl">
+        <ul class="navbar-nav mr-auto mb-2 mb-xl-0">
+          <li class="nav-item active">
+            <a class="nav-link" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="dropdownXxl" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdownXxl">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form>
+          <input class="form-control" type="text" placeholder="Search" aria-label="Search">
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark" aria-label="Eighth navbar example">
+    <div class="container">
+      <a class="navbar-brand" href="#">Container</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample07" aria-controls="navbarsExample07" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarsExample07">
+        <ul class="navbar-nav mr-auto mb-2 mb-lg-0">
+          <li class="nav-item active">
+            <a class="nav-link" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="dropdown07" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown07">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form>
+          <input class="form-control" type="text" placeholder="Search" aria-label="Search">
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark" aria-label="Ninth navbar example">
+    <div class="container-xl">
+      <a class="navbar-brand" href="#">Container XL</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample07XL" aria-controls="navbarsExample07XL" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarsExample07XL">
+        <ul class="navbar-nav mr-auto mb-2 mb-lg-0">
+          <li class="nav-item active">
+            <a class="nav-link" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="dropdown07XL" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown07XL">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form>
+          <input class="form-control" type="text" placeholder="Search" aria-label="Search">
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container-xl mb-4">
+    <p>Matching .container-xl...</p>
+  </div>
+
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark" aria-label="Tenth navbar example">
+    <div class="container-fluid">
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample08" aria-controls="navbarsExample08" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse justify-content-md-center" id="navbarsExample08">
         <ul class="navbar-nav">
           <li class="nav-item active">
             <a class="nav-link" aria-current="page" href="#">Centered nav only</a>
@@ -387,8 +323,8 @@ extra_css:
             <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
           </li>
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="dropdown10" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
-            <ul class="dropdown-menu" aria-labelledby="dropdown10">
+            <a class="nav-link dropdown-toggle" href="#" id="dropdown08" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown08">
               <li><a class="dropdown-item" href="#">Action</a></li>
               <li><a class="dropdown-item" href="#">Another action</a></li>
               <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -399,16 +335,82 @@ extra_css:
     </div>
   </nav>
 
-  <main>
-    <div class="bg-light p-5 rounded">
-      <div class="col-sm-8 mx-auto">
-        <h1>Navbar examples</h1>
-        <p>This example is a quick exercise to illustrate how the navbar and its contents work. Some navbars extend the width of the viewport, others are confined within a <code>.container</code>. For positioning of navbars, checkout the <a href="{{< docsref "/examples/navbar-static" >}}">top</a> and <a href="{{< docsref "/examples/navbar-fixed" >}}">fixed top</a> examples.</p>
-        <p>At the smallest breakpoint, the collapse plugin is used to hide the links and show a menu button to toggle the collapsed content.</p>
-        <p>
-          <a class="btn btn-primary" href="{{< docsref "/components/navbar" >}}" role="button">View navbar docs &raquo;</a>
-        </p>
+  <div class="container">
+    <nav class="navbar navbar-expand-lg navbar-light bg-light rounded" aria-label="Eleventh navbar example">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="#">Navbar</a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample09" aria-controls="navbarsExample09" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarsExample09">
+          <ul class="navbar-nav mr-auto mb-2 mb-lg-0">
+            <li class="nav-item active">
+              <a class="nav-link" aria-current="page" href="#">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#">Link</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="dropdown09" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+              <ul class="dropdown-menu" aria-labelledby="dropdown09">
+                <li><a class="dropdown-item" href="#">Action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Something else here</a></li>
+              </ul>
+            </li>
+          </ul>
+          <form>
+            <input class="form-control" type="text" placeholder="Search" aria-label="Search">
+          </form>
+        </div>
+      </div>
+    </nav>
+
+    <nav class="navbar navbar-expand-lg navbar-light bg-light rounded" aria-label="Twelfth navbar example">
+      <div class="container-fluid">
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExample10" aria-controls="navbarsExample10" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse justify-content-md-center" id="navbarsExample10">
+          <ul class="navbar-nav">
+            <li class="nav-item active">
+              <a class="nav-link" aria-current="page" href="#">Centered nav only</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#">Link</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="dropdown10" data-toggle="dropdown" aria-expanded="false">Dropdown</a>
+              <ul class="dropdown-menu" aria-labelledby="dropdown10">
+                <li><a class="dropdown-item" href="#">Action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Something else here</a></li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <div>
+      <div class="bg-light p-5 rounded">
+        <div class="col-sm-8 mx-auto">
+          <h1>Navbar examples</h1>
+          <p>This example is a quick exercise to illustrate how the navbar and its contents work. Some navbars extend the width of the viewport, others are confined within a <code>.container</code>. For positioning of navbars, checkout the <a href="{{< docsref "/examples/navbar-static" >}}">top</a> and <a href="{{< docsref "/examples/navbar-fixed" >}}">fixed top</a> examples.</p>
+          <p>At the smallest breakpoint, the collapse plugin is used to hide the links and show a menu button to toggle the collapsed content.</p>
+          <p>
+            <a class="btn btn-primary" href="{{< docsref "/components/navbar" >}}" role="button">View navbar docs &raquo;</a>
+          </p>
+        </div>
       </div>
     </div>
-  </main>
-</div>
+  </div>
+</main>

--- a/site/content/docs/5.0/examples/offcanvas/index.html
+++ b/site/content/docs/5.0/examples/offcanvas/index.html
@@ -8,10 +8,10 @@ extra_js:
 body_class: "bg-light"
 ---
 
-<nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-dark">
+<nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-dark" aria-label="Main navigation">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Offcanvas navbar</a>
-    <button class="navbar-toggler p-0 border-0" type="button" data-toggle="offcanvas">
+    <button class="navbar-toggler p-0 border-0" type="button" data-toggle="offcanvas" aria-label="Toggle Navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 
@@ -47,7 +47,7 @@ body_class: "bg-light"
 </nav>
 
 <div class="nav-scroller bg-white shadow-sm">
-  <nav class="nav nav-underline">
+  <nav class="nav nav-underline" aria-label="Secondary navigation">
     <a class="nav-link active" aria-current="page" href="#">Dashboard</a>
     <a class="nav-link" href="#">
       Friends
@@ -64,10 +64,10 @@ body_class: "bg-light"
 </div>
 
 <main class="container">
-  <div class="d-flex align-items-center p-3 my-3 text-white-50 bg-purple rounded shadow-sm">
+  <div class="d-flex align-items-center p-3 my-3 text-white bg-purple rounded shadow-sm">
     <img class="mr-3" src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" alt="" width="50" height="50">
     <div class="lh-1">
-      <h6 class="mb-0 text-white lh-1">Bootstrap</h6>
+      <h1 class="h6 mb-0 text-white lh-1">Bootstrap</h1>
       <small>Since 2011</small>
     </div>
   </div>

--- a/site/content/docs/5.0/examples/offcanvas/offcanvas.css
+++ b/site/content/docs/5.0/examples/offcanvas/offcanvas.css
@@ -64,4 +64,4 @@ body {
 
 .text-white-50 { color: rgba(255, 255, 255, .5); }
 
-.bg-purple { background-color: #6f42c1; }
+.bg-purple { background-color: #000; } /* Boosted mod */

--- a/site/content/docs/5.0/examples/pricing/index.html
+++ b/site/content/docs/5.0/examples/pricing/index.html
@@ -6,8 +6,8 @@ extra_css:
 include_js: false
 ---
 
-<div class="d-flex flex-column flex-md-row align-items-center p-3 px-md-4 mb-3 bg-white border-bottom shadow-sm">
-  <h5 class="my-0 mr-md-auto font-weight-normal">Company name</h5>
+<header class="d-flex flex-column flex-md-row align-items-center p-3 px-md-4 mb-3 bg-white border-bottom shadow-sm">
+  <p class="h5 my-0 mr-md-auto font-weight-normal">Company name</p>
   <nav class="my-2 my-md-0 mr-md-3">
     <a class="p-2 text-dark" href="#">Features</a>
     <a class="p-2 text-dark" href="#">Enterprise</a>
@@ -15,14 +15,14 @@ include_js: false
     <a class="p-2 text-dark" href="#">Pricing</a>
   </nav>
   <a class="btn btn-outline-primary" href="#">Sign up</a>
-</div>
+</header>
 
-<div class="pricing-header px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">
-  <h1 class="display-4">Pricing</h1>
-  <p class="lead">Quickly build an effective pricing table for your potential customers with this Bootstrap example. It’s built with default Bootstrap components and utilities with little customization.</p>
-</div>
+<main class="container">
+  <div class="pricing-header px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">
+    <h1 class="display-4">Pricing</h1>
+    <p class="lead">Quickly build an effective pricing table for your potential customers with this Bootstrap example. It’s built with default Bootstrap components and utilities with little customization.</p>
+  </div>
 
-<div class="container">
   <div class="row row-cols-1 row-cols-md-3 mb-3 text-center">
     <div class="col">
       <div class="card mb-4 shadow-sm">
@@ -114,4 +114,4 @@ include_js: false
       </div>
     </div>
   </footer>
-</div>
+</main>

--- a/site/content/docs/5.0/examples/product/index.html
+++ b/site/content/docs/5.0/examples/product/index.html
@@ -5,8 +5,8 @@ extra_css:
   - "product.css"
 ---
 
-<nav class="site-header sticky-top py-1">
-  <div class="container d-flex flex-column flex-md-row justify-content-between">
+<header class="site-header sticky-top py-1">
+  <nav class="container d-flex flex-column flex-md-row justify-content-between">
     <a class="py-2" href="#" aria-label="Product">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="d-block mx-auto" role="img" viewBox="0 0 24 24"><title>Product</title><circle cx="12" cy="12" r="10"/><path d="M14.31 8l5.74 9.94M9.69 8h11.48M7.38 12l5.74-9.94M9.69 16L3.95 6.06M14.31 16H2.83m13.79-4l-5.74 9.94"/></svg>
     </a>
@@ -17,86 +17,88 @@ extra_css:
     <a class="py-2 d-none d-md-inline-block" href="#">Support</a>
     <a class="py-2 d-none d-md-inline-block" href="#">Pricing</a>
     <a class="py-2 d-none d-md-inline-block" href="#">Cart</a>
-  </div>
-</nav>
+  </nav>
+</header>
 
-<div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center bg-light">
-  <div class="col-md-5 p-lg-5 mx-auto my-5">
-    <h1 class="display-4 font-weight-normal">Punny headline</h1>
-    <p class="lead font-weight-normal">And an even wittier subheading to boot. Jumpstart your marketing efforts with this example based on Apple’s marketing pages.</p>
-    <a class="btn btn-outline-secondary" href="#">Coming soon</a>
+<main>
+  <div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center bg-light">
+    <div class="col-md-5 p-lg-5 mx-auto my-5">
+      <h1 class="display-4 font-weight-normal">Punny headline</h1>
+      <p class="lead font-weight-normal">And an even wittier subheading to boot. Jumpstart your marketing efforts with this example based on Apple’s marketing pages.</p>
+      <a class="btn btn-outline-secondary" href="#">Coming soon</a>
+    </div>
+    <div class="product-device shadow-sm d-none d-md-block"></div>
+    <div class="product-device product-device-2 shadow-sm d-none d-md-block"></div>
   </div>
-  <div class="product-device shadow-sm d-none d-md-block"></div>
-  <div class="product-device product-device-2 shadow-sm d-none d-md-block"></div>
-</div>
 
-<div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
-  <div class="bg-dark mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center text-white overflow-hidden">
-    <div class="my-3 py-3">
-      <h2 class="display-5">Another headline</h2>
-      <p class="lead">And an even wittier subheading.</p>
+  <div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
+    <div class="bg-dark mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center text-white overflow-hidden">
+      <div class="my-3 py-3">
+        <h2 class="display-5">Another headline</h2>
+        <p class="lead">And an even wittier subheading.</p>
+      </div>
+      <div class="bg-light shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
     </div>
-    <div class="bg-light shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
-  </div>
-  <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
-    <div class="my-3 p-3">
-      <h2 class="display-5">Another headline</h2>
-      <p class="lead">And an even wittier subheading.</p>
+    <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
+      <div class="my-3 p-3">
+        <h2 class="display-5">Another headline</h2>
+        <p class="lead">And an even wittier subheading.</p>
+      </div>
+      <div class="bg-dark shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
     </div>
-    <div class="bg-dark shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
   </div>
-</div>
 
-<div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
-  <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
-    <div class="my-3 p-3">
-      <h2 class="display-5">Another headline</h2>
-      <p class="lead">And an even wittier subheading.</p>
+  <div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
+    <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
+      <div class="my-3 p-3">
+        <h2 class="display-5">Another headline</h2>
+        <p class="lead">And an even wittier subheading.</p>
+      </div>
+      <div class="bg-dark shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
     </div>
-    <div class="bg-dark shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
-  </div>
-  <div class="bg-primary mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center text-white overflow-hidden">
-    <div class="my-3 py-3">
-      <h2 class="display-5">Another headline</h2>
-      <p class="lead">And an even wittier subheading.</p>
+    <div class="bg-primary mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center text-white overflow-hidden">
+      <div class="my-3 py-3">
+        <h2 class="display-5">Another headline</h2>
+        <p class="lead">And an even wittier subheading.</p>
+      </div>
+      <div class="bg-light shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
     </div>
-    <div class="bg-light shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
   </div>
-</div>
 
-<div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
-  <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
-    <div class="my-3 p-3">
-      <h2 class="display-5">Another headline</h2>
-      <p class="lead">And an even wittier subheading.</p>
+  <div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
+    <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
+      <div class="my-3 p-3">
+        <h2 class="display-5">Another headline</h2>
+        <p class="lead">And an even wittier subheading.</p>
+      </div>
+      <div class="bg-white shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
     </div>
-    <div class="bg-white shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
-  </div>
-  <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
-    <div class="my-3 py-3">
-      <h2 class="display-5">Another headline</h2>
-      <p class="lead">And an even wittier subheading.</p>
+    <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
+      <div class="my-3 py-3">
+        <h2 class="display-5">Another headline</h2>
+        <p class="lead">And an even wittier subheading.</p>
+      </div>
+      <div class="bg-white shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
     </div>
-    <div class="bg-white shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
   </div>
-</div>
 
-<div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
-  <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
-    <div class="my-3 p-3">
-      <h2 class="display-5">Another headline</h2>
-      <p class="lead">And an even wittier subheading.</p>
+  <div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
+    <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
+      <div class="my-3 p-3">
+        <h2 class="display-5">Another headline</h2>
+        <p class="lead">And an even wittier subheading.</p>
+      </div>
+      <div class="bg-white shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
     </div>
-    <div class="bg-white shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
-  </div>
-  <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
-    <div class="my-3 py-3">
-      <h2 class="display-5">Another headline</h2>
-      <p class="lead">And an even wittier subheading.</p>
+    <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
+      <div class="my-3 py-3">
+        <h2 class="display-5">Another headline</h2>
+        <p class="lead">And an even wittier subheading.</p>
+      </div>
+      <div class="bg-white shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
     </div>
-    <div class="bg-white shadow-sm mx-auto" style="width: 80%; height: 300px; border-radius: 21px 21px 0 0;"></div>
   </div>
-</div>
+</main>
 
 <footer class="container py-5">
   <div class="row">

--- a/site/content/docs/5.0/examples/product/product.css
+++ b/site/content/docs/5.0/examples/product/product.css
@@ -12,7 +12,7 @@
   backdrop-filter: saturate(180%) blur(20px);
 }
 .site-header a {
-  color: #727272;
+  color: #8e8e8e;
   transition: color .15s ease-in-out;
 }
 .site-header a:hover {

--- a/site/content/docs/5.0/examples/sign-in/index.html
+++ b/site/content/docs/5.0/examples/sign-in/index.html
@@ -7,18 +7,20 @@ body_class: "text-center"
 include_js: false
 ---
 
-<form class="form-signin">
-  <img class="mb-4" src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" alt="" width="50" height="50">
-  <h1 class="h3 mb-3 font-weight-normal">Please sign in</h1>
-  <label for="inputEmail" class="visually-hidden">Email address</label>
-  <input type="email" id="inputEmail" class="form-control" placeholder="Email address" required autofocus>
-  <label for="inputPassword" class="visually-hidden">Password</label>
-  <input type="password" id="inputPassword" class="form-control" placeholder="Password" required>
-  <div class="checkbox mb-3">
-    <label>
-      <input type="checkbox" value="remember-me"> Remember me
-    </label>
-  </div>
-  <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
-  <p class="mt-5 mb-3 text-muted">&copy; 2017-{{< year >}}</p>
-</form>
+<main class="form-signin">
+  <form>
+    <img class="mb-4" src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" alt="" width="50" height="50">
+    <h1 class="h3 mb-3 font-weight-normal">Please sign in</h1>
+    <label for="inputEmail" class="visually-hidden">Email address</label>
+    <input type="email" id="inputEmail" class="form-control" placeholder="Email address" required autofocus>
+    <label for="inputPassword" class="visually-hidden">Password</label>
+    <input type="password" id="inputPassword" class="form-control" placeholder="Password" required>
+    <div class="checkbox mb-3">
+      <label>
+        <input type="checkbox" value="remember-me"> Remember me
+      </label>
+    </div>
+    <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
+    <p class="mt-5 mb-3 text-muted">&copy; 2017-{{< year >}}</p>
+  </form>
+</main>

--- a/site/content/docs/5.0/guidelines/alerts.md
+++ b/site/content/docs/5.0/guidelines/alerts.md
@@ -11,8 +11,6 @@ Alerts are available in [four styles]({{< docsref "/components/alerts" >}}#examp
 
 ## Success
 
-<i><button></button></i>
-
 {{< alert success >}}
 
 ## Information

--- a/site/content/docs/5.0/guidelines/alerts.md
+++ b/site/content/docs/5.0/guidelines/alerts.md
@@ -11,6 +11,8 @@ Alerts are available in [four styles]({{< docsref "/components/alerts" >}}#examp
 
 ## Success
 
+<i><button></button></i>
+
 {{< alert success >}}
 
 ## Information

--- a/site/content/docs/versions.md
+++ b/site/content/docs/versions.md
@@ -13,7 +13,7 @@ description: An appendix of hosted documentation for nearly every release of Boo
     {{- range $i, $version := $versions }}
       {{- $len := len $versions -}}
       {{ if (eq $i 0) }}<div class="list-group">{{ end }}
-        <a class="list-group-item list-group-item-action py-2 text-primary{{ if (eq $version.v $.Site.Params.docs_version) }} d-flex justify-content-between align-items-center{{ end }}" href="{{ $release.baseurl }}/{{ $version.v }}/">
+        <a class="list-group-item list-group-item-action py-2 {{ if (eq $version.v $.Site.Params.docs_version) }} d-flex justify-content-between align-items-center{{ end }}" href="{{ $release.baseurl }}/{{ $version.v }}/">
           {{ $version.v }}
           {{ if (eq $version.v $.Site.Params.docs_version) -}}
           <span class="badge bg-primary">Latest</span>

--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -15,22 +15,22 @@
         {{ partial "docs-sidebar" . }}
       </div>
 
-      <div class="bd-intro pt-4 pl-lg-4">
-        <h1 class="bd-title" id="content">{{ .Title | markdownify }}</h1>
-        <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>
-        {{ partial "ads" . }}
-      </div>
-
       {{ if (eq .Page.Params.toc true) }}
-        <div class="bd-toc py-4 border-left border-light border-sm">
+        <aside class="bd-toc py-4 border-left border-light border-sm">
           <div class="bd-toc-nav">
             <strong class="d-block h6 my-2 pl-xl-3 pb-2 border-bottom border-light border-sm">On this page</strong>
             <div class="pl-xl-3">{{ .TableOfContents }}</div>
           </div>
-        </div>
+        </aside>
       {{ end }}
 
       <main class="bd-content order-1 pb-4 pl-lg-4">
+        <div class="bd-intro pt-2">
+          <h1 class="bd-title" id="content">{{ .Title | markdownify }}</h1>
+          <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>
+          {{ partial "ads" . }}
+        </div>
+
         {{ if .Page.Params.sections }}
           <div class="row g-3">
             {{ range .Page.Params.sections }}

--- a/site/layouts/_default/guidelines.html
+++ b/site/layouts/_default/guidelines.html
@@ -15,22 +15,22 @@
         {{ partial "guidelines-sidebar" . }}
       </div>
 
-      <div class="bd-intro pt-4 pl-lg-4">
-        <h1 class="bd-title" id="content">{{ .Title | markdownify }}</h1>
-        <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>
-        {{ partial "ads" . }}
-      </div>
-
       {{ if (eq .Page.Params.toc true) }}
-        <div class="bd-toc py-4 border-left border-light border-sm">
+        <aside class="bd-toc py-4 border-left border-light border-sm">
           <div class="bd-toc-nav">
             <strong class="d-block h6 my-2 pl-xl-3 pb-2 border-bottom border-light border-sm">On this page</strong>
             <div class="pl-xl-3">{{ .TableOfContents }}</div>
           </div>
-        </div>
+        </aside>
       {{ end }}
 
       <main class="bd-content bd-guidelines pb-4 {{ if eq .Title "Typography" }}bd-typography{{ else if eq .Title "Alerts" }}bd-alerts{{ end }} order-1 pl-lg-4">
+        <div class="bd-intro pt-2">
+          <h1 class="bd-title" id="content">{{ .Title | markdownify }}</h1>
+          <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>
+          {{ partial "ads" . }}
+        </div>
+
         {{ if .Page.Params.sections }}
           <div class="row g-3">
             {{ range .Page.Params.sections }}

--- a/site/layouts/_default/home.html
+++ b/site/layouts/_default/home.html
@@ -9,8 +9,10 @@
 
     {{ partial "docs-navbar" . }}
 
-    {{ partial "home/masthead" . }}
-    {{ partial "home/masthead-followup" . }}
+    <main>
+      {{ partial "home/masthead" . }}
+      {{ partial "home/masthead-followup" . }}
+    </main>
 
     {{ .Content }}
 

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -9,21 +9,21 @@
 
     {{ partial "docs-navbar" . }}
 
-    <header class="py-5 border-bottom border-light">
-      <div class="container pt-md-1 pb-md-4">
-        <h1 class="bd-title mt-0">{{ .Title | markdownify }}</h1>
-        <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>
-        {{ if eq .Title "Examples" }}
-        <div class="d-flex flex-column flex-sm-row">
-          <a href="{{ .Site.Params.download.dist_examples }}" class="btn btn-lg btn-secondary" onclick="dataLayer.push({'event': 'clic', 'site_name':'accessibility-boosted', 'phase':'prod', 'track_category':'download', 'track_name':'zip-example', 'track_cible':'hero'});">Download Examples</a>
-          <a href="{{ .Site.Params.download.source }}" class="btn btn-lg btn-primary mt-3 mt-sm-0 ml-sm-3" onclick="dataLayer.push({'event': 'clic', 'site_name':'accessibility-boosted', 'phase':'prod', 'track_category':'download', 'track_name':'example', 'track_cible':'hero'});">Download source code</a>
-        </div>
-        {{ end }}
-        {{ partial "ads" . }}
-      </div>
-    </header>
-
     <main class="bd-content order-1 py-5" id="content">
+      <div class="mb-5 pb-5 border-bottom border-light">
+        <div class="container pt-md-1 pb-md-4">
+          <h1 class="bd-title mt-0">{{ .Title | markdownify }}</h1>
+          <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>
+          {{ if eq .Title "Examples" }}
+          <div class="d-flex flex-column flex-sm-row">
+            <a href="{{ .Site.Params.download.dist_examples }}" class="btn btn-lg btn-secondary" onclick="dataLayer.push({'event': 'clic', 'site_name':'accessibility-boosted', 'phase':'prod', 'track_category':'download', 'track_name':'zip-example', 'track_cible':'hero'});">Download Examples</a>
+            <a href="{{ .Site.Params.download.source }}" class="btn btn-lg btn-primary mt-3 mt-sm-0 ml-sm-3" onclick="dataLayer.push({'event': 'clic', 'site_name':'accessibility-boosted', 'phase':'prod', 'track_category':'download', 'track_name':'example', 'track_cible':'hero'});">Download source code</a>
+          </div>
+          {{ end }}
+          {{ partial "ads" . }}
+        </div>
+      </div>
+
       <div class="container">
         {{ .Content }}
       </div>

--- a/site/layouts/partials/home/masthead-followup.html
+++ b/site/layouts/partials/home/masthead-followup.html
@@ -1,4 +1,4 @@
-<div class="bd-followup">
+<section class="bd-followup">
   <div class="container py-3 py-md-5">
     <div class="row align-items-center">
       <div class="col-md-5">
@@ -19,9 +19,9 @@
       </div>
     </div>
   </div>
-</div>
+</section>
 
-<div class="bd-followup">
+<section class="bd-followup">
   <div class="container py-3 py-md-5">
     <div class="row align-items-center">
       <div class="col-md-5">
@@ -46,9 +46,9 @@
       </div>
     </div>
   </div>
-</div>
+</section>
 
-<div class="bd-followup">
+<section class="bd-followup">
   <div class="container py-3 py-md-5">
     <div class="row align-items-center">
       <div class="col-md-5">
@@ -71,4 +71,4 @@
       </div>
     </div>
   </div>
-</div>
+</section>

--- a/site/layouts/partials/home/masthead.html
+++ b/site/layouts/partials/home/masthead.html
@@ -1,4 +1,4 @@
-<main class="bd-masthead" id="content">
+<div class="bd-masthead" id="content">
   <div class="container">
     <div class="row">
       <div class="col-6 mx-auto col-md-4 order-md-2 col-lg-5">
@@ -25,4 +25,4 @@
     </div>
     {{ partial "ads.html" . }}
   </div>
-</main>
+</div>

--- a/site/layouts/shortcodes/alert.html
+++ b/site/layouts/shortcodes/alert.html
@@ -33,7 +33,7 @@ where type is one of info (default), danger, warning, success
 <div class="alert alert-{{ $css_class }} alert-dismissible fade show" role="alert">
   <span class="alert-icon"><span class="visually-hidden">{{ humanize $css_class }}</span></span>
   <div>
-    <h4 class="alert-heading">{{ humanize $css_class }} notification text goes here.</h4>
+    <h3 class="alert-heading">{{ humanize $css_class }} notification text goes here.</h3>
     <p>Description text goes here.</p>
   </div>
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"></button>
@@ -41,7 +41,7 @@ where type is one of info (default), danger, warning, success
 <div class="alert alert-{{ $css_class }} alert-dismissible fade show" role="alert">
   <span class="alert-icon"><span class="visually-hidden">{{ humanize $css_class }}</span></span>
   <div>
-    <h4 class="alert-heading">{{ humanize $css_class }} notification text goes here. <a href="#">Action</a></h4>
+    <h3 class="alert-heading">{{ humanize $css_class }} notification text goes here. <a href="#">Action</a></h3>
     <p>Description text goes here.</p>
   </div>
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"></button>

--- a/site/layouts/shortcodes/placeholder.html
+++ b/site/layouts/shortcodes/placeholder.html
@@ -23,7 +23,7 @@
 {{- $show_title := not (eq $title "false") -}}
 {{- $show_text := not (eq $text "false") -}}
 
-<svg class="bd-placeholder-img{{ with $class }} {{ . }}{{ end }}" width="{{ $width }}" height="{{ $height }}" xmlns="http://www.w3.org/2000/svg"{{ if (or $show_title $show_text) }} aria-label="{{ if $show_title }}{{ $title }}{{ if $show_text }}: {{ end }}{{ end }}{{ if ($show_text) }}{{ $text }}{{ end }}"{{ end }} preserveAspectRatio="xMidYMid slice" role="img" focusable="false">
+<svg class="bd-placeholder-img{{ with $class }} {{ . }}{{ end }}" width="{{ $width }}" height="{{ $height }}" xmlns="http://www.w3.org/2000/svg"{{ if (or $show_title $show_text) }}  role="img" aria-label="{{ if $show_title }}{{ $title }}{{ if $show_text }}: {{ end }}{{ end }}{{ if ($show_text) }}{{ $text }}{{ end }}"{{ else }} aria-hidden="true"{{ end }} preserveAspectRatio="xMidYMid slice" focusable="false">
   {{- if $show_title -}}<title>{{ $title }}</title>{{- end -}}
   <rect width="100%" height="100%" fill="{{ $background }}"/>
   {{- if $show_text -}}<text x="50%" y="50%" fill="{{ $color }}" dy=".3em" class="font-weight-bold">{{ $text }}</text>{{- end -}}


### PR DESCRIPTION
Closes #449 

Here's a comprehensive list of ignored rules and elements, to discuss:

1. The `heading-order` rule is ignored, since Bootstrap doesn't want to improve their heading hierarchy (and this is probably not a big deal, only a few level skipped).
2. `.bd-search` is ignored, it comes from Algolia (third-party).
3. `.active` and `[aria-current]` are ignored since their contrasts aren't sufficient (`#f16e00` on `#fff`, brand side).
4. ~~`pre *` for code blocks, our current syntax highlighting theme still have contrast issues.~~
5. `.modal` since it's flagged as `aria-hidden` containing interactive content: this is how the modal works…
6. `#TableOfContents` is flagged as redundant `nav` landmark, which is generated by Hugo (so we can't change it) and moreover is not an issue at all (third-party, sort of).
7. `.bd-example nav` is flagged too for the same reason, but it's meant to document `nav` usage, so…
8. ~~`.bd-callout h4`: our callout themes currently output contrasts between 3:1 and 4.5:1 for `h4`, which is flagged as invalid.~~
9. ~~And all examples should be improved.~~

**Every improvements should be suggested to Bootstrap directly.**

To maybe fine-tune our criterias, [pa11y's wiki has a comprehensive list of ignorable rules](https://github.com/pa11y/pa11y/wiki/HTML-CodeSniffer-Rules).

Percy works fine, see #460 (before it's getting closed!).

