### PR TITLE
CI optimizations

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -23,16 +23,23 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Bail early
+        if: contains(github.event.*.labels.*.name, 'skip:ci') || contains(github.event.*.labels.*.name, 'skip:browserstack')
+        run: exit 0
+
       - name: Clone repository
         uses: actions/checkout@v2
+        if: failure()
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+        if: failure()
 
       - run: node --version
       - run: npm --version
+        if: failure()
 
       - name: Set up npm cache
         uses: actions/cache@v2
@@ -42,15 +49,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.os }}-node-v${{ env.NODE }}-
+        if: failure()
 
       - name: Install npm dependencies
         run: npm ci
+        if: failure()
 
       - name: Run dist
         run: npm run dist
+        if: failure()
 
       - name: Run BrowserStack tests
         run: npm run js-test-cloud
         env:
           BROWSER_STACK_ACCESS_KEY: "${{ secrets.BROWSER_STACK_ACCESS_KEY }}"
           BROWSER_STACK_USERNAME: "${{ secrets.BROWSER_STACK_USERNAME }}"
+        if: failure()

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -5,6 +5,12 @@ on:
       - v5-dev
       - "!dependabot/**"
   pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
     branches:
       - v5-dev
       - "!dependabot/**"
@@ -17,16 +23,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Bail early
+        if: github.repository == 'Orange-OpenSource/Orange-Boosted-Bootstrap' && contains(github.event.*.labels.*.name, 'skip:ci')
+        run: exit 0
+
       - name: Clone repository
         uses: actions/checkout@v2
+        if: failure()
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+        if: failure()
 
       - run: node --version
       - run: npm --version
+        if: failure()
 
       - name: Set up npm cache
         uses: actions/cache@v2
@@ -36,15 +49,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.os }}-node-v${{ env.NODE }}-
+        if: failure()
 
       - name: Install npm dependencies
         run: npm ci
+        if: failure()
 
       - name: Run dist
         run: npm run dist
+        if: failure()
 
       - name: Run bundlewatch
         run: npm run bundlewatch
         env:
           BUNDLEWATCH_GITHUB_TOKEN: "${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}"
           CI_BRANCH_BASE: v5-dev
+        if: failure()

--- a/.github/workflows/css.yml
+++ b/.github/workflows/css.yml
@@ -5,6 +5,12 @@ on:
       - v5-dev
       - "!dependabot/**"
   pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
     branches:
       - v5-dev
       - "!dependabot/**"
@@ -17,16 +23,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Bail early
+        if: github.repository == 'Orange-OpenSource/Orange-Boosted-Bootstrap' && contains(github.event.*.labels.*.name, 'skip:ci')
+        run: exit 0
+
       - name: Clone repository
         uses: actions/checkout@v2
+        if: failure()
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+        if: failure()
 
       - run: node --version
       - run: npm --version
+        if: failure()
 
       - name: Set up npm cache
         uses: actions/cache@v2
@@ -36,9 +49,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.os }}-node-v${{ env.NODE }}-
+        if: failure()
 
       - name: Install npm dependencies
         run: npm ci
+        if: failure()
 
       - name: Build CSS
         run: npm run css
+        if: failure()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,18 +1,16 @@
 name: Docs
 on:
   push:
-    paths:
-      - 'js/**'
-      - 'scss/**'
-      - 'site/**'
     branches:
       - v5-dev
       - "!dependabot/**"
   pull_request:
-    paths:
-      - 'js/**'
-      - 'scss/**'
-      - 'site/**'
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
     branches:
       - v5-dev
       - "!dependabot/**"
@@ -25,15 +23,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Bail early
+        if: github.repository == 'Orange-OpenSource/Orange-Boosted-Bootstrap' && contains(github.event.*.labels.*.name, 'skip:ci')
+        run: exit 0
+
       - name: Clone repository
         uses: actions/checkout@v2
+        if: failure()
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+        if: failure()
 
       - run: java -version
+        if: failure()
 
       - name: Set up npm cache
         uses: actions/cache@v2
@@ -43,9 +48,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.os }}-node-v${{ env.NODE }}-
+        if: failure()
 
       - name: Install npm dependencies
         run: npm ci
+        if: failure()
 
       - name: Test docs
         run: npm run docs
+        if: failure()

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,14 +1,16 @@
 name: JS Tests
 on:
   push:
-    paths:
-      - 'js/**'
     branches:
       - v5-dev
       - "!dependabot/**"
   pull_request:
-    paths:
-      - 'js/**'
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
     branches:
       - v5-dev
       - "!dependabot/**"
@@ -26,13 +28,19 @@ jobs:
         node: [10, 12, 14]
 
     steps:
+      - name: Bail early
+        if: github.repository == 'Orange-OpenSource/Orange-Boosted-Bootstrap' && contains(github.event.*.labels.*.name, 'skip:ci')
+        run: exit 0
+
       - name: Clone repository
         uses: actions/checkout@v2
+        if: failure()
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+        if: failure()
 
       - name: Set up npm cache
         uses: actions/cache@v2
@@ -42,15 +50,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-v${{ matrix.node }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.os }}-node-v${{ matrix.node }}-
+        if: failure()
 
       - name: Install npm dependencies
         run: npm ci
+        if: failure()
 
       - name: Run dist
         run: npm run js
+        if: failure()
 
       - name: Run JS tests
         run: npm run js-test
+        if: failure()
 
       - name: Run Coveralls
         uses: coverallsapp/github-action@master
@@ -58,3 +70,4 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           path-to-lcov: "./js/coverage/lcov.info"
+        if: failure()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,12 @@ on:
       - v5-dev
       - "!dependabot/**"
   pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
     branches:
       - v5-dev
       - "!dependabot/**"
@@ -17,13 +23,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Bail early
+        if: github.repository == 'Orange-OpenSource/Orange-Boosted-Bootstrap' && contains(github.event.*.labels.*.name, 'skip:ci')
+        run: exit 0
+
       - name: Clone repository
         uses: actions/checkout@v2
+        if: failure()
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+        if: failure()
 
       - name: Set up npm cache
         uses: actions/cache@v2
@@ -33,9 +45,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.os }}-node-v${{ env.NODE }}-
+        if: failure()
 
       - name: Install npm dependencies
         run: npm ci
+        if: failure()
 
       - name: Lint
         run: npm run lint
+        if: failure()

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -2,14 +2,16 @@ name: CSS (node-sass)
 
 on:
   push:
-    paths:
-      - 'scss/**'
     branches:
       - v5-dev
       - "!dependabot/**"
   pull_request:
-    paths:
-      - 'scss/**'
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
     branches:
       - v5-dev
       - "!dependabot/**"
@@ -22,16 +24,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Bail early
+        if: github.repository == 'Orange-OpenSource/Orange-Boosted-Bootstrap' && contains(github.event.*.labels.*.name, 'skip:ci')
+        run: exit 0
+
       - name: Clone repository
         uses: actions/checkout@v2
+        if: failure()
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+        if: failure()
 
       - name: Build CSS with node-sass
         run: |
           npx --package node-sass@latest node-sass --version
           npx --package node-sass@latest node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 scss/ -o dist-sass/css/
           ls -Al dist-sass/css
+        if: failure()

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -1,18 +1,16 @@
 name: Tests
 on:
   push:
-    paths:
-      - 'js/**'
-      - 'scss/**'
-      - 'site/**'
     branches:
       - v5-dev
       - "!dependabot/**"
   pull_request:
-    paths:
-      - 'js/**'
-      - 'scss/**'
-      - 'site/**'
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
     branches:
       - v5-dev
       - "!dependabot/**"
@@ -25,13 +23,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Bail early
+        if: github.repository == 'Orange-OpenSource/Orange-Boosted-Bootstrap' && (contains(github.event.*.labels.*.name, 'skip:ci') || contains(github.event.*.labels.*.name, 'skip:pa11y'))
+        run: exit 0
+
       - name: Clone repository
         uses: actions/checkout@v2
+        if: failure()
 
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
           node-version: "${{ env.NODE }}"
+        if: failure()
 
       - name: Set up npm cache
         uses: actions/cache@v2
@@ -41,18 +45,23 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.OS }}-node-v${{ env.NODE }}-
+        if: failure()
 
       - name: Install npm dependencies
         run: npm ci
+        if: failure()
 
       - name: Compile dist
         run: npm run dist
+        if: failure()
 
       - name: Test docs
         run: npm run docs-build
+        if: failure()
 
       - name: Run accessibility tests
         run: npm run docs-accessibility
+        if: failure()
 
       - name: Generate HTML accessibility results
         run: npm run docs-pa11y-html

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,10 +1,18 @@
 name: Tests
 on:
   push:
+    paths:
+      - 'js/**'
+      - 'scss/**'
+      - 'site/content/docs/**/guidelines'
     branches:
       - v5-dev
       - "!dependabot/**"
   pull_request:
+    paths:
+      - 'js/**'
+      - 'scss/**'
+      - 'site/content/docs/**/guidelines'
     branches:
       - v5-dev
       - "!dependabot/**"

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,18 +1,16 @@
 name: Tests
 on:
   push:
-    paths:
-      - 'js/**'
-      - 'scss/**'
-      - 'site/content/docs/**/guidelines'
     branches:
       - v5-dev
       - "!dependabot/**"
   pull_request:
-    paths:
-      - 'js/**'
-      - 'scss/**'
-      - 'site/content/docs/**/guidelines'
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
     branches:
       - v5-dev
       - "!dependabot/**"
@@ -25,13 +23,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Bail early
+        if: github.repository == 'Orange-OpenSource/Orange-Boosted-Bootstrap' && (contains(github.event.*.labels.*.name, 'skip:ci') || contains(github.event.*.labels.*.name, 'skip:percy'))
+        run: exit 0
+
       - name: Clone repository
         uses: actions/checkout@v2
+        if: failure()
 
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
           node-version: "${{ env.NODE }}"
+        if: failure()
 
       - name: Set up npm cache
         uses: actions/cache@v2
@@ -41,15 +45,19 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-node-v${{ matrix.node }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.OS }}-node-v${{ matrix.node }}-
+        if: failure()
 
       - name: Install npm dependencies
         run: npm ci
+        if: failure()
 
       - name: Compile dist
         run: npm run dist
+        if: failure()
 
       - name: Build docs
         run: npm run docs-build
+        if: failure()
 
       - name: Percy Test
         uses: percy/snapshot-action@v0.1.2
@@ -59,3 +67,4 @@ jobs:
           verbose: true
         env:
           PERCY_TOKEN: "${{ secrets.PERCY_TOKEN }}"
+        if: failure()


### PR DESCRIPTION
Reduce our ecological footprint, somehow?

- [Skip action when a specific label is added or removed](https://github.community/t/how-can-i-keep-github-event-pull-request-labels-up-to-date-when-re-trying-a-workflow/119386/2)
- [Skip actions when an existing label is set](https://github.community/t/skip-action-when-label-already-on-pr-vs-on-label-create-event/121037/2)

Targets:
- [x] Percy has a snapshots quota per month,
- [x] BrowserStack runs several VMs…
- [x] Netlify deploys a technical URL
- [x] Pa11y is quite heavy too.

The other ones already fit their target: either by filetype (e.g. compile, lint, test, optimize images) or event type (e.g. notify on published release). I guess we're able to add a few labels, such as `skip:percy`, `skip:browserstack`, etc. And `skip:ci` should cancel all workflows, I guess.