### PR TITLE
Use supporting colors for badges

### DIFF
--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -51,19 +51,22 @@
 // Contextual variations (linked badges get darker on :hover).
 
 @each $color, $value in $theme-colors {
-  .badge-#{$color} {
-    @include badge-variant($value);
-
-    @if $color == "info" {
-      &.badge-lg,
-      &.badge-xlg {
-        color: $white;
-      }
+  // Boosted mod: disallow functionnal colors for background
+  @if ($value != $success) and ($value != $danger) and ($value != $info) and ($value != $warning) {
+    .badge-#{$color} {
+      @include badge-variant($value);
     }
   }
 }
 
-// Boosted mod
+// Boosted mod: supporting colour as background
+@each $color, $value in $supporting-colors {
+  .badge-#{$color} {
+    @include badge-variant($value);
+  }
+}
+
+// Boosted mod: focus visibility
 .badge[href] {
   @include transition($transition-focus); // Boosted mod
   &:focus {
@@ -76,6 +79,7 @@
   }
 }
 
+// Boosted mod: sizes variant
 .badge-xlg {
   @include font-size($badge-font-size-xlg);
   padding: $badge-padding-y-lg $badge-padding-x-lg;


### PR DESCRIPTION
Fixes #463 

Preview: https://deploy-preview-466--boosted.netlify.app/docs/4.5/components/badge/#contextual-variations
FYI, since v5 uses `.bg-*` utilities for this, it already uses supporting colors for badges: https://v5-dev--boosted.netlify.app/docs/5.0/components/badge/#background-colors