### PR TITLE
Back-to-top

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -13,4 +13,3 @@ iOS >= 10
 Safari >= 10
 Android >= 6
 not Explorer <= 11
-Firefox ESR

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "23.7 kB"
+      "maxSize": "24 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",
-      "maxSize": "21.7 kB"
+      "maxSize": "21.9 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "24 kB"
+      "maxSize": "23.9 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",
-      "maxSize": "21.9 kB"
+      "maxSize": "21.7 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.js",

--- a/scss/_back-to-top.scss
+++ b/scss/_back-to-top.scss
@@ -1,0 +1,73 @@
+// Boosted only
+// See https://moderncss.dev/pure-css-smooth-scroll-back-to-top/
+[id="#{$back-to-top-target-id}"]:target {
+  scroll-margin-top: $back-to-top-target-offset-top;
+}
+
+.back-to-top {
+  position: absolute;
+  top: $back-to-top-display-threshold;
+  right: $back-to-top-offset-right;
+  bottom: $back-to-top-offset-bottom;
+  z-index: $zindex-back-to-top;
+  pointer-events: none;
+
+  @include media-breakpoint-up(xl) {
+    right: $back-to-top-offset-right * 2;
+    bottom: $back-to-top-offset-bottom * 2;
+  }
+}
+
+.back-to-top-link {
+  position: sticky;
+  top: $back-to-top-link-offset-top;
+  // @TODO Could be dropped when .btn-icon come in
+  min-width: $back-to-top-width;
+  min-height: $back-to-top-height;
+  padding: 0;
+  // End @TODO
+  pointer-events: all;
+
+  @include media-breakpoint-up(xl) {
+    top: $back-to-top-link-offset-top-xl;
+
+    &[data-#{$boosted-variable-prefix}label]::before {
+      position: absolute;
+      right: $back-to-top-title-offset-right;
+      padding: $back-to-top-title-padding;
+      color: color-contrast($back-to-top-title-bg-color);
+      white-space: nowrap;
+      content: attr(data-#{$boosted-variable-prefix}label);
+      background-color: $back-to-top-title-bg-color;
+    }
+
+    &[data-#{$boosted-variable-prefix}label]:hover::before,
+    &[data-#{$boosted-variable-prefix}label]:focus::before {
+      text-decoration: $link-decoration;
+    }
+  }
+
+  /* &:not([title]) :only-child {
+    margin-right: $spacer / -2;
+  } */
+
+  // @TODO Could be dropped when .btn-icon come in
+  &::after {
+    display: inline-block;
+    width: $back-to-top-icon-width;
+    height: $back-to-top-icon-height;
+    content: "";
+    background: $back-to-top-icon-bg;
+    transform: rotate(.25turn);
+  }
+
+  &:hover:not(:active)::after,
+  &:focus:not(:active)::after {
+    filter: $back-to-top-icon-hover-filter;
+  }
+
+  &:not([title]):not([data-#{$boosted-variable-prefix}label])::after {
+    margin-left: $spacer / 2;
+  }
+  // End @TODO
+}

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -127,7 +127,7 @@
   display: inline-block;
   width: $carousel-control-icon-width;
   height: $carousel-control-icon-width;
-  background: rgba($carousel-indicator-active-bg, .5) escape-svg($carousel-control-icon-bg) no-repeat subtract(50%, $spacer / 10) 50% / #{$carousel-control-icon-size $carousel-control-icon-size}; // Boosted mod
+  background: rgba($carousel-indicator-active-bg, .5) $carousel-control-icon-bg no-repeat subtract(50%, $spacer / 10) 50% / #{$carousel-control-icon-size $carousel-control-icon-size}; // Boosted mod
   @include border-radius(50%, 50%);
 }
 

--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -10,7 +10,7 @@
   padding: $btn-close-padding-y $btn-close-padding-x;
   font-size: $btn-close-size; // Boosted mod
   color: $btn-close-color;
-  background: transparent escape-svg($btn-close-bg) center / $btn-close-width auto no-repeat; // include transparent for button elements
+  background: transparent $btn-close-bg center / $btn-close-width auto no-repeat; // include transparent for button elements // Boosted mod
   border: 0; // for button elements
   outline-offset: map-get($spacers, 2);
   @include border-radius();

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -346,7 +346,7 @@
 
     // Boosted mod: close icon when opened
     &[aria-expanded="true"] .navbar-toggler-icon {
-      background-image: escape-svg($navbar-light-toggler-icon-close-bg);
+      background-image: $navbar-light-toggler-icon-close-bg;
     }
     // End mod
   }

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -46,6 +46,7 @@
 //    See https://developer.mozilla.org/fr/docs/Web/CSS/font-synthesis
 
 body {
+  position: relative; // Boosted mod: required for back-to-top component
   margin: 0; // 1
   font-family: $font-family-base;
   font-synthesis: none; // Boosted mod // 5

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -8,6 +8,12 @@
     --#{$variable-prefix}#{$color}: #{$value};
   }
 
+  // Boosted mod
+  @each $icon, $svg in $svg-as-custom-props {
+    --#{$boosted-variable-prefix}#{$icon}-icon: #{escape-svg($svg)};
+  }
+  // End mod
+
   // Use `inspect` for lists so that quoted items keep the quotes.
   // See https://github.com/sass/sass/issues/2383#issuecomment-336349172
   --#{$variable-prefix}font-sans-serif: #{inspect($font-family-sans-serif)};

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -253,7 +253,7 @@ h2,
     margin-left: $linked-chevron-margin-left;
     vertical-align: middle;
     content: "";
-    background-image: escape-svg($chevron-icon);
+    background-image: var(--#{$boosted-variable-prefix}chevron-icon);
     background-repeat: no-repeat;
     transform: $linked-chevron-transform;
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -236,7 +236,7 @@ $escaped-characters: (
 ) !default;
 
 // Boosted mod
-// For colored filters, see https://codepen.io/sosuke/pen/Pjoqqp
+//// SVG as Data-URi
 $chevron-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'><path d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/></svg>") !default;
 $chevron-icon-disabled: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'><path fill='#{$gray-700}' d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/></svg>") !default;
 $cross-icon:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30' fill='#{$black}'><path d='M15 17.121l-8.132 8.132-2.121-2.12L12.879 15 4.747 6.868l2.12-2.121L15 12.879l8.132-8.132 2.12 2.121L17.122 15l8.132 8.132-2.121 2.12L15 17.123z'/></svg>") !default;
@@ -245,6 +245,15 @@ $success-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
 $info-icon:             url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 125 125'><path fill='#{$info}' d='M62.5 0a62.5 62.5 0 100 125 62.5 62.5 0 000-125zm0 14.7a11 11 0 110 22 11 11 0 010-22zM47.8 44.1h25.7v46.2c0 4.7 1.3 6.5 1.8 7.2.8 1 2.3 1.5 4.8 1.6h.8v3.8H47.8v-3.7h.8c2.3-.1 4-.8 5-2 .4-.4 1-2 1-7V57c0-4.8-.6-6.6-1.2-7.3-.8-1-2.4-1.5-4.9-1.6h-.7V44z'/></svg>") !default;
 $warning-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path fill='#{$warning}' d='M15 0a15 15 0 100 30 15 15 0 000-30zm.15 5.39h.01c1.12 0 2 .95 1.92 2.06l-.63 10.43c0 .7-.58.97-1.29.97-.72 0-1.28-.27-1.28-.97l-.63-10.46c-.06-1.09.8-2.01 1.9-2.03zm-.3 15.33c.11 0 .21 0 .31.02 2.19.35 2.19 3.5 0 3.84-2.77.44-3.1-3.86-.3-3.86z'/></svg>") !default;
 $danger-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 140 125'><path fill='#{$danger}' d='M70.3 0c-5.8 0-10.8 3.1-13.5 7.8L2.3 101.3l-.2.2A15.6 15.6 0 0015.6 125H125a15.6 15.6 0 0013.5-23.5L83.8 7.8A15.6 15.6 0 0070.3 0zm19.2 50a6.4 6.4 0 014.4 1.9 6.4 6.4 0 010 9L79.4 75.6l15 15a6.4 6.4 0 010 9.2 6.4 6.4 0 01-4.5 1.9 6.4 6.4 0 01-4.6-2l-15-15-15 15a6.4 6.4 0 01-4.6 2 6.4 6.4 0 01-4.6-2 6.4 6.4 0 010-9l15-15L46.8 61a6.4 6.4 0 119-9.1l14.6 14.5L84.8 52a6.4 6.4 0 014.7-1.9z'/></svg>") !default;
+//// SVG used several times
+$svg-as-custom-props: (
+  "chevron": $chevron-icon,
+  "close": $cross-icon,
+  "success": $success-icon,
+  "error": $danger-icon
+) !default;
+//// Filters
+// see https://codepen.io/sosuke/pen/Pjoqqp
 $invert-filter:         invert(1) !default;
 $orange-filter:         invert(46%) sepia(60%) saturate(2878%) hue-rotate(6deg) brightness(98%) contrast(104%) !default;
 // End mod
@@ -878,8 +887,8 @@ $form-feedback-font-style:          null !default;
 $form-feedback-valid-color:         $success !default;
 $form-feedback-invalid-color:       $danger !default;
 
-$form-feedback-icon-valid:          $success-icon !default;
-$form-feedback-icon-invalid:        $danger-icon !default;
+$form-feedback-icon-valid:          var(--#{$boosted-variable-prefix}success-icon) !default;
+$form-feedback-icon-invalid:        var(--#{$boosted-variable-prefix}error-icon) !default;
 $form-feedback-icon-size:           add($spacer / 4, $spacer / 2) !default; // Boosted mod
 
 // scss-docs-start form-validation-states
@@ -983,7 +992,7 @@ $navbar-light-hover-color:           $accessible-orange !default;
 $navbar-light-active-color:          $accessible-orange !default;
 $navbar-light-disabled-color:        $gray-500 !default;
 $navbar-light-toggler-icon-bg:       url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='#{$black}' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>") !default;
-$navbar-light-toggler-icon-close-bg: $cross-icon !default; // Boosted mod
+$navbar-light-toggler-icon-close-bg: var(--#{$boosted-variable-prefix}close-icon) !default; // Boosted mod
 $navbar-light-toggler-border-color:  null !default;
 
 $navbar-light-brand-color:          $navbar-light-active-color !default;
@@ -1080,11 +1089,11 @@ $pagination-padding-end:            1.125rem !default;
 $pagination-item-size:              $spacer * 2 !default;
 $pagination-active-item-bg:         $primary !default;
 $pagination-active-item-border:     $pagination-active-item-bg !default;
-$pagination-icon:                   $chevron-icon !default;
+$pagination-icon:                   var(--#{$boosted-variable-prefix}chevron-icon) !default;
 $pagination-icon-margin:            .1875rem !default;
 $pagination-icon-width:             add(.5rem, 1px) !default;
 $pagination-icon-height:            subtract(1rem, 1px) !default;
-$pagination-icon-background:        escape-svg($pagination-icon) no-repeat 50% / #{$pagination-icon-width} $pagination-icon-height !default;
+$pagination-icon-background:        $pagination-icon no-repeat 50% / #{$pagination-icon-width} $pagination-icon-height !default;
 // End mod
 
 // Cards
@@ -1284,10 +1293,10 @@ $alert-border-width:                $border-width !default;
 $alert-padding-sm:                  $spacer / 2 !default;
 $alert-colors:                      map-remove($theme-colors, "primary", "secondary", "light", "dark") !default;
 $alert-icons: (
-  "success": escape-svg($success-icon),
+  "success": var(--#{$boosted-variable-prefix}success-icon),
   "info":    escape-svg($info-icon),
   "warning": escape-svg($warning-icon),
-  "danger":  escape-svg($danger-icon)
+  "danger":  var(--#{$boosted-variable-prefix}error-icon)
 ) !default;
 $alert-logo-size:                   add($spacer / 2, 1rem) !default;
 $alert-logo-size-sm:                add(1rem, 1px) !default;
@@ -1402,7 +1411,7 @@ $carousel-control-icon-width:        2.5rem !default;
 // Boosted mod
 $carousel-control-icon-size:         1.5rem !default;
 $carousel-control-icon-active-bg:    $component-active-bg !default;
-$carousel-control-icon-bg:           $chevron-icon !default;
+$carousel-control-icon-bg:           var(--#{$boosted-variable-prefix}chevron-icon) !default;
 $carousel-control-icon-disabled-bg:  $chevron-icon-disabled !default;
 $carousel-control-icon-filter:       $invert-filter !default;
 // End mod
@@ -1437,7 +1446,7 @@ $btn-close-height:           $btn-close-width !default;
 $btn-close-padding-x:        map-get($spacers, 1) !default;
 $btn-close-padding-y:        $btn-close-padding-x !default;
 $btn-close-color:            $black !default;
-$btn-close-bg:               $cross-icon !default;
+$btn-close-bg:               var(--#{$boosted-variable-prefix}close-icon) !default;
 $btn-close-bg-stroke:        $cross-icon-stroke !default;
 $btn-close-focus-shadow:     null !default;
 $btn-close-disabled-opacity: .5 !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -908,6 +908,7 @@ $zindex-modal-backdrop:             1040 !default;
 $zindex-modal:                      1050 !default;
 $zindex-popover:                    1060 !default;
 $zindex-tooltip:                    1070 !default;
+$zindex-back-to-top:                1080 !default; // Boosted mod
 // scss-docs-end zindex-stack
 
 // Navs
@@ -1471,3 +1472,25 @@ $pre-line-height:                   1.25 !default; // Boosted mod
 //// Minimum target size (44×44px)
 $target-size: 2.75rem !default;
 
+//// Back to top
+// scss-docs-start back-to-top
+$back-to-top-display-threshold:  100vh !default;
+$back-to-top-target-id:          "top" !default;
+$back-to-top-target-offset-top:  $spacer * 5 !default; // Matching .navbar computed height
+$back-to-top-offset:             $spacer * 1.5 !default;
+$back-to-top-offset-right:       $back-to-top-offset !default;
+$back-to-top-offset-bottom:      $back-to-top-offset !default;
+$back-to-top-link-offset-top:    subtract(100vh, $back-to-top-offset * 4) !default;
+$back-to-top-link-offset-top-xl: subtract(100vh, $spacer * 5) !default;
+$back-to-top-title-offset-right: add(100%, $border-width) !default;
+$back-to-top-title-padding:      subtract($btn-padding-y, 1px) $btn-padding-x add($btn-padding-y, 1px) !default;
+$back-to-top-title-bg-color:     $white !default;
+// scss-docs-end back-to-top
+// @TODO Could be dropped when .btn-icon come in
+$back-to-top-width:              $spacer * 2 !default;
+$back-to-top-height:             $spacer * 2 !default;
+$back-to-top-icon-width:         $pagination-icon-width !default;
+$back-to-top-icon-height:        $pagination-icon-height !default;
+$back-to-top-icon-bg:            $pagination-icon-background !default;
+$back-to-top-icon-hover-filter:  $invert-filter !default;
+// End @TODO

--- a/scss/boosted.scss
+++ b/scss/boosted.scss
@@ -49,6 +49,8 @@
 @import "carousel";
 @import "spinners";
 
+// Boosted
+@import "back-to-top";
 
 // Helpers
 @import "helpers";
@@ -56,6 +58,4 @@
 
 // Utilities
 @import "utilities/api";
-
-// Boosted
 // scss-docs-end import-stack

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -25,7 +25,7 @@
     @if $enable-validation-icons {
       .form-control {
         @include form-validation-state-selector($state) {
-          background: escape-svg($icon) no-repeat right map-get($spacers, 2) center / $spacer;
+          background: $icon no-repeat right map-get($spacers, 2) center / $spacer;
         }
       }
     }
@@ -47,7 +47,7 @@
           height: $form-feedback-icon-size;
           margin-right: map-get($spacers, 1);
           content: "";
-          background: escape-svg($form-feedback-icon-invalid) no-repeat;
+          background: $form-feedback-icon-invalid no-repeat;
         }
       }
     }

--- a/site/assets/js/tac.js
+++ b/site/assets/js/tac.js
@@ -6,12 +6,6 @@
 (function () {
   'use strict'
 
-  function dropEmoji(id) {
-    var button = document.getElementById(id)
-    var buttonText = typeof String.prototype.trimStart === 'function' ? button.textContent.trimStart() : button.textContent.trimLeft()
-    button.textContent = buttonText.slice(2)
-  }
-
   window.addEventListener('tac.root_available', function () {
     var tac = document.getElementById('tarteaucitron')
 
@@ -24,9 +18,6 @@
     })
 
     document.getElementById('tarteaucitronClosePanel').classList.add('btn-close')
-
-    dropEmoji('tarteaucitronAllAllowed')
-    dropEmoji('tarteaucitronAllDenied')
   }, { once: true })
 
   window.addEventListener('tac.open_alert', function () {
@@ -36,8 +27,6 @@
     alert.querySelector('.tarteaucitronAllow').classList.add('btn', 'btn-sm', 'btn-success', 'mx-sm-2', 'ml-lg-auto', 'my-2', 'my-lg-0')
     alert.querySelector('.tarteaucitronDeny').classList.add('btn', 'btn-sm', 'btn-danger', 'mx-sm-2', 'my-2', 'my-lg-0')
     alert.querySelector('.tarteaucitronDeny').classList.add('btn', 'btn-sm', 'btn-danger', 'mx-sm-2', 'my-2', 'my-lg-0')
-    dropEmoji('tarteaucitronPersonalize2')
-    dropEmoji('tarteaucitronAllDenied2')
   }, { once: true })
 
   window.addEventListener('tac.open_panel', function () {

--- a/site/assets/scss/_boosted.scss
+++ b/site/assets/scss/_boosted.scss
@@ -113,3 +113,10 @@ body {
     text-decoration: none;
   }
 }
+
+// Back to top offset
+[id="#{$back-to-top-target-id}"]:target {
+  @include media-breakpoint-up(md) {
+    scroll-margin-top: $offset-top;
+  }
+}

--- a/site/assets/scss/_skippy.scss
+++ b/site/assets/scss/_skippy.scss
@@ -1,5 +1,5 @@
 .skippy {
-  background-color: $black;
+  z-index: $zindex-skippy; // Boosted mod
 
   a {
     color: $white;

--- a/site/assets/scss/_variables.scss
+++ b/site/assets/scss/_variables.scss
@@ -7,14 +7,20 @@ $bd-purple-light:  lighten(saturate($bd-purple, 5%), 45%); // stylelint-disable-
 $bd-info:          $info;
 $bd-warning:       $warning;
 $bd-danger:        $danger;
-$dropdown-active-icon: $form-check-input-checked-bg-image; // Boosted mod
 
 // Boosted mod
+$dropdown-active-icon: $form-check-input-checked-bg-image;
+
+$zindex-skippy: 1080;
+
 $offset-top: add(10rem, $border-width / 2);
-$sidebar-height: subtract(100vh, add($offset-top, 2rem));
-$sidebar-base-padding: $spacer / 2;
+
+$sidebar-height:         subtract(100vh, add($offset-top, 2rem));
+$sidebar-base-padding:   $spacer / 2;
 $sidebar-button-padding: $sidebar-base-padding $sidebar-base-padding add($sidebar-base-padding, $border-width);
-$sidebar-link-padding: $sidebar-base-padding / 2 $sidebar-base-padding $sidebar-base-padding / 2 $spacer;
-$documentation-link-color: shade-color($info, 20%);
+$sidebar-link-padding:   $sidebar-base-padding / 2 $sidebar-base-padding $sidebar-base-padding / 2 $spacer;
+
+$documentation-link-color:    shade-color($info, 20%);
 $documentation-link-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path fill='#{$documentation-link-color}' fill-rule='evenodd' d='M9.26 25a1.77 1.77 0 01-1.76-1.76V6.76A1.77 1.77 0 019.26 5h12.36v2.35h1.17V25M20.44 6.18H9.26a.59.59 0 00-.58.58.59.59 0 00.58.6h1.18V15l1.77-1.76L13.97 15V7.35h6.47z'/></svg>");
+
 $tac-prefix: "tarteaucitron";

--- a/site/content/docs/5.0/components/back-to-top.md
+++ b/site/content/docs/5.0/components/back-to-top.md
@@ -1,0 +1,139 @@
+---
+layout: docs
+title: Back to top
+description: Sticky back-to-top link appearing after scrolling down one viewport height.
+group: components
+toc: true
+---
+
+## Overview
+
+Boosted "back to top" provides a way to get back to the top of the page using a simple link. It's built only with HTML and CSS, meaning you don't need any JavaScript. It only requires a `.back-to-top` wrapper and a `.back-to-top-link`, at the end of your `body`— just before your scripts.
+
+For accessibility purposes, back-to-top link contains a `.visually-hidden` text content and a `data-o-label` attribute— whose **value should match hidden text content** to make sure it's usable with speech recognition software. The `data-o-label` attribute content is displayed in a `::before` pseudo-element thanks to the `attr()` CSS function.
+
+We also recommend using a `nav` wrapper —alongside an accurate `aria-label`— to ease discoverability through landmarks.
+
+Make sure you leave enough space between the back-to-top link and the bottom of the viewport to:
+- prevent the component being overlapped by bottom navigation bar on mobile and notification tooltips for Windows users,
+- avoid proximity with system interactive areas, which could lead to accidentally activating an adjacent target.
+
+
+{{< callout >}}
+### Smooth scroll
+
+Smooth scrolling does not depend on this component. It's turned on only when the user has **not** explicitly signaled that they’d prefer reduced motion (i.e. where `prefers-reduced-motion: no-preference`) through the `scroll-behavior` property. [Read more about `prefers-reduced-motion` in our accessibility page]({{< docsref "/getting-started/accessibility#reduced-motion" >}}).
+{{< /callout >}}
+
+## Example
+
+<div class="bd-example">
+  <nav aria-label="Standard back to top example" class="back-to-top position-static ps-5 ms-5">
+    <a href="#top" class="back-to-top-link btn btn-secondary position-relative top-0" data-o-label="Back to top">
+      <span class="visually-hidden">Back to top</span>
+    </a>
+  </nav>
+</div>
+{{< example show_preview="false" >}}
+<nav aria-label="Back to top" class="back-to-top">
+  <a href="#top" class="back-to-top-link btn btn-secondary" data-o-label="Back to top">
+    <span class="visually-hidden">Back to top</span>
+  </a>
+</nav>
+{{< /example >}}
+
+{{< callout warning >}}
+### Define a target
+
+Since we're using a link, **you need a valid target**. We recommend adding an anchor link at the beginning of your markup, like so: `<a id="top"></a>`.
+You may use another `id`, but if you're using a fixed header you'll need to override our `$back-to-top-target-id` variable to ensure it won't overlap content after scrolling up.
+{{< /callout >}}
+
+### Always visible
+
+Add `.position-fixed` utility to your `.back-to-top-link` to make your back-to-top link persistent.
+
+{{< example show_preview="false" >}}
+<nav aria-label="Fixed back to top example" class="back-to-top">
+  <a href="#top" class="back-to-top-link position-fixed btn btn-secondary" data-o-label="Back to top">
+    <span class="visually-hidden">Back to top</span>
+  </a>
+</nav>
+{{< /example >}}
+
+### Label inside
+
+Drop the `data-o-label` attribute and the `<span class="visually-hidden">` and use [spacing utilities]({{< docsref "/utilities/spacing" >}}) to fine tune your button.
+
+<div class="bd-example">
+  <nav aria-label="Label inside back to top example" class="back-to-top position-static">
+    <a href="#top" class="back-to-top-link position-static btn btn-secondary px-2">Back to top</a>
+  </nav>
+</div>
+{{< example show_preview="false" >}}
+<nav aria-label="Back to top" class="back-to-top">
+  <a href="#top" class="back-to-top-link btn btn-secondary px-2">Back to top</a>
+</nav>
+{{< /example >}}
+
+### Icon only
+
+Use a `title` attribute instead of `data-o-label` to ensure a visible label is still provided on demand for sighted users.
+
+<div class="bd-example">
+  <nav aria-label="Icon only back to top example" class="back-to-top position-static">
+    <a href="#top" class="back-to-top-link position-static btn btn-secondary" title="Back to top">
+      <span class="visually-hidden">Back to top</span>
+    </a>
+  </nav>
+</div>
+{{< example show_preview="false" >}}
+<nav aria-label="Back to top" class="back-to-top">
+  <a href="#top" class="back-to-top-link btn btn-secondary" title="Back to top">
+    <span class="visually-hidden">Back to top</span>
+  </a>
+</nav>
+{{< /example >}}
+
+## Sass options
+
+Back to top link can be customized in a few ways: either making it appear after more or less vertical scrolling, modify its offset from the bottom right corner, etc.
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>$back-to-top-display-threshold</code></td>
+      <td>
+        Defines the vertical threshold at which "back to top" link appears.
+      </td>
+      <td><code>100vh</code></td>
+    </tr>
+    <tr>
+      <td><code>$back-to-top-target-id</code></td>
+      <td>
+        Target's <code>id</code>, used to apply <code>scroll-margin-top</code> when anchor is active.
+      </td>
+      <td><code>"top"</code></td>
+    </tr>
+    <tr>
+      <td><code>$back-to-top-offset</code></td>
+      <td>
+        Base offset, used to place "back to top" link in the bottom right corner of the page.
+      </td>
+      <td><code>$spacer * 1.5</code></td>
+    </tr>
+  </tbody>
+</table>
+
+### Variables
+
+For more details, please have a look at the exhaustive list of available variables:
+
+{{< scss-docs name="back-to-top" file="scss/_variables.scss" >}}

--- a/site/content/docs/5.0/customize/css-variables.md
+++ b/site/content/docs/5.0/customize/css-variables.md
@@ -36,6 +36,26 @@ Have a look at our table documentation for some [insight into how we're using CS
 
 We're also using CSS variables across our grids—primarily for gutters—with more component usage coming in the future.
 
+<!-- Boosted mod -->
+## Deduping embedded SVGs
+
+Boosted uses [embedded SVGs as data URIs]({{< docsref "/customize/overview" >}}#csps-and-embedded-svgs) in the wild, which means extremely long strings in CSS. When one of them is used several times in the stylesheet, CSS custom properties allows to factorize its string— thus to decrease output filesize.
+
+```css
+:root {
+  --o-chevron-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'%3e%3cpath d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/%3e%3c/svg%3e");
+}
+
+.back-to-top-link::after {
+  background-image: var(--o-chevron-icon);
+}
+
+.pagination-item:first-child .page-link::before {
+  background-image: var(--o-chevron-icon);
+}
+```
+<!-- End mod -->
+
 ## Examples
 
 CSS variables offer similar flexibility to Sass's variables, but without the need for compilation before being served to the browser. For example, here we're resetting our page's font and link styles with CSS variables.

--- a/site/content/docs/5.0/examples/cheatsheet-rtl/index.html
+++ b/site/content/docs/5.0/examples/cheatsheet-rtl/index.html
@@ -8,6 +8,8 @@ extra_js:
 direction: rtl
 ---
 
+<a id="top" class="position-absolute"></a><!-- Boosted mod -->
+
 <header class="bd-header navbar navbar-expand-md navbar-dark bg-dark">
   <div class="container-fluid">
     <h1 class="navbar-brand">
@@ -45,6 +47,7 @@ direction: rtl
         <ul class="list-unstyled collapse" id="components-collapse">
           <li><a class="d-flex" href="#accordion">الأكورديون</a></li>
           <li><a class="d-flex" href="#alerts">إنذار</a></li>
+          <li><a class="d-flex" href="#back-to-top">Back to to</a></li><!-- Boosted mod -->
           <li><a class="d-flex" href="#badge">شارة</a></li>
           <li><a class="d-flex" href="#breadcrumb">مسار التنقل</a></li>
           <li><a class="d-flex" href="#buttons">أزرار</a></li>
@@ -667,6 +670,36 @@ direction: rtl
         {{< /example >}}
       </div>
     </article>
+    <!-- Boosted mod -->
+    <article class="my-3" id="back-to-top">
+      <div class="bd-heading sticky-xl-top align-self-start mt-5 mb-3 mt-xl-0 mb-xl-2">
+        <h3>عد إلى الأعلى</h3>
+        <a class="d-flex align-items-center" href="{{< docsref "/components/back-to-top" >}}">توثيق</a>
+      </div>
+
+      <div class="row row-cols-3">
+        {{< example show_markup="false" >}}
+        <nav aria-label="معيار العودة إلى أعلى مثال" class="back-to-top position-static ps-5 ms-5">
+          <a href="#top" class="back-to-top-link btn btn-secondary position-relative top-0" data-o-label="عد إلى الأعلى">
+            <span class="visually-hidden">عد إلى الأعلى</span>
+          </a>
+        </nav>
+        {{< /example >}}
+        {{< example show_markup="false" class="bd-example mt-0" >}}
+        <nav aria-label="تسمية من الداخل إلى أعلى مثال" class="back-to-top position-static">
+          <a href="#top" class="back-to-top-link position-static btn btn-secondary px-2">عد إلى الأعلى</a>
+        </nav>
+        {{< /example >}}
+        {{< example show_markup="false" class="bd-example mt-0" >}}
+        <nav aria-label="رمز فقط إلى أعلى مثال" class="back-to-top position-static">
+          <a href="#top" class="back-to-top-link position-static btn btn-secondary" title="عد إلى الأعلى">
+            <span class="visually-hidden">عد إلى الأعلى</span>
+          </a>
+        </nav>
+        {{< /example >}}
+      </div>
+    </article>
+    <!-- End mod -->
     <article class="my-3" id="badge">
       <div class="bd-heading sticky-xl-top align-self-start mt-5 mb-3 mt-xl-0 mb-xl-2">
         <h3>شارة</h3>
@@ -1501,3 +1534,11 @@ direction: rtl
     </div>
   </div>
 </div>
+
+<!-- Boosted mod -->
+<nav aria-label="عد إلى الأعلى" class="back-to-top">
+  <a href="#top" class="back-to-top-link btn btn-secondary" data-o-label="عد إلى الأعلى">
+    <span class="visually-hidden">عد إلى الأعلى</span>
+  </a>
+</nav>
+<!-- End mod -->

--- a/site/content/docs/5.0/examples/cheatsheet/cheatsheet.js
+++ b/site/content/docs/5.0/examples/cheatsheet/cheatsheet.js
@@ -36,7 +36,7 @@
   function setActiveItem() {
     var hash = window.location.hash
 
-    if (hash === '') {
+    if (hash === '' || hash === 'top') {
       return
     }
 

--- a/site/content/docs/5.0/examples/cheatsheet/index.html
+++ b/site/content/docs/5.0/examples/cheatsheet/index.html
@@ -7,6 +7,8 @@ extra_js:
   - src: "cheatsheet.js"
 ---
 
+<a id="top" class="position-absolute"></a><!-- Boosted mod -->
+
 <header class="bd-header navbar navbar-expand-md navbar-dark bg-dark">
   <div class="container-fluid">
     <h1 class="navbar-brand">
@@ -44,6 +46,7 @@ extra_js:
         <ul class="list-unstyled collapse" id="components-collapse">
           <li><a class="d-flex" href="#accordion">Accordion</a></li>
           <li><a class="d-flex" href="#alerts">Alerts</a></li>
+          <li><a class="d-flex" href="#back-to-top">Back to top</a></li>
           <li><a class="d-flex" href="#badge">Badge</a></li>
           <li><a class="d-flex" href="#breadcrumb">Breadcrumb</a></li>
           <li><a class="d-flex" href="#buttons">Buttons</a></li>
@@ -660,6 +663,34 @@ extra_js:
             <p class="mb-0">Whenever you need to, be sure to use margin utilities to keep things nice and tidy.</p>
           </div>
         </div>
+        {{< /example >}}
+      </div>
+    </article>
+    <article class="my-3" id="back-to-top">
+      <div class="bd-heading sticky-xl-top align-self-start mt-5 mb-3 mt-xl-0 mb-xl-2">
+        <h3>Back to top</h3>
+        <a class="d-flex align-items-center" href="{{< docsref "/components/back-to-top" >}}">Documentation</a>
+      </div>
+
+      <div class="row row-cols-3">
+        {{< example show_markup="false" >}}
+        <nav aria-label="Standard back to top example" class="back-to-top position-static ps-5 ms-5">
+          <a href="#top" class="back-to-top-link btn btn-secondary position-relative top-0" data-o-label="Back to top">
+            <span class="visually-hidden">Back to top</span>
+          </a>
+        </nav>
+        {{< /example >}}
+        {{< example show_markup="false" class="bd-example mt-0" >}}
+        <nav aria-label="Label inside back to top example" class="back-to-top position-static">
+          <a href="#top" class="back-to-top-link position-static btn btn-secondary px-2">Back to top</a>
+        </nav>
+        {{< /example >}}
+        {{< example show_markup="false" class="bd-example mt-0" >}}
+        <nav aria-label="Icon only back to top example" class="back-to-top position-static">
+          <a href="#top" class="back-to-top-link position-static btn btn-secondary" title="Back to top">
+            <span class="visually-hidden">Back to top</span>
+          </a>
+        </nav>
         {{< /example >}}
       </div>
     </article>
@@ -1485,3 +1516,11 @@ extra_js:
     </div>
   </div>
 </div>
+
+<!-- Boosted mod -->
+<nav aria-label="Back to top" class="back-to-top">
+  <a href="#top" class="back-to-top-link btn btn-secondary" data-o-label="Back to top">
+    <span class="visually-hidden">Back to top</span>
+  </a>
+</nav>
+<!-- End mod -->

--- a/site/content/docs/5.0/guidelines/buttons.md
+++ b/site/content/docs/5.0/guidelines/buttons.md
@@ -254,9 +254,14 @@ This feature will be delivered with [#521]({{< param repo >}}/issues/521).
 
 ## Back to top
 
-{{< callout info >}}
-This feature will be delivered with [#523]({{< param repo >}}/issues/523).
-{{< /callout >}}
+[Documentation]({{< docsref "/components/back-to-top" >}})&nbsp;—&nbsp;{{< anchor web-btn-btt-001 >}}
+
+<nav aria-label="Icon only back to top example" class="back-to-top position-static">
+  <a href="#top" class="back-to-top-link position-static btn btn-secondary" title="Back to top">
+    <span class="visually-hidden">Back to top</span>
+  </a>
+</nav>
+
 
 ## Social buttons
 

--- a/site/content/docs/5.0/utilities/position.md
+++ b/site/content/docs/5.0/utilities/position.md
@@ -94,11 +94,11 @@ Here are some real life examples of these classes:
 </button>
 
 <button type="button" class="btn btn-dark position-relative">
-  Marker <svg width="1em" height="1em" viewBox="0 0 16 16" class="position-absolute top-100 start-50 translate-middle mt-1 bi bi-caret-down-fill" fill="#212529" xmlns="http://www.w3.org/2000/svg"><path d="M7.247 11.14L2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/></svg>
+  Marker <svg width="1em" height="1em" viewBox="0 0 16 16" class="position-absolute top-100 start-50 translate-middle mt-1 bi bi-caret-down-fill" xmlns="http://www.w3.org/2000/svg"><path d="M7.247 11.14L2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/></svg>
 </button>
 
 <button type="button" class="btn btn-primary position-relative">
-  Alerts <span class="position-absolute top-0 start-100 translate-middle badge border border-light rounded-circle bg-danger p-2"><span class="visually-hidden">unread messages</span></span>
+  Alerts <span class="position-absolute top-0 start-100 translate-middle badge border rounded-circle bg-warning p-2"><span class="visually-hidden">unread messages</span></span>
 </button>
 {{< /example >}}
 

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -57,6 +57,7 @@
   pages:
     - title: Accordion
     - title: Alerts
+    - title: Back to top
     - title: Badge
     - title: Breadcrumb
     - title: Buttons

--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -23,7 +23,7 @@
         </div>
       {{ end }}
 
-      <div class="bd-content ps-lg-4">
+      <div class="bd-content ps-lg-4 mb-3">
         {{ if .Page.Params.sections }}
           <div class="row g-3">
             {{ range .Page.Params.sections }}

--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -19,7 +19,7 @@
       {{ if (eq .Page.Params.toc true) }}
         <div class="bd-toc mt-4 mb-5 my-md-0 py-md-4 border-start border-light border-1">
           <strong class="d-block h6 my-2 ps-xl-3 pb-2 border-bottom border-light border-1">On this page</strong>
-          <div class="ps-xl-3">{{ .TableOfContents }}</div>
+          <div class="ps-lg-3">{{ .TableOfContents }}</div>
         </div>
       {{ end }}
 

--- a/site/layouts/_default/guidelines.html
+++ b/site/layouts/_default/guidelines.html
@@ -25,11 +25,11 @@
         {{ if (eq .Page.Params.toc true) }}
           <div class="bd-toc mt-4 mb-5 my-md-0 py-md-4 border-start border-light border-1">
             <strong class="d-block h6 my-2 ps-xl-3 pb-2 border-bottom border-light border-1">On this page</strong>
-            <div class="ps-xl-3">{{ .TableOfContents }}</div>
+            <div class="ps-lg-3">{{ .TableOfContents }}</div>
           </div>
         {{ end }}
 
-      <div class="bd-content ps-lg-4">
+      <div class="bd-content ps-lg-4 mb-3">
         {{ if .Page.Params.sections }}
             <div class="row g-3">
               {{ range .Page.Params.sections }}

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -1,4 +1,4 @@
-<footer class="bd-footer p-3 p-md-5 bg-dark">
+<footer class="bd-footer py-3 py-md-4 bg-dark">
   <div class="container">
     <p class="mb-0">This documentation is an adaptation made by Orange.</p>
     <p class="mb-0">Original version designed and built with all the love in the world by the <a href="https://github.com/orgs/twbs/people">Bootstrap core team</a> with the help of <a href="https://github.com/twbs/bootstrap/graphs/contributors">their contributors</a>.</p>
@@ -7,7 +7,7 @@
       —&nbsp;just like <a href="https://github.com/twbs/bootstrap/blob/main/LICENSE" target="_blank" rel="license noopener">Bootstrap</a>,
       docs <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank" rel="license noopener">CC BY 3.0</a>.
     </p>
-    <ul class="bd-footer-links ps-0 mb-3">
+    <ul class="bd-footer-links ps-0 mb-0">
       <li class="list-inline-item me-3 mb-3 mb-md-0 d-block d-md-inline-block"><span>Currently v{{ .Site.Params.current_version }}</span></li>
       <li class="list-inline-item me-3"><a href="{{ .Site.Params.repo }}">GitHub</a></li>
       <li class="list-inline-item me-3"><a href="/docs/{{ .Site.Params.docs_version }}/examples/">Examples</a></li>
@@ -19,3 +19,10 @@
     </ul>
   </div>
 </footer>
+<!-- Boosted mod: back-to-top component -->
+<nav aria-label="Back to top" class="back-to-top">
+  <a href="#top" class="back-to-top-link btn btn-secondary" data-o-label="Back to top">
+    <span class="visually-hidden">Back to top</span>
+  </a>
+</nav>
+<!-- End mod -->

--- a/site/layouts/partials/skippy.html
+++ b/site/layouts/partials/skippy.html
@@ -1,3 +1,4 @@
+<a id="top"></a><!-- Boosted mod: anchor for back-to-top link -->
 <div class="skippy visually-hidden-focusable overflow-hidden">
   <nav aria-label="Skip links" class="container-xl">
     <a class="d-inline-flex p-2 m-1" href="#content">Skip to main content</a>

--- a/site/layouts/partials/skippy.html
+++ b/site/layouts/partials/skippy.html
@@ -1,9 +1,9 @@
 <a id="top"></a><!-- Boosted mod: anchor for back-to-top link -->
-<div class="skippy visually-hidden-focusable overflow-hidden">
-  <nav aria-label="Skip links" class="container-xl">
-    <a class="d-inline-flex p-2 m-1" href="#content">Skip to main content</a>
+<div class="skippy visually-hidden-focusable overflow-hidden position-fixed top-0 end-0 start-0">
+  <nav aria-label="Skip links" class="container-xxl py-1 ps-5">
+    <a class="d-inline-flex p-2 ms-3" href="#content">Skip to main content</a>
     {{ if (eq .Page.Layout "docs") -}}
-    <a class="d-none d-md-inline-flex p-2 m-1" href="#bd-docs-nav">Skip to docs navigation</a>
+    <a class="d-none d-md-inline-flex p-2" href="#bd-docs-nav">Skip to docs navigation</a>
     {{- end }}
   </nav>
 </div>


### PR DESCRIPTION
Closes #523 

---

There's also a good case to use `var()` and custom properties to lighten up a few things, starting at `$chevron-icon` occurrencies.


- [x] Should match specs (eg. either the Web UI Kit or any pattern from the WAI — or both…)
- [x] Docs added — maybe to Design Guidelines too
- [x] Run linters
- [x] Run compilers
- [x] Run tests
- [x] Cross-browser test:
  - Firefox ESR
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [x] Commited with `feat(…): …` message
- [x] Mention it in Ship List (#585) and in Migration Guide (if `back-from-v4`) (#383)
- [x] Add in the cheatsheet example ?

---

**Preview**: https://deploy-preview-600--boosted.netlify.app/docs/5.0/components/back-to-top/

