### PR TITLE
docs(analytics): drop read more link

### DIFF
--- a/site/assets/js/tac.js
+++ b/site/assets/js/tac.js
@@ -52,11 +52,6 @@
     var toggle = document.createRange().createContextualFragment('<div class="form-check form-switch my-2 my-lg-0"><input class="form-check-input ml-0" type="checkbox" id="googletagmanagerAllowed" aria-describedby="tacCLgoogletagmanager" onchange="' + choiceEvent + '"><label class="form-check-label visually-hidden" for="googletagmanagerAllowed">Google Tag Manager</label></div>')
     ask.innerHTML = ''
     ask.append(toggle)
-
-    var link = document.querySelector('[href="/docs/5.0/about/cookies/"]')
-    link.removeAttribute('target')
-    link.removeAttribute('rel')
-    link.removeAttribute('title')
   }, { once: true })
 })()
 
@@ -71,7 +66,6 @@ if (typeof tarteaucitron !== 'undefined') {
     showIcon: false,
     handleBrowserDNTRequest: true,
     useExternalCss: true,
-    readmoreLink: '/docs/5.0/about/cookies/',
     mandatory: false
   })
 


### PR DESCRIPTION
Either we don't link to our cookies page or we add content to our cookies page; but for now, giving users more info about GTM cookies seems more important than linking to our own content.