### PR TITLE
Carousels

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,35 +26,35 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "23.1 kB"
+      "maxSize": "23.4 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",
-      "maxSize": "21.1 kB"
+      "maxSize": "21.5 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.js",
-      "maxSize": "43.5 kB"
+      "maxSize": "44.15 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.min.js",
-      "maxSize": "22.1 kB"
+      "maxSize": "22.4 kB"
     },
     {
       "path": "./dist/js/boosted.esm.js",
-      "maxSize": "26.1 kB"
+      "maxSize": "26.7 kB"
     },
     {
       "path": "./dist/js/boosted.esm.min.js",
-      "maxSize": "17.75 kB"
+      "maxSize": "18 kB"
     },
     {
       "path": "./dist/js/boosted.js",
-      "maxSize": "27.75 kB"
+      "maxSize": "27.5 kB"
     },
     {
       "path": "./dist/js/boosted.min.js",
-      "maxSize": "15.5 kB"
+      "maxSize": "15.75 kB"
     }
   ],
   "ci": {

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -56,7 +56,7 @@ jobs:
         uses: percy/snapshot-action@v0.1.2
         with:
           build-directory: "_gh_pages/"
-          flags: "--snapshot-files ./index.html,./docs/5.0/guidelines/**/*.html"
+          flags: "--snapshot-files ./index.html,./docs/5.0/guidelines/**/*.html,./docs/5.0/examples/cheatsheet/index.html,./docs/5.0/examples/cheatsheet-rtl/index.html"
           verbose: true
         env:
           PERCY_TOKEN: "${{ secrets.PERCY_TOKEN }}"

--- a/config.yml
+++ b/config.yml
@@ -60,7 +60,7 @@ params:
   repo:                 "https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap"
   twitter:              "orange"
   icons:                "https://design.orange.com/icons-libraries/"
-  bootstrap:            "https://v5.getbootstrap.com"
+  bootstrap:            "https://getbootstrap.com"
 
   download:
     source:             "https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/archive/v5.0.0-beta1.zip"

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -92,6 +92,8 @@ const SELECTOR_INDICATORS = '.carousel-indicators'
 const SELECTOR_DATA_SLIDE = '[data-bs-slide], [data-bs-slide-to]'
 const SELECTOR_DATA_RIDE = '[data-bs-ride="carousel"]'
 
+const PREFIX_CUSTOM_PROPS = 'o-' // Boosted mod: should match `$boosted-variable-prefix` in scss/_variables.scss
+
 const PointerType = {
   TOUCH: 'touch',
   PEN: 'pen'
@@ -421,6 +423,14 @@ class Carousel extends BaseComponent {
     } else {
       this._config.interval = this._config.defaultInterval || this._config.interval
     }
+
+    // Boosted mod: set progress indicator's interval as custom property
+    if (this._indicatorsElement && this._config.interval !== Default.interval) {
+      const currentIndex = this._getItemIndex(element)
+      const currentIndicator = SelectorEngine.findOne(`:nth-child(${currentIndex + 1})`, this._indicatorsElement)
+      currentIndicator.style.setProperty(`--${PREFIX_CUSTOM_PROPS}carousel-interval`, `${this._config.interval}ms`)
+    }
+    // End mod
   }
 
   _slide(direction, element) {

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -257,6 +257,177 @@ describe('Carousel', () => {
       }, 10)
     })
 
+    // Boosted mod
+    it('should stay at the end when the next method is called and wrap is false', done => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide">',
+        '  <div class="carousel-inner">',
+        '    <div id="one" class="carousel-item"></div>',
+        '    <div id="two" class="carousel-item"></div>',
+        '    <div id="three" class="carousel-item active">item 3</div>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const lastElement = fixtureEl.querySelector('#three')
+      const carousel = new Carousel(carouselEl, { wrap: false })
+
+      carouselEl.addEventListener('slid.bs.carousel', () => {
+        throw new Error('carousel slid when it should not have slid')
+      })
+
+      carousel.next()
+
+      setTimeout(() => {
+        expect(lastElement.classList.contains('active')).toEqual(true)
+        done()
+      }, 10)
+    })
+
+    it('should disable next control when the last item becomes active and wrap is false', done => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide">',
+        '  <div class="carousel-inner">',
+        '    <div id="one" class="carousel-item"></div>',
+        '    <div id="two" class="carousel-item active"></div>',
+        '    <div id="three" class="carousel-item">item 3</div>',
+        '  </div>',
+        '  <button class="carousel-control-prev"></button>',
+        '  <button class="carousel-control-next"></button>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const prevControl = fixtureEl.querySelector('.carousel-control-prev')
+      const nextControl = fixtureEl.querySelector('.carousel-control-next')
+      const carousel = new Carousel(carouselEl, { wrap: false })
+
+      carousel.next()
+
+      setTimeout(() => {
+        expect(nextControl.disabled).toEqual(true)
+        expect(prevControl.disabled).toEqual(false)
+        done()
+      }, 10)
+    })
+
+    it('should disable prev control when the first item becomes active and wrap is false', done => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide">',
+        '  <div class="carousel-inner">',
+        '    <div id="one" class="carousel-item"></div>',
+        '    <div id="two" class="carousel-item active"></div>',
+        '    <div id="three" class="carousel-item">item 3</div>',
+        '  </div>',
+        '  <button class="carousel-control-prev"></button>',
+        '  <button class="carousel-control-next"></button>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const prevControl = fixtureEl.querySelector('.carousel-control-prev')
+      const nextControl = fixtureEl.querySelector('.carousel-control-next')
+      const carousel = new Carousel(carouselEl, { wrap: false })
+
+      carousel.prev()
+
+      setTimeout(() => {
+        expect(prevControl.disabled).toEqual(true)
+        expect(nextControl.disabled).toEqual(false)
+        done()
+      }, 10)
+    })
+
+    it('should disable prev control using aria-disabled if control is a link', done => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide">',
+        '  <div class="carousel-inner">',
+        '    <div id="one" class="carousel-item"></div>',
+        '    <div id="two" class="carousel-item active"></div>',
+        '    <div id="three" class="carousel-item">item 3</div>',
+        '  </div>',
+        '  <a href="#" class="carousel-control-prev"></a>',
+        '  <a href="#" class="carousel-control-next"></a>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const prevControl = fixtureEl.querySelector('.carousel-control-prev')
+      const carousel = new Carousel(carouselEl, { wrap: false })
+
+      carousel.prev()
+
+      setTimeout(() => {
+        expect(prevControl.getAttribute('aria-disabled')).toEqual('true')
+        expect(prevControl.getAttribute('tabindex')).toEqual('-1')
+        done()
+      }, 10)
+    })
+
+    it('should add done class when at the end, the next method is called and wrap is false', done => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide">',
+        '  <ol class="carousel-indicators">',
+        '    <li data-bs-target="#myCarousel" data-bs-slide-to="0"></li>',
+        '    <li data-bs-target="#myCarousel" data-bs-slide-to="1"></li>',
+        '    <li data-bs-target="#myCarousel" data-bs-slide-to="2" class="active"></li>',
+        '  </ol>',
+        '  <div class="carousel-inner">',
+        '    <div id="one" class="carousel-item"></div>',
+        '    <div id="two" class="carousel-item"></div>',
+        '    <div id="three" class="carousel-item active">item 3</div>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const carousel = new Carousel(carouselEl, { wrap: false })
+
+      carouselEl.addEventListener('slid.bs.carousel', () => {
+        throw new Error('carousel slid when it should not have slid')
+      })
+
+      carousel.next()
+
+      setTimeout(() => {
+        expect(carousel._element.classList.contains('done')).toEqual(true)
+        done()
+      }, 10)
+    })
+
+    it('should not add done class when at the start, the prev method is called and wrap is false', done => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide">',
+        '  <ol class="carousel-indicators">',
+        '    <li data-bs-target="#myCarousel" data-bs-slide-to="0" class="active"></li>',
+        '    <li data-bs-target="#myCarousel" data-bs-slide-to="1"></li>',
+        '    <li data-bs-target="#myCarousel" data-bs-slide-to="2"></li>',
+        '  </ol>',
+        '  <div class="carousel-inner">',
+        '    <div id="one" class="carousel-item active"></div>',
+        '    <div id="two" class="carousel-item"></div>',
+        '    <div id="three" class="carousel-item">item 3</div>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const carousel = new Carousel(carouselEl, { wrap: false })
+
+      carouselEl.addEventListener('slid.bs.carousel', () => {
+        throw new Error('carousel slid when it should not have slid')
+      })
+
+      carousel.prev()
+
+      setTimeout(() => {
+        expect(carousel._element.classList.contains('done')).toEqual(false)
+        done()
+      }, 10)
+    })
+    // End mod
+
     it('should not add touch event listeners if touch = false', () => {
       fixtureEl.innerHTML = '<div></div>'
 
@@ -721,6 +892,33 @@ describe('Carousel', () => {
   })
 
   describe('pause', () => {
+    // Boosted mod
+    it('should add paused class', () => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide">',
+        '  <ol class="carousel-indicators">',
+        '    <li data-bs-target="#myCarousel" data-bs-slide-to="0" class="active"></li>',
+        '    <li data-bs-target="#myCarousel" data-bs-slide-to="1"></li>',
+        '    <li data-bs-target="#myCarousel" data-bs-slide-to="2"></li>',
+        '  </ol>',
+        '  <div class="carousel-inner">',
+        '    <div class="carousel-item active">item 1</div>',
+        '    <div class="carousel-item">item 2</div>',
+        '    <div class="carousel-item">item 3</div>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const carousel = new Carousel(carouselEl)
+
+      carousel.pause()
+
+      expect(carousel._isPaused).toEqual(true)
+      expect(carousel._element.classList.contains('paused')).toEqual(true)
+    })
+    // End mod
+
     it('should call cycle if the carousel have carousel-item-next and carousel-item-prev class', () => {
       fixtureEl.innerHTML = [
         '<div id="myCarousel" class="carousel slide">',
@@ -729,8 +927,8 @@ describe('Carousel', () => {
         '    <div class="carousel-item carousel-item-next">item 2</div>',
         '    <div class="carousel-item">item 3</div>',
         '  </div>',
-        '  <div class="carousel-control-prev"></div>',
-        '  <div class="carousel-control-next"></div>',
+        '  <button class="carousel-control-prev"></button>',
+        '  <button class="carousel-control-next"></button>',
         '</div>'
       ].join('')
 
@@ -755,8 +953,8 @@ describe('Carousel', () => {
         '    <div class="carousel-item">item 2</div>',
         '    <div class="carousel-item">item 3</div>',
         '  </div>',
-        '  <div class="carousel-control-prev"></div>',
-        '  <div class="carousel-control-next"></div>',
+        '  <button class="carousel-control-prev"></button>',
+        '  <button class="carousel-control-next"></button>',
         '</div>'
       ].join('')
 
@@ -781,8 +979,8 @@ describe('Carousel', () => {
         '    <div class="carousel-item">item 2</div>',
         '    <div class="carousel-item">item 3</div>',
         '  </div>',
-        '  <div class="carousel-control-prev"></div>',
-        '  <div class="carousel-control-next"></div>',
+        '  <button class="carousel-control-prev"></button>',
+        '  <button class="carousel-control-next"></button>',
         '</div>'
       ].join('')
 
@@ -800,6 +998,29 @@ describe('Carousel', () => {
   })
 
   describe('cycle', () => {
+    // Boosted mod
+    it('should remove the paused class', () => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide">',
+        '  <div class="carousel-inner">',
+        '    <div class="carousel-item active">item 1</div>',
+        '    <div class="carousel-item">item 2</div>',
+        '    <div class="carousel-item">item 3</div>',
+        '  </div>',
+        '  <button class="carousel-control-prev"></button>',
+        '  <button class="carousel-control-next"></button>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const carousel = new Carousel(carouselEl)
+
+      carousel.cycle()
+
+      expect(carousel._element.classList.contains('paused')).toEqual(false)
+    })
+    // End mod
+
     it('should set an interval', () => {
       fixtureEl.innerHTML = [
         '<div id="myCarousel" class="carousel slide">',
@@ -808,8 +1029,8 @@ describe('Carousel', () => {
         '    <div class="carousel-item">item 2</div>',
         '    <div class="carousel-item">item 3</div>',
         '  </div>',
-        '  <div class="carousel-control-prev"></div>',
-        '  <div class="carousel-control-next"></div>',
+        '  <button class="carousel-control-prev"></button>',
+        '  <button class="carousel-control-next"></button>',
         '</div>'
       ].join('')
 
@@ -831,8 +1052,8 @@ describe('Carousel', () => {
         '    <div class="carousel-item">item 2</div>',
         '    <div class="carousel-item">item 3</div>',
         '  </div>',
-        '  <div class="carousel-control-prev"></div>',
-        '  <div class="carousel-control-next"></div>',
+        '  <button class="carousel-control-prev"></button>',
+        '  <button class="carousel-control-next"></button>',
         '</div>'
       ].join('')
 
@@ -855,8 +1076,8 @@ describe('Carousel', () => {
         '    <div class="carousel-item">item 2</div>',
         '    <div class="carousel-item">item 3</div>',
         '  </div>',
-        '  <div class="carousel-control-prev"></div>',
-        '  <div class="carousel-control-next"></div>',
+        '  <button class="carousel-control-prev"></button>',
+        '  <button class="carousel-control-next"></button>',
         '</div>'
       ].join('')
 
@@ -902,6 +1123,39 @@ describe('Carousel', () => {
 
       expect(carousel._config.interval).toEqual(9385)
     })
+
+    // Boosted mod
+    it('should set --o-carousel-interval custom property on indicator if data-bs-interval is provided', () => {
+      fixtureEl.innerHTML = [
+        '<div id="myCarousel" class="carousel slide">',
+        '  <ol class="carousel-indicators">',
+        '    <li id="firstIndicator" data-bs-target="#myCarousel" data-bs-slide-to="0" class="active"></li>',
+        '    <li id="secondIndicator" data-bs-target="#myCarousel" data-bs-slide-to="1"></li>',
+        '    <li data-bs-target="#myCarousel" data-bs-slide-to="2"></li>',
+        '  </ol>',
+        '  <div class="carousel-inner">',
+        '    <div class="carousel-item active" data-bs-interval="7">item 1</div>',
+        '    <div id="secondItem" class="carousel-item" data-bs-interval="9385">item 2</div>',
+        '    <div class="carousel-item">item 3</div>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const firstIndicator = fixtureEl.querySelector('#firstIndicator')
+      const secondItemEl = fixtureEl.querySelector('#secondItem')
+      const secondIndicator = fixtureEl.querySelector('#secondIndicator')
+      const carousel = new Carousel(carouselEl)
+      carousel.cycle()
+
+      expect(firstIndicator.style.getPropertyValue('--o-carousel-interval')).toEqual('7ms')
+
+      carousel._activeElement = secondItemEl
+      carousel.cycle()
+
+      expect(secondIndicator.style.getPropertyValue('--o-carousel-interval')).toEqual('9385ms')
+    })
+    // End mod
   })
 
   describe('to', () => {

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -13,7 +13,6 @@
 
 .carousel {
   position: relative;
-  margin-bottom: $carousel-margin-bottom; // Boosted mod
 }
 
 .carousel.pointer-event {
@@ -114,11 +113,11 @@
 }
 
 .carousel-control-prev {
-  left: $carousel-control-offset; // Boosted mod
+  left: 0;
   background-image: if($enable-gradients, linear-gradient(90deg, rgba($black, .25), rgba($black, .001)), null);
 }
 .carousel-control-next {
-  right: $carousel-control-offset; // Boosted mod
+  right: 0;
   background-image: if($enable-gradients, linear-gradient(270deg, rgba($black, .25), rgba($black, .001)), null);
 }
 
@@ -128,7 +127,8 @@
   display: inline-block;
   width: $carousel-control-icon-width;
   height: $carousel-control-icon-width;
-  background: escape-svg($carousel-control-prev-icon-bg) no-repeat 50% / #{$carousel-control-icon-size $carousel-control-icon-size}; // Boosted mod
+  background: rgba($carousel-indicator-active-bg, .5) escape-svg($carousel-control-icon-bg) no-repeat subtract(50%, $spacer / 10) 50% / #{$carousel-control-icon-size $carousel-control-icon-size}; // Boosted mod
+  @include border-radius(50%, 50%);
 }
 
 // Boosted mod
@@ -145,6 +145,34 @@
   transform: scaleX(-1);
 }
 */
+
+@each $direction in "prev", "next" {
+  .carousel-control-#{$direction} {
+    &:hover,
+    &:focus {
+      .carousel-control-#{$direction}-icon {
+        background-color: $carousel-indicator-active-bg;
+        filter: $carousel-control-icon-filter;
+      }
+    }
+
+    &:active {
+      .carousel-control-#{$direction}-icon {
+        background-color: $carousel-control-icon-active-bg;
+        filter: none;
+      }
+    }
+
+    &:disabled,
+    &[aria-disabled] {
+      pointer-events: none;
+
+      .carousel-control-#{$direction}-icon {
+        background-image: escape-svg($carousel-control-icon-disabled-bg);
+      }
+    }
+  }
+}
 // End mod
 
 // Optional indicator pips
@@ -152,19 +180,20 @@
 // Add an ordered list with the following class and add a list item for each
 // slide your carousel holds.
 
+/* rtl:begin:ignore */
 .carousel-indicators {
   position: absolute;
-  right: 0;
-  bottom: -$carousel-margin-bottom;
-  left: 0;
+  bottom: 0;
+  left: 50%; // Boosted mod
   z-index: 2;
   display: flex;
   justify-content: center;
-  padding-left: 0; // override <ol> default
-  // Use the .carousel-control's width as margin so we don't overlay those
-  margin-right: $carousel-control-width;
-  margin-left: $carousel-control-width;
+  padding: $carousel-indicators-padding-y 0; // Boosted mod
+  // Boosted mod: no margins
   list-style: none;
+  background: rgba($carousel-indicator-active-bg, .5); // Boosted mod
+  transform: translateX(-50%); // Boosted mod
+  @include border-radius($spacer, $spacer); // Boosted mod
 
   li {
     box-sizing: content-box;
@@ -176,20 +205,95 @@
     text-indent: -999px;
     cursor: pointer;
     background-color: $carousel-control-color; // Boosted mod
-    background-clip: padding-box;
-    // Use transparent borders to increase the hit area by 10px on top and bottom.
-    border-top: $carousel-indicator-hit-area-height solid transparent;
-    border-bottom: $carousel-indicator-hit-area-height solid transparent;
+    // Boosted mod: use our own target-size() mixin instead of transparent borders
     opacity: $carousel-indicator-opacity;
     @include transition($carousel-indicator-transition);
-    @include border-radius(50%, 50%); // Boosted mod
+
+    // Boosted mod
+    @include border-radius(50%, 50%);
+    @include target-size($carousel-indicator-hit-area-height);
+
+    &:hover,
+    &:focus {
+      background-color: color-contrast($carousel-indicator-active-bg);
+      transform: scale($carousel-indicator-hover-scale);
+
+      &::before {
+        transform: translate3d(-50%, -50%, 0) scale($carousel-indicator-active-scale);
+      }
+    }
   }
 
   .active {
-    background-color: $carousel-indicator-active-bg; // Boosted mod
+    background-color: $carousel-indicator-active-bg;
+    border-color: color-contrast($carousel-indicator-active-bg);
     opacity: $carousel-indicator-active-opacity;
+
+    @if $enable-transitions {
+      // Animation based on Lea Verou's simple pie chart
+      // See https://www.smashingmagazine.com/2015/07/designing-simple-pie-charts-with-css/
+      background-image: linear-gradient(to right, transparent 50%, color-contrast($carousel-indicator-active-bg) 0);
+      transform: scale($carousel-indicator-hover-scale);
+      // No need to feature test mask-*
+      // See https://caniuse.com/mdn-css_properties_mask-image
+      mask-image: radial-gradient(circle at 50%, transparent 33%, $white add(33%, 1px));
+
+      &:hover,
+      &:focus {
+        mask-image: none;
+      }
+
+      &::before {
+        transform: translate3d(-50%, -50%, 0) scale($carousel-indicator-active-scale);
+      }
+
+      &::after {
+        position: absolute;
+        top: 0;
+        left: 50%;
+        width: 50%;
+        height: 100%;
+        content: "";
+        background-color: inherit;
+        transform-origin: left;
+        // stylelint-disable-next-line function-disallowed-list
+        animation: carousel-progress calc(#{$carousel-indicator-animation-interval} / 2) linear infinite, carousel-progress-half $carousel-indicator-animation-interval step-end infinite;
+        @include border-radius($carousel-indicator-active-radius, $carousel-indicator-active-radius);
+      }
+
+      @keyframes carousel-progress {
+        to { transform: rotate(.5turn); }
+      }
+
+      @keyframes carousel-progress-half {
+        50% { background: color-contrast($carousel-indicator-active-bg); }
+      }
+
+      .carousel.done &,
+      .carousel.paused &,
+      .carousel.static & {
+        background: color-contrast($carousel-indicator-active-bg);
+
+        &::after {
+          animation: none;
+        }
+      }
+
+      @if $enable-reduced-motion {
+        @media (prefers-reduced-motion: reduce) {
+          background: color-contrast($carousel-indicator-active-bg);
+
+          &::after {
+            animation: none;
+          }
+        }
+      }
+    }
   }
 }
+
+/* rtl:end:ignore */
+// End mod
 
 
 // Optional captions
@@ -198,26 +302,12 @@
 
 .carousel-caption {
   position: absolute;
+  right: (100% - $carousel-caption-width) / 2;
   bottom: $carousel-caption-spacer;
-  left: map-get($spacers, 5);
-  padding: $carousel-caption-padding-y; // Boosted mod
+  left: (100% - $carousel-caption-width) / 2;
+  padding: $carousel-caption-padding-y $carousel-caption-padding-x; // Boosted mod
   color: $carousel-caption-color;
-  background-color: color-contrast($carousel-caption-color); // Boosted mod
+  background-color: color-contrast($carousel-caption-color); // Boosted mod: ensure contrast
 }
 
-// Dark mode carousel
-
-.carousel-dark {
-  .carousel-control-prev-icon,
-  .carousel-control-next-icon {
-    filter: $carousel-dark-control-icon-filter;
-  }
-
-  .carousel-indicators li {
-    background-color: $carousel-dark-indicator-active-bg;
-  }
-
-  .carousel-caption {
-    color: $carousel-dark-caption-color;
-  }
-}
+// Boosted mod: no dark carousel

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -15,6 +15,7 @@
 @import "mixins/visually-hidden";
 @import "mixins/reset-text";
 @import "mixins/text-truncate";
+@import "mixins/target-size"; // Boosted mod
 
 // Utilities
 @import "mixins/utilities";

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -75,6 +75,7 @@
   letter-spacing: inherit; // Boosted mod
   white-space: nowrap;
   @include transition($navbar-brand-transition); // Boosted mod
+  @include target-size($navbar-brand-logo-height); // Boosted mod
 
   &:hover,
   &:focus {
@@ -88,17 +89,6 @@
   .h1, .h2, .h3, .h4, .h5, .h6 { // stylelint-disable-line selector-list-comma-newline-after
     margin: 0 0 0 $spacer;
     line-height: inherit;
-  }
-
-  //// Increase touch target size
-  &::before {
-    position: absolute;
-    top: $navbar-brand-hit-area-offset;
-    left: $navbar-brand-hit-area-offset;
-    width: $navbar-brand-logo-height;
-    height: $navbar-brand-logo-height;
-    content: "";
-    transform: translate3d(-50%, -50%, 0);
   }
 
   //// Orange's master logo
@@ -287,12 +277,6 @@
         .navbar-brand {
           align-self: flex-end;
           margin: 0 $spacer subtract($spacer, $border-width) 0;
-
-          &::before {
-            top: 0;
-            left: 0;
-            transform: none;
-          }
 
           img {
             width: $navbar-brand-logo-height;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -92,24 +92,16 @@
 
     &:hover,
     &:focus {
-      color: $pagination-hover-bg;
-      background-color: $pagination-hover-color;
-      border-color: $pagination-hover-color;
-      outline-color: $pagination-hover-color; // Boosted mod
-
-      &::before {
-        background-image: escape-svg($pagination-icon-hover);
-      }
+      filter: $invert-filter;
+      border-color: $pagination-hover-bg;
+      outline-color: $pagination-hover-bg;
     }
 
     &:active {
       color: color-contrast($pagination-active-item-bg);
       background-color: $pagination-active-item-bg;
+      filter: none;
       border-color: $pagination-active-item-border;
-
-      &::before {
-        background-image: escape-svg($pagination-icon);
-      }
     }
 
     &.has-label {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -269,6 +269,7 @@ $enable-important-utilities:  true !default;
 // Prefix for :root CSS variables
 
 $variable-prefix:             bs- !default;
+$boosted-variable-prefix:     o- !default;
 
 // Gradient
 //
@@ -1371,6 +1372,13 @@ $carousel-indicator-opacity:         null !default;
 $carousel-indicator-active-bg:       $primary !default;
 $carousel-indicator-active-opacity:  null !default;
 $carousel-indicator-transition:      null !default;
+// Boosted mod
+$carousel-indicator-hover-scale:        1.5 !default;
+$carousel-indicator-active-scale:       calc(2 / 3) !default; // stylelint-disable-line function-disallowed-list
+$carousel-indicator-active-radius:      0 100% 100% 0 / 50% !default;
+$carousel-indicator-animation-duration: 5000ms !default;
+$carousel-indicator-animation-interval: var(--#{$boosted-variable-prefix}carousel-interval, #{$carousel-indicator-animation-duration}) !default;
+// End mod
 
 $carousel-caption-color:             $black !default;
 $carousel-caption-padding-y:         $spacer !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -932,7 +932,6 @@ $navbar-nav-link-padding-x:         $nav-link-padding-x / 2 !default;
 $navbar-icon-size:                     $spacer * 1.5 !default;
 //$navbar-height:                        6.25rem !default;
 $navbar-brand-logo-height:             add($spacer * 1.5, $spacer) !default;
-$navbar-brand-hit-area-offset:         add($spacer / 4, $spacer / 2) !default;
 $navbar-brand-logo-minimized-height:   $spacer * 1.5 !default;
 //$navbar-supra-padding-y:               $navbar-brand-logo-height / 10 !default;
 //$navbar-supra-padding-x:               $spacer / 4 * 1.5 !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -237,7 +237,7 @@ $escaped-characters: (
 
 // Boosted mod
 $chevron-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'><path d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/></svg>") !default;
-$chevron-icon-disabled: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'><path fill='#{$light}' d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/></svg>") !default;
+$chevron-icon-disabled: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'><path fill='#{$gray-700}' d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/></svg>") !default;
 $cross-icon:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' fill='#{$black}'><path d='M15 17.121l-8.132 8.132-2.121-2.12L12.879 15 4.747 6.868l2.12-2.121L15 12.879l8.132-8.132 2.12 2.121L17.122 15l8.132 8.132-2.121 2.12L15 17.123z'/></svg>") !default;
 $cross-icon-stroke:     url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' fill='#{$black}'><path stroke='#{$black}' stroke-width='5' stroke-linecap='round' d='M15 17.121l-8.132 8.132-2.121-2.12L12.879 15 4.747 6.868l2.12-2.121L15 12.879l8.132-8.132 2.12 2.121L17.122 15l8.132 8.132-2.121 2.12L15 17.123z'/></svg>") !default;
 $success-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 125 125'><path fill='#{$success}' d='M62.5 0a62.5 62.5 0 100 125 62.5 62.5 0 000-125zm28 29.4c3.3 0 6 2.6 6 5.9a5.9 5.9 0 01-1.3 3.7L57.7 86a5.8 5.8 0 01-9.1 0L29.8 62.5c-.8-1-1.2-2.3-1.2-3.7a5.9 5.9 0 011.7-4.1l2.3-2.4a5.8 5.8 0 014.2-1.7 5.8 5.8 0 013.8 1.4L52 64.7 86.6 31a5.8 5.8 0 014-1.6z'/></svg>") !default;
@@ -1355,20 +1355,18 @@ $breadcrumb-border-radius:          null !default;
 
 // Carousel
 
-$carousel-margin-bottom:             $spacer * 3 !default; // Boosted mod
 $carousel-control-color:             $black !default;
-$carousel-control-width:             $spacer * 1.5 !default;
+$carousel-control-width:             $spacer * 3 !default;
 $carousel-control-opacity:           null !default;
 $carousel-control-hover-opacity:     null !default;
 $carousel-control-transition:        $transition-focus !default;
-$carousel-control-offset:            $spacer / 2 !default; // Boosted mod
 
-$carousel-indicator-width:           $spacer / 2 !default;
-$carousel-indicator-height:          $spacer / 2 !default;
-$carousel-indicator-hit-area-height: null !default;
-$carousel-indicator-spacer:          3px !default;
+$carousel-indicator-width:           .5rem !default;
+$carousel-indicator-height:          .5rem !default;
+$carousel-indicator-hit-area-height: $spacer * 1.5 !default;
+$carousel-indicator-spacer:          $spacer / 2 !default;
 $carousel-indicator-opacity:         null !default;
-$carousel-indicator-active-bg:       $primary !default;
+$carousel-indicator-active-bg:       $white !default;
 $carousel-indicator-active-opacity:  null !default;
 $carousel-indicator-transition:      null !default;
 // Boosted mod
@@ -1376,24 +1374,30 @@ $carousel-indicator-hover-scale:        1.5 !default;
 $carousel-indicator-active-scale:       calc(2 / 3) !default; // stylelint-disable-line function-disallowed-list
 $carousel-indicator-active-radius:      0 100% 100% 0 / 50% !default;
 $carousel-indicator-animation-duration: 5000ms !default;
-$carousel-indicator-animation-interval: var(--#{$boosted-variable-prefix}carousel-interval, #{$carousel-indicator-animation-duration}) !default;
+$carousel-indicator-animation-interval: var(--carousel-interval, #{$carousel-indicator-animation-duration}) !default;
+$carousel-indicators-padding-y:         $spacer / 2 !default;
 // End mod
 
+$carousel-caption-width:             70% !default;
 $carousel-caption-color:             $black !default;
 $carousel-caption-padding-y:         $spacer !default;
-$carousel-caption-spacer:            0 !default;
+$carousel-caption-padding-x:         $spacer !default; // Boosted mod
+$carousel-caption-spacer:            $spacer * 3 !default;
 
-$carousel-control-icon-width:        2.375rem !default;
-$carousel-control-icon-size:         $spacer * 1.5 !default; // Boosted mod
-
-$carousel-control-prev-icon-bg:      $chevron-icon !default;
+$carousel-control-icon-width:        2.5rem !default;
+// Boosted mod
+$carousel-control-icon-size:         1.5rem !default;
+$carousel-control-icon-active-bg:    $component-active-bg !default;
+$carousel-control-icon-bg:           $chevron-icon !default;
+$carousel-control-icon-disabled-bg:  $chevron-icon-disabled !default;
+$carousel-control-icon-filter:       $invert-filter !default;
+// End mod
 
 $carousel-transition-duration:       .6s !default;
 $carousel-transition:                transform $carousel-transition-duration $transition-timing !default; // Define transform transition first if using multiple transitions (e.g., `transform 2s ease, opacity .5s ease-out`)
 
-$carousel-dark-indicator-active-bg:  $black !default;
-$carousel-dark-caption-color:        $black !default;
-$carousel-dark-control-icon-filter:  invert(1) grayscale(100) !default;
+// Boosted mod: no dark carousel
+
 
 // Spinners
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1445,6 +1445,6 @@ $pre-line-height:                   1.25 !default; // Boosted mod
 // Boosted mod
 //
 
-//// Accordions
-//$accordion-spacer:            .875rem !default;
-//$accordion-spacer-sm:         $spacer / 2 !default;
+//// Minimum target size (44×44px)
+$target-size: 2.75rem !default;
+

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -236,15 +236,15 @@ $escaped-characters: (
 ) !default;
 
 // Boosted mod
-$chevron-icon:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'><path d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/></svg>") !default;
-$chevron-icon-hover:  url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'><path fill='#{$white}' d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/></svg>") !default;
-$cross-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' fill='#{$black}'><path d='M15 17.121l-8.132 8.132-2.121-2.12L12.879 15 4.747 6.868l2.12-2.121L15 12.879l8.132-8.132 2.12 2.121L17.122 15l8.132 8.132-2.121 2.12L15 17.123z'/></svg>") !default;
-$cross-icon-stroke:   url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' fill='#{$black}'><path stroke='#{$black}' stroke-width='5' stroke-linecap='round' d='M15 17.121l-8.132 8.132-2.121-2.12L12.879 15 4.747 6.868l2.12-2.121L15 12.879l8.132-8.132 2.12 2.121L17.122 15l8.132 8.132-2.121 2.12L15 17.123z'/></svg>") !default;
-//$chevron-icon-active: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'><path fill='#{$primary}' d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/></svg>") !default;
-$success-icon:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 125 125'><path fill='#{$success}' d='M62.5 0a62.5 62.5 0 100 125 62.5 62.5 0 000-125zm28 29.4c3.3 0 6 2.6 6 5.9a5.9 5.9 0 01-1.3 3.7L57.7 86a5.8 5.8 0 01-9.1 0L29.8 62.5c-.8-1-1.2-2.3-1.2-3.7a5.9 5.9 0 011.7-4.1l2.3-2.4a5.8 5.8 0 014.2-1.7 5.8 5.8 0 013.8 1.4L52 64.7 86.6 31a5.8 5.8 0 014-1.6z'/></svg>") !default;
-$info-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 125 125'><path fill='#{$info}' d='M62.5 0a62.5 62.5 0 100 125 62.5 62.5 0 000-125zm0 14.7a11 11 0 110 22 11 11 0 010-22zM47.8 44.1h25.7v46.2c0 4.7 1.3 6.5 1.8 7.2.8 1 2.3 1.5 4.8 1.6h.8v3.8H47.8v-3.7h.8c2.3-.1 4-.8 5-2 .4-.4 1-2 1-7V57c0-4.8-.6-6.6-1.2-7.3-.8-1-2.4-1.5-4.9-1.6h-.7V44z'/></svg>") !default;
-$warning-icon:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path fill='#{$warning}' d='M15 0a15 15 0 100 30 15 15 0 000-30zm.15 5.39h.01c1.12 0 2 .95 1.92 2.06l-.63 10.43c0 .7-.58.97-1.29.97-.72 0-1.28-.27-1.28-.97l-.63-10.46c-.06-1.09.8-2.01 1.9-2.03zm-.3 15.33c.11 0 .21 0 .31.02 2.19.35 2.19 3.5 0 3.84-2.77.44-3.1-3.86-.3-3.86z'/></svg>") !default;
-$danger-icon:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 140 125'><path fill='#{$danger}' d='M70.3 0c-5.8 0-10.8 3.1-13.5 7.8L2.3 101.3l-.2.2A15.6 15.6 0 0015.6 125H125a15.6 15.6 0 0013.5-23.5L83.8 7.8A15.6 15.6 0 0070.3 0zm19.2 50a6.4 6.4 0 014.4 1.9 6.4 6.4 0 010 9L79.4 75.6l15 15a6.4 6.4 0 010 9.2 6.4 6.4 0 01-4.5 1.9 6.4 6.4 0 01-4.6-2l-15-15-15 15a6.4 6.4 0 01-4.6 2 6.4 6.4 0 01-4.6-2 6.4 6.4 0 010-9l15-15L46.8 61a6.4 6.4 0 119-9.1l14.6 14.5L84.8 52a6.4 6.4 0 014.7-1.9z'/></svg>") !default;
+$chevron-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'><path d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/></svg>") !default;
+$chevron-icon-disabled: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'><path fill='#{$light}' d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/></svg>") !default;
+$cross-icon:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' fill='#{$black}'><path d='M15 17.121l-8.132 8.132-2.121-2.12L12.879 15 4.747 6.868l2.12-2.121L15 12.879l8.132-8.132 2.12 2.121L17.122 15l8.132 8.132-2.121 2.12L15 17.123z'/></svg>") !default;
+$cross-icon-stroke:     url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' fill='#{$black}'><path stroke='#{$black}' stroke-width='5' stroke-linecap='round' d='M15 17.121l-8.132 8.132-2.121-2.12L12.879 15 4.747 6.868l2.12-2.121L15 12.879l8.132-8.132 2.12 2.121L17.122 15l8.132 8.132-2.121 2.12L15 17.123z'/></svg>") !default;
+$success-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 125 125'><path fill='#{$success}' d='M62.5 0a62.5 62.5 0 100 125 62.5 62.5 0 000-125zm28 29.4c3.3 0 6 2.6 6 5.9a5.9 5.9 0 01-1.3 3.7L57.7 86a5.8 5.8 0 01-9.1 0L29.8 62.5c-.8-1-1.2-2.3-1.2-3.7a5.9 5.9 0 011.7-4.1l2.3-2.4a5.8 5.8 0 014.2-1.7 5.8 5.8 0 013.8 1.4L52 64.7 86.6 31a5.8 5.8 0 014-1.6z'/></svg>") !default;
+$info-icon:             url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 125 125'><path fill='#{$info}' d='M62.5 0a62.5 62.5 0 100 125 62.5 62.5 0 000-125zm0 14.7a11 11 0 110 22 11 11 0 010-22zM47.8 44.1h25.7v46.2c0 4.7 1.3 6.5 1.8 7.2.8 1 2.3 1.5 4.8 1.6h.8v3.8H47.8v-3.7h.8c2.3-.1 4-.8 5-2 .4-.4 1-2 1-7V57c0-4.8-.6-6.6-1.2-7.3-.8-1-2.4-1.5-4.9-1.6h-.7V44z'/></svg>") !default;
+$warning-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path fill='#{$warning}' d='M15 0a15 15 0 100 30 15 15 0 000-30zm.15 5.39h.01c1.12 0 2 .95 1.92 2.06l-.63 10.43c0 .7-.58.97-1.29.97-.72 0-1.28-.27-1.28-.97l-.63-10.46c-.06-1.09.8-2.01 1.9-2.03zm-.3 15.33c.11 0 .21 0 .31.02 2.19.35 2.19 3.5 0 3.84-2.77.44-3.1-3.86-.3-3.86z'/></svg>") !default;
+$danger-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 140 125'><path fill='#{$danger}' d='M70.3 0c-5.8 0-10.8 3.1-13.5 7.8L2.3 101.3l-.2.2A15.6 15.6 0 0015.6 125H125a15.6 15.6 0 0013.5-23.5L83.8 7.8A15.6 15.6 0 0070.3 0zm19.2 50a6.4 6.4 0 014.4 1.9 6.4 6.4 0 010 9L79.4 75.6l15 15a6.4 6.4 0 010 9.2 6.4 6.4 0 01-4.5 1.9 6.4 6.4 0 01-4.6-2l-15-15-15 15a6.4 6.4 0 01-4.6 2 6.4 6.4 0 01-4.6-2 6.4 6.4 0 010-9l15-15L46.8 61a6.4 6.4 0 119-9.1l14.6 14.5L84.8 52a6.4 6.4 0 014.7-1.9z'/></svg>") !default;
+$invert-filter:         invert(1) !default;
 // End mod
 
 // Options
@@ -1059,7 +1059,7 @@ $pagination-disabled-color:         $gray-500 !default;
 $pagination-disabled-bg:            $white !default;
 $pagination-disabled-border-color:  $pagination-disabled-color !default;
 
-$pagination-transition:             color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
+$pagination-transition:             color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, filter .15s ease-in-out !default;
 
 // Boosted mod
 $pagination-padding-end:            1.125rem !default;
@@ -1067,7 +1067,6 @@ $pagination-item-size:              $spacer * 2 !default;
 $pagination-active-item-bg:         $primary !default;
 $pagination-active-item-border:     $pagination-active-item-bg !default;
 $pagination-icon:                   $chevron-icon !default;
-$pagination-icon-hover:             $chevron-icon-hover !default;
 $pagination-icon-margin:            .1875rem !default;
 $pagination-icon-width:             add(.5rem, 1px) !default;
 $pagination-icon-height:            subtract(1rem, 1px) !default;
@@ -1424,7 +1423,7 @@ $btn-close-bg:               $cross-icon !default;
 $btn-close-bg-stroke:        $cross-icon-stroke !default;
 $btn-close-focus-shadow:     null !default;
 $btn-close-disabled-opacity: .5 !default;
-$btn-close-white-filter:     invert(1) grayscale(100%) brightness(200%) !default;
+$btn-close-white-filter:     $invert-filter !default;
 
 // Boosted mod
 $btn-close-size:             $h2-font-size !default;

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -145,7 +145,7 @@
 
 .form-switch {
   // Boosted mod
-  --o-switch-gradient: #{linear-gradient(to right, $white $form-switch-bg-square-size, transparent)};
+  --#{$boosted-variable-prefix}switch-gradient: #{linear-gradient(to right, $white $form-switch-bg-square-size, transparent)};
   min-height: $form-switch-width / 2;
   padding-left: $form-switch-padding-start;
 
@@ -154,7 +154,7 @@
     height: $form-switch-width / 2;
     margin-left: $form-switch-padding-start * -1;
     background-color: $black;
-    background-image: escape-svg($form-switch-bg-image), var(--o-switch-gradient);
+    background-image: escape-svg($form-switch-bg-image), var(--#{$boosted-variable-prefix}switch-gradient);
     background-position: $form-switch-bg-position, 0 0;
     background-size: $form-switch-bg-size, $form-switch-bg-square-size; // Get a 1px separation
     border-color: $black;
@@ -167,11 +167,11 @@
       border-color: $primary;
 
       @if $enable-gradients {
-        background-image: escape-svg($form-switch-checked-bg-image), var(--#{$variable-prefix}gradient), var(--o-switch-gradient);
+        background-image: escape-svg($form-switch-checked-bg-image), var(--#{$variable-prefix}gradient), var(--#{$boosted-variable-prefix}switch-gradient);
         background-position: $form-switch-checked-bg-position, 100%, 100% 0;
         background-size: $form-switch-checked-bg-size, auto, $form-switch-bg-square-size;
       } @else {
-        background-image: escape-svg($form-switch-checked-bg-image), var(--o-switch-gradient);
+        background-image: escape-svg($form-switch-checked-bg-image), var(--#{$boosted-variable-prefix}switch-gradient);
         background-position: $form-switch-checked-bg-position, 100% 0;
         background-size: $form-switch-checked-bg-size, $form-switch-bg-square-size;
       }
@@ -198,9 +198,9 @@
       // Boosted mod
       &:checked {
         @if $enable-gradients {
-          background-image: escape-svg($form-switch-disabled-bg-image), var(--#{$variable-prefix}gradient), var(--o-switch-gradient);
+          background-image: escape-svg($form-switch-disabled-bg-image), var(--#{$variable-prefix}gradient), var(--#{$boosted-variable-prefix}switch-gradient);
         } @else {
-          background-image: escape-svg($form-switch-disabled-bg-image), var(--o-switch-gradient);
+          background-image: escape-svg($form-switch-disabled-bg-image), var(--#{$boosted-variable-prefix}switch-gradient);
         }
       }
       // End mod

--- a/scss/mixins/_target-size.scss
+++ b/scss/mixins/_target-size.scss
@@ -1,0 +1,23 @@
+// Minimum target size should be 44×44 CSS pixels
+//
+// See https://www.w3.org/WAI/WCAG21/Understanding/target-size.html
+// See https://w3c.github.io/wcag/understanding/pointer-target-spacing.html
+// See https://checklists.opquast.com/en/qualiteweb/the-size-of-the-clickable-elements-is-sufficient
+
+// scss-docs-start target-size
+@mixin target-size($size: $target-size, $pseudo-element: before, $position: relative, $width: $size, $height: $size) {
+  position: $position;
+
+  &::#{$pseudo-element} {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: $width;
+    min-width: 100%;
+    height: $height;
+    min-height: 100%;
+    content: "";
+    transform: translate3d(-50%, -50%, 0);
+  }
+}
+// scss-docs-end target-size

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -113,12 +113,6 @@
     margin-bottom: 0;
   }
 
-  // Boosted mod
-  > .carousel:last-child {
-    margin-bottom: $carousel-margin-bottom;
-  }
-  // End mod
-
   // Images
   > svg + svg,
   > img + img {

--- a/site/content/docs/5.0/components/carousel.md
+++ b/site/content/docs/5.0/components/carousel.md
@@ -52,7 +52,19 @@ Carousels don't automatically normalize slide dimensions. As such, you may need 
 
 ### With indicators
 
-You can also add the indicators to the carousel, alongside the controls, too.
+You can also add the indicators to the carousel.
+
+<!-- Boosted mod -->
+
+Indicators are animated to show the active slide progress, based on its interval. It adapts to [any interval you set](#individual-carousel-item-interval) thanks to the `--o-carousel-interval` CSS custom property.
+Carousel progress indicator is paused under multiple conditions:
+
+* when the `prefers-reduced-motion` media query equals `reduce` [to improve accessibility]({{< docsref "/getting-started/accessibility#reduced-motion" >}}).
+* when the carousel is paused—on hover by default, but can be changed using [the `data-bs-pause` attribute](#options): a `.paused` class is added to the carousel.
+* when the carousel [doesn't cycle](#prevent-cycling) and is stopped at one end: a `.done` class is added to the carousel.
+* when the carousel is [static](#static-carousel), ie. when it has `.static` class.
+
+<!-- End mod -->
 
 {{< example >}}
 <div id="carouselExampleIndicators" class="carousel slide" data-bs-ride="carousel">
@@ -227,16 +239,15 @@ Use `data-bs-wrap="false"` to prevent carousel from cycling continuously.
 <!-- End mod -->
 
 <!-- Boosted mod: needed to check carousel indicators without autoplay -->
-### Static carousel (no autoplay)
+### Static carousel
 
 To prevent the carousel from autoplaying, use the following attributes combo:
 1. do not use `data-bs-ride="carousel"` attribute, to prevent instant initialization,
-2. add `data-bs-slide="false"` to prevent autoplaying after the first user interaction,
-2. add `data-bs-pause="hover focus"` to prevent autoplaying when carousel contains focus,
+2. add `data-bs-interval="false"` to prevent autoplaying by removing any timing related feature,
 3. add `.static` class to your carousel, to cancel progress indicators animation.
 
 {{< example >}}
-<div id="carouselExampleNoRide" class="carousel slide static" data-bs-slide="false" data-bs-pause="hover focus">
+<div id="carouselExampleNoRide" class="carousel slide static" data-bs-interval="false">
   <ol class="carousel-indicators">
     <li data-bs-target="#carouselExampleNoRide" data-bs-slide-to="0" class="active"></li>
     <li data-bs-target="#carouselExampleNoRide" data-bs-slide-to="1"></li>

--- a/site/content/docs/5.0/components/carousel.md
+++ b/site/content/docs/5.0/components/carousel.md
@@ -162,11 +162,18 @@ Add `data-bs-interval=""` to a `.carousel-item` to change the amount of time to 
 
 {{< example >}}
 <div id="carouselExampleInterval" class="carousel slide" data-bs-ride="carousel">
+  <!-- Boosted mod -->
+  <ol class="carousel-indicators">
+    <li data-bs-target="#carouselExampleInterval" data-bs-slide-to="0" class="active"></li>
+    <li data-bs-target="#carouselExampleInterval" data-bs-slide-to="1"></li>
+    <li data-bs-target="#carouselExampleInterval" data-bs-slide-to="2"></li>
+  </ol>
+  <!-- End mod -->
   <div class="carousel-inner">
-    <div class="carousel-item active">
+    <div class="carousel-item active" data-bs-interval="10000">
       {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#000" background="#4bb4e6" text="First slide" >}}
     </div>
-    <div class="carousel-item">
+    <div class="carousel-item" data-bs-interval="2000">
       {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#000" background="#50be87" text="Second slide" >}}
     </div>
     <div class="carousel-item">
@@ -184,50 +191,81 @@ Add `data-bs-interval=""` to a `.carousel-item` to change the amount of time to 
 </div>
 {{< /example >}}
 
-## Dark variant
+<!-- Boosted mod: needed to check carousel indicator's progress when no cycle -->
+### Prevent cycling
 
-Add `.carousel-dark` to the `.carousel` for darker controls, indicators, and captions. Controls have been inverted from their default white fill with the `filter` CSS property. Captions and controls have additional Sass variables that customize the `color` and `background-color`.
+Use `data-bs-wrap="false"` to prevent carousel from cycling continuously.
 
 {{< example >}}
-<div id="carouselExampleDark" class="carousel carousel-dark slide" data-bs-ride="carousel">
+<div id="carouselExampleNoWrap" class="carousel slide" data-bs-wrap="false" data-bs-ride="carousel">
   <ol class="carousel-indicators">
-    <li data-bs-target="#carouselExampleDark" data-bs-slide-to="0" class="active"></li>
-    <li data-bs-target="#carouselExampleDark" data-bs-slide-to="1"></li>
-    <li data-bs-target="#carouselExampleDark" data-bs-slide-to="2"></li>
+    <li data-bs-target="#carouselExampleNoWrap" data-bs-slide-to="0" class="active"></li>
+    <li data-bs-target="#carouselExampleNoWrap" data-bs-slide-to="1"></li>
+    <li data-bs-target="#carouselExampleNoWrap" data-bs-slide-to="2"></li>
   </ol>
   <div class="carousel-inner">
-    <div class="carousel-item active" data-bs-interval="10000">
-      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#aaa" background="#f5f5f5" text="First slide" >}}
-      <div class="carousel-caption d-none d-md-block">
-        <h5>First slide label</h5>
-        <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
-      </div>
-    </div>
-    <div class="carousel-item" data-bs-interval="2000">
-      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#bbb" background="#eee" text="Second slide" >}}
-      <div class="carousel-caption d-none d-md-block">
-        <h5>Second slide label</h5>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-      </div>
+    <div class="carousel-item active">
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#000" background="#4bb4e6" text="First slide" >}}
     </div>
     <div class="carousel-item">
-      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#999" background="#e5e5e5" text="Third slide" >}}
-      <div class="carousel-caption d-none d-md-block">
-        <h5>Third slide label</h5>
-        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur.</p>
-      </div>
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#000" background="#50be87" text="Second slide" >}}
+    </div>
+    <div class="carousel-item">
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#000" background="#a885d8" text="Third slide" >}}
     </div>
   </div>
-  <a class="carousel-control-prev" href="#carouselExampleDark" role="button" data-bs-slide="prev">
+  <a class="carousel-control-prev" href="#carouselExampleNoWrap" role="button" data-bs-slide="prev">
     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
     <span class="visually-hidden">Previous</span>
   </a>
-  <a class="carousel-control-next" href="#carouselExampleDark" role="button" data-bs-slide="next">
+  <a class="carousel-control-next" href="#carouselExampleNoWrap" role="button" data-bs-slide="next">
     <span class="carousel-control-next-icon" aria-hidden="true"></span>
     <span class="visually-hidden">Next</span>
   </a>
 </div>
 {{< /example >}}
+<!-- End mod -->
+
+<!-- Boosted mod: needed to check carousel indicators without autoplay -->
+### Static carousel (no autoplay)
+
+To prevent the carousel from autoplaying, use the following attributes combo:
+1. do not use `data-bs-ride="carousel"` attribute, to prevent instant initialization,
+2. add `data-bs-slide="false"` to prevent autoplaying after the first user interaction,
+2. add `data-bs-pause="hover focus"` to prevent autoplaying when carousel contains focus,
+3. add `.static` class to your carousel, to cancel progress indicators animation.
+
+{{< example >}}
+<div id="carouselExampleNoRide" class="carousel slide static" data-bs-slide="false" data-bs-pause="hover focus">
+  <ol class="carousel-indicators">
+    <li data-bs-target="#carouselExampleNoRide" data-bs-slide-to="0" class="active"></li>
+    <li data-bs-target="#carouselExampleNoRide" data-bs-slide-to="1"></li>
+    <li data-bs-target="#carouselExampleNoRide" data-bs-slide-to="2"></li>
+  </ol>
+  <div class="carousel-inner">
+    <div class="carousel-item active">
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#000" background="#4bb4e6" text="First slide" >}}
+    </div>
+    <div class="carousel-item">
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#000" background="#50be87" text="Second slide" >}}
+    </div>
+    <div class="carousel-item">
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#000" background="#a885d8" text="Third slide" >}}
+    </div>
+  </div>
+  <a class="carousel-control-prev" href="#carouselExampleNoRide" role="button" data-bs-slide="prev">
+    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+    <span class="visually-hidden">Previous</span>
+  </a>
+  <a class="carousel-control-next" href="#carouselExampleNoRide" role="button" data-bs-slide="next">
+    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+    <span class="visually-hidden">Next</span>
+  </a>
+</div>
+{{< /example >}}
+<!-- End mod -->
+
+<!-- Boosted mod: no dark variant -->
 
 ## Usage
 

--- a/site/content/docs/5.0/getting-started/accessibility.md
+++ b/site/content/docs/5.0/getting-started/accessibility.md
@@ -57,6 +57,13 @@ On browsers that support `prefers-reduced-motion`, and where the user has *not* 
 
 Boosted includes [WICG's `:focus-visible` polyfill](https://github.com/WICG/focus-visible) to ensure an enhanced focus visibility for keyboard users while shutting down focus styles on active state.
 
+### Minimum target size
+
+Boosted provides `target-size()` mixin to ensure a minimum target size, adding a centered pseudo-element with a minimum size —defaulting to `44px` to pass [WCAG 2.1 "Target Size" Success Criterion (2.5.5)](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html)— alongside a few arguments to fit specific needs (eg. different width and height, using `::after` instead of `::before`, etc.).
+
+{{< scss-docs name="target-size" file="scss/mixins/_target-size.scss" >}}
+
+
 ## Additional resources
 
 - [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/WCAG21/)

--- a/site/content/docs/5.0/guidelines/navigation.md
+++ b/site/content/docs/5.0/guidelines/navigation.md
@@ -82,6 +82,55 @@ toc: true
   </ul>
 </nav>
 
+## Pagination dots
+
+[Documentation]({{< docsref "/components/carousel#with-indicators" >}})&nbsp;—&nbsp;{{< anchor web-nav-pdt-001 >}}
+
+<div id="carouselExampleIndicators" class="carousel slide" data-bs-ride="carousel">
+  <ol class="carousel-indicators">
+    <li data-bs-target="#carouselExampleIndicators" data-bs-slide-to="0" class="active"></li>
+    <li data-bs-target="#carouselExampleIndicators" data-bs-slide-to="1"></li>
+    <li data-bs-target="#carouselExampleIndicators" data-bs-slide-to="2"></li>
+  </ol>
+  <div class="carousel-inner">
+    <div class="carousel-item active">
+      {{< placeholder width="800" height="60" class="bd-placeholder-img-lg d-block w-100" background="#000" text=" " >}}
+    </div>
+    <div class="carousel-item">
+      {{< placeholder width="800" height="60" class="bd-placeholder-img-lg d-block w-100" background="#eee" text=" " >}}
+    </div>
+    <div class="carousel-item">
+      {{< placeholder width="800" height="60" class="bd-placeholder-img-lg d-block w-100" background="#666" text=" " >}}
+    </div>
+  </div>
+</div>
+
+## Carousel navigation
+
+[Documentation]({{< docsref "/components/carousel" >}})&nbsp;—&nbsp;{{< anchor web-nav-cna-001 >}}
+
+<div id="carouselExampleControls" class="carousel slide" data-bs-wrap="false">
+  <div class="carousel-inner">
+    <div class="carousel-item active">
+      {{< placeholder width="800" height="200" class="bd-placeholder-img-lg d-block w-100" color="#fff" background="#000" text="First slide" >}}
+    </div>
+    <div class="carousel-item">
+      {{< placeholder width="800" height="200" class="bd-placeholder-img-lg d-block w-100" color="#000" background="#eee" text="Second slide" >}}
+    </div>
+    <div class="carousel-item">
+      {{< placeholder width="800" height="200" class="bd-placeholder-img-lg d-block w-100" color="#000" background="#ccc" text="Third slide" >}}
+    </div>
+  </div>
+  <a class="carousel-control-prev" href="#carouselExampleControls" role="button" data-bs-slide="prev">
+    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+    <span class="visually-hidden">Previous</span>
+  </a>
+  <a class="carousel-control-next" href="#carouselExampleControls" role="button" data-bs-slide="next">
+    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+    <span class="visually-hidden">Next</span>
+  </a>
+</div>
+
 ## Accordion
 
 [Documentation]({{< docsref "/components/accordion" >}})
@@ -89,43 +138,43 @@ toc: true
   <div class="col">
     <h3 class="h6">Small — {{< anchor web-nav-acc-001 >}}</h3>
     <div class="accordion accordion-sm" id="accordionExampleSmall">
-          <div class="accordion-item">
-            <h2 class="accordion-header" id="headingOneSmall">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOneSmall" aria-expanded="false" aria-controls="collapseOneSmall">
-                Title
-              </button>
-            </h2>
-            <div id="collapseOneSmall" class="accordion-collapse collapse" aria-labelledby="headingOneSmall" data-bs-parent="#accordionExampleSmall">
-              <div class="accordion-body">
-                <strong>This is the first item's accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
-              </div>
-            </div>
-          </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header" id="headingTwoSmall">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwoSmall" aria-expanded="false" aria-controls="collapseTwoSmall">
-                Title
-              </button>
-            </h2>
-            <div id="collapseTwoSmall" class="accordion-collapse collapse" aria-labelledby="headingTwoSmall" data-bs-parent="#accordionExampleSmall">
-              <div class="accordion-body">
-                <strong>This is the second item's accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
-              </div>
-            </div>
-          </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header" id="headingThreeSmall">
-              <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThreeSmall" aria-expanded="true" aria-controls="collapseThreeSmall">
-                Title
-              </button>
-            </h2>
-            <div id="collapseThreeSmall" class="accordion-collapse collapse show" aria-labelledby="headingThreeSmall" data-bs-parent="#accordionExampleSmall">
-              <div class="accordion-body">
-                <strong>This is the third item's accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
-              </div>
-            </div>
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingOneSmall">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOneSmall" aria-expanded="false" aria-controls="collapseOneSmall">
+            Title
+          </button>
+        </h2>
+        <div id="collapseOneSmall" class="accordion-collapse collapse" aria-labelledby="headingOneSmall" data-bs-parent="#accordionExampleSmall">
+          <div class="accordion-body">
+            <strong>This is the first item's accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
           </div>
         </div>
+      </div>
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingTwoSmall">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwoSmall" aria-expanded="false" aria-controls="collapseTwoSmall">
+            Title
+          </button>
+        </h2>
+        <div id="collapseTwoSmall" class="accordion-collapse collapse" aria-labelledby="headingTwoSmall" data-bs-parent="#accordionExampleSmall">
+          <div class="accordion-body">
+            <strong>This is the second item's accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
+          </div>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingThreeSmall">
+          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThreeSmall" aria-expanded="true" aria-controls="collapseThreeSmall">
+            Title
+          </button>
+        </h2>
+        <div id="collapseThreeSmall" class="accordion-collapse collapse show" aria-labelledby="headingThreeSmall" data-bs-parent="#accordionExampleSmall">
+          <div class="accordion-body">
+            <strong>This is the third item's accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <div class="col">
     <h3 class="h6">Medium — {{< anchor web-nav-acc-002 >}}</h3>


### PR DESCRIPTION
Closes #550, closes #551 

## To-do

- [x] Check if we can set an animation for "in progress" state, probably using an inline custom property for both `animation-duration` and `animation-play-state` (on `:hover`).
  - [x] use a prefix for `--carousel-interval`, and probably extend this to all boosted-only custom props — using a variable prefix?
- [x] Carousel controls
- [x] Disable prev/next controls when not going to wrap
- [x] ~~Get things done by adding pause button?~~ (#366)
- [x] Dark variant → **dropped**
- [x] JS tests **(!)**
  - `.paused` should be added on `mouseenter`, removed on `mouseleave`
  - `.done` should be added when last slide and `data-bs-wrap="false"`
  - `--o-carousel-interval` should be set on indicator when `data-bs-interval` is provided
- [x] What should be documented?
  - [x] Pagination dots added in Design Guidelines, at least
  - [x] Document the behaviour using custom property (with custom prefix?) and new `.paused` / `.done` classes?
  - [x] New `target-size()` mixin Somewhere?
  - [x] All of those in the migration guide issue (#383)
- [x] ~~Should the animated progress indicator be a variant?~~
- [x] Test in RTL **(!)** → JS seems good, CSS animation is wrong so far
- [x] Add more JS tests **(!)**
- [x] static carousel uses `data-bs-interval="false"`? [Bootstrap #32640 comment](https://github.com/twbs/bootstrap/issues/32640#issuecomment-751880429)
- [x] improve `target-size()`: 
   - dissociate width and height
   - use `44px` equivalent as default size
   - set minimum width and height matching parent's, or try `min-content` and other keywords?
- [x] cross-browser testing

---
Preview: https://deploy-preview-573--boosted.netlify.app/docs/5.0/components/carousel/ ("with indicators", "Individual .carousel-item interval", "Prevent cycling", "Static carousel")