### PR TITLE
docs(forms): drop useless text in horizontal form example

### DIFF
--- a/site/content/docs/5.0/forms/layout.md
+++ b/site/content/docs/5.0/forms/layout.md
@@ -158,8 +158,7 @@ At times, you maybe need to use margin or padding utilities to create that perfe
     </div>
   </fieldset>
   <div class="row mb-3">
-    <div class="col-form-label col-sm-2 pt-0">Checkbox</div>
-    <div class="col-sm-10">
+    <div class="col-sm-10 offset-sm-2">
       <div class="form-check">
         <input class="form-check-input" type="checkbox" id="gridCheck1">
         <label class="form-check-label" for="gridCheck1">


### PR DESCRIPTION
Folowwing #517 