### PR TITLE
feat: Stepped Process: add the component from v4

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "26.2 kB"
+      "maxSize": "26.6 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",
-      "maxSize": "23.9 kB"
+      "maxSize": "24.3 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.js",

--- a/scss/_stepped-process.scss
+++ b/scss/_stepped-process.scss
@@ -1,0 +1,124 @@
+//
+// Orange stepped process
+//
+.stepped-process {
+  ol {
+    display: flex;
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+    font-size: $small-font-size;
+    font-weight: $font-weight-bold;
+    text-align: center;
+    list-style: none;
+    counter-reset: $stepped-process-counter;
+  }
+}
+
+.stepped-process-item {
+  display: flex;
+  flex: 1;
+  padding: $step-item-padding;
+  margin-right: $step-item-margin-end;
+  counter-increment: $stepped-process-counter;
+  background-color: $step-item-bg;
+
+  &.active {
+    background-color: $step-item-active-bg;
+  }
+
+  .active ~ & {
+    background-color: $step-item-next-bg;
+  }
+}
+
+.stepped-process-link {
+  flex: 1 0 $step-link-width;
+  max-width: $step-link-width;
+  margin: auto;
+  overflow: hidden;
+  line-height: 1;
+  color: $step-link-color;
+  text-decoration: if($link-decoration == none, null, none);
+  white-space: nowrap;
+  outline-offset: $spacer;
+
+  &::before {
+    content: $step-link-marker;
+  }
+
+  &:hover,
+  &:focus {
+    color: $step-link-color;
+  }
+
+  &:hover {
+    text-decoration: if($link-hover-decoration == underline, null, underline);
+  }
+
+  &:focus {
+    text-decoration: $link-decoration;
+    outline-offset: $spacer / 4;
+  }
+
+  .active &,
+  .active ~ .stepped-process-item & {
+    color: $step-link-active-color;
+  }
+}
+
+@include media-breakpoint-up(sm) {
+  .stepped-process-item {
+    position: relative;
+    padding: $step-item-padding 0;
+    margin: 0;
+    filter: $step-item-drop-shadow;
+
+    & + & {
+      padding-left: $step-item-padding-end;
+    }
+
+    &:not(:last-child)::after {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: subtract(100%, 1px);
+      z-index: -1;
+      width: $step-item-arrow-width;
+      content: "";
+      background-color: inherit;
+      clip-path: $step-item-arrow-shape;
+    }
+  }
+
+  @for $i from 1 through $stepped-process-max-items {
+    .stepped-process-item:nth-child(#{$i}) {
+      $index: subtract($stepped-process-max-items, $i);
+      z-index: if($index == 0, null, $index);
+    }
+  }
+
+  .active .stepped-process-link {
+    max-width: none;
+
+    &::before {
+      content: $step-link-marker-lg;
+    }
+  }
+}
+
+@include media-breakpoint-between(sm, xl) {
+  .stepped-process-item.active {
+    flex: $stepped-process-max-items - 1;
+  }
+}
+
+@include media-breakpoint-up(xl) {
+  .stepped-process-link {
+    max-width: none;
+  }
+
+  .stepped-process-link::before {
+    content: $step-link-marker-lg;
+  }
+}

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1643,4 +1643,28 @@ $back-to-top-icon:               var(--#{$boosted-variable-prefix}chevron-icon) 
 $back-to-top-icon-width:         add(.5rem, 1px) !default;
 $back-to-top-icon-height:        subtract(1rem, 1px) !default;
 // scss-docs-end back-to-top
+
+//// Stepped process
+// scss-docs-start stepped-process
+$stepped-process-max-items: 5 !default;
+$stepped-process-counter:   step !default; // Used as a counter name
+
+$step-item-margin-end:   $border-width !default;
+$step-item-padding:      .5rem !default;
+$step-item-bg:           $black !default;
+$step-item-active-bg:    $primary !default;
+$step-item-next-bg:      $gray-400 !default;
+$step-item-shadow-size:  $border-width * 1.5 !default;
+$step-item-drop-shadow:  drop-shadow($step-item-shadow-size 0 0 $white) #{"/* rtl:"} drop-shadow(-$step-item-shadow-size 0 0 $white) #{"*/"} !default;
+$step-item-padding-end:  $step-item-padding * 2 !default;
+
+$step-link-width:        1.25ch !default; // Matches width of a single number
+$step-link-color:        $white !default;
+$step-link-active-color: $black !default;
+$step-link-marker:       counter($stepped-process-counter) "\A0" !default;
+$step-link-marker-lg:    counter($stepped-process-counter) ".\A0" !default;
+
+$step-item-arrow-width:  1rem !default;
+$step-item-arrow-shape:  polygon(0% 0%, subtract(100%, $border-width) 50%, 0% 100%) #{"/* rtl:"} polygon(100% 0%, $border-width 50%, 100% 100%) #{"*/"} !default; // Used in clip-path
+// scss-docs-end stepped-process
 // End mod

--- a/scss/boosted.scss
+++ b/scss/boosted.scss
@@ -51,6 +51,7 @@
 
 // Boosted
 @import "back-to-top";
+@import "stepped-process";
 
 // Helpers
 @import "helpers";

--- a/site/content/docs/5.0/components/stepped-process.md
+++ b/site/content/docs/5.0/components/stepped-process.md
@@ -1,0 +1,48 @@
+---
+layout: docs
+title: Stepped process
+description: Stepped process bar used for multiple steps forms process
+group: components
+toc: true
+---
+
+## How to use
+
+Use a `nav` element with `.stepped-process` class, containing an ordered list `<ol>` with `.stepped-process-item` class on list items.
+
+Use short labels for each step, otherwise they will be cut off to preserve inline layout. More information can be carried on the `title` attribute of the `.stepped-process-link`.
+
+Add `.active` to a `.stepped-process-item` to indicate the current step, alongside `aria-current="step"` to convey the active state to assistive technologies.
+
+## Example
+
+{{< example >}}
+<nav class="stepped-process" aria-label="Checkout process">
+  <p class="float-start mt-2 me-2 fw-bold d-sm-none">Step</p>
+  <ol>
+    <li class="stepped-process-item">
+      <a class="stepped-process-link" href="#" title="1. Sign in">Sign in</a>
+    </li>
+    <li class="stepped-process-item active">
+      <a class="stepped-process-link" href="#" title="2. Review" aria-current="step">Review</a>
+    </li>
+    <li class="stepped-process-item">
+      <a class="stepped-process-link" href="#" title="3. Delivery">Delivery</a>
+    </li>
+    <li class="stepped-process-item">
+      <a class="stepped-process-link" href="#" title="4. Payment">Payment</a>
+    </li>
+    <li class="stepped-process-item">
+      <a class="stepped-process-link" href="#" title="5. Place order">Place order</a>
+    </li>
+  </ol>
+</nav>
+{{< /example >}}
+
+## Sass
+
+### Variables
+
+For more details, please have a look at the exhaustive list of available variables:
+
+{{< scss-docs name="stepped-process" file="scss/_variables.scss" >}}

--- a/site/content/docs/5.0/examples/cheatsheet-rtl/index.html
+++ b/site/content/docs/5.0/examples/cheatsheet-rtl/index.html
@@ -65,6 +65,7 @@ direction: rtl
           <li><a class="d-flex" href="#progress">شريط التقدم</a></li>
           <li><a class="d-flex" href="#scrollspy">مخطوطة</a></li>
           <li><a class="d-flex" href="#spinners">المغازل</a></li>
+          <li><a class="d-flex" href="#stepped-process">عملية متدرجة</a></li>
           <li><a class="d-flex" href="#toasts">نخب</a></li>
           <li><a class="d-flex" href="#tooltips">تلميحات الأدوات</a></li>
         </ul>
@@ -1418,6 +1419,36 @@ direction: rtl
         {{< /example >}}
       </div>
     </article>
+    <article class="my-3" id="stepped-process">
+      <div class="bd-heading sticky-xl-top align-self-start mt-5 mb-3 mt-xl-0 mb-xl-2">
+        <h3>عملية متدرجة</h3>
+        <a class="d-flex align-items-center" href="{{< docsref "/components/stepped-process" >}}">Documentation</a>
+      </div>
+      <div>
+        {{< example show_markup="false" >}}
+        <nav class="stepped-process" aria-label="مثال على الخطوات">
+          <p class="float-start mt-2 me-2 fw-bold d-sm-none">خطوة</p>
+          <ol>
+            <li class="stepped-process-item">
+              <a class="stepped-process-link" href="#" title="1. الخطوةالاولى">الخطوةالاولى</a>
+            </li>
+            <li class="stepped-process-item active">
+              <a class="stepped-process-link" href="#" title="2. الخطوة الثانية" aria-current="step">الخطوة الثانية</a>
+            </li>
+            <li class="stepped-process-item">
+              <a class="stepped-process-link" href="#" title="3. الخطوة الثالثة">الخطوة الثالثة</a>
+            </li>
+            <li class="stepped-process-item">
+              <a class="stepped-process-link" href="#" title="4. الخطوة الرابعة">الخطوة الرابعة</a>
+            </li>
+            <li class="stepped-process-item">
+              <a class="stepped-process-link" href="#" title="5. الخطوة الخامسة">الخطوة الخامسة</a>
+            </li>
+          </ol>
+        </nav>
+        {{< /example >}}
+      </div>
+    </article>
     <article class="my-3" id="popovers">
       <div class="bd-heading sticky-xl-top align-self-start mt-5 mb-3 mt-xl-0 mb-xl-2">
         <h3>بوبوفيرس</h3>
@@ -1425,6 +1456,7 @@ direction: rtl
       </div>
 
       <div>
+      
         {{< example show_markup="false" >}}
         <button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" title="عنوان Popover" data-bs-content="وإليك بعض المحتويات الرائعة. إنه ممتع للغاية. حق؟">انقر لتبديل المنبثقة</button>
         {{< /example >}}

--- a/site/content/docs/5.0/examples/cheatsheet/index.html
+++ b/site/content/docs/5.0/examples/cheatsheet/index.html
@@ -60,6 +60,7 @@ extra_js:
           <li><a class="d-flex" href="#navs">Navs</a></li>
           <li><a class="d-flex" href="#navbar">Navbar</a></li>
           <li><a class="d-flex" href="#pagination">Pagination</a></li>
+          <li><a class="d-flex" href="#stepped-process">Stepped process</a></li>
           <li><a class="d-flex" href="#popovers">Popovers</a></li>
           <li><a class="d-flex" href="#progress">Progress</a></li>
           <li><a class="d-flex" href="#scrollspy">Scrollspy</a></li>
@@ -1408,6 +1409,36 @@ extra_js:
             <li class="page-item"><a class="page-link" href="#">3</a></li>
             <li class="page-item"><a class="page-link" href="#" aria-label="Next"></a></li>
           </ul>
+        </nav>
+        {{< /example >}}
+      </div>
+    </article>
+    <article class="my-3" id="stepped-process">
+      <div class="bd-heading sticky-xl-top align-self-start mt-5 mb-3 mt-xl-0 mb-xl-2">
+        <h3>Stepped process</h3>
+        <a class="d-flex align-items-center" href="{{< docsref "/components/stepped-process" >}}">Documentation</a>
+      </div>
+      <div>
+        {{< example show_markup="false" >}}
+        <nav class="stepped-process" aria-label="Steps example">
+          <p class="float-start mt-2 me-2 fw-bold d-sm-none">Step</p>
+          <ol>
+            <li class="stepped-process-item">
+              <a class="stepped-process-link" href="#" title="1. Step one">Step one</a>
+            </li>
+            <li class="stepped-process-item active">
+              <a class="stepped-process-link" href="#" title="2. Step two" aria-current="step">Step two</a>
+            </li>
+            <li class="stepped-process-item">
+              <a class="stepped-process-link" href="#" title="3. Step three">Step three</a>
+            </li>
+            <li class="stepped-process-item">
+              <a class="stepped-process-link" href="#" title="4. Step four">Step four</a>
+            </li>
+            <li class="stepped-process-item">
+              <a class="stepped-process-link" href="#" title="5. Step five">Step five</a>
+            </li>
+          </ol>
         </nav>
         {{< /example >}}
       </div>

--- a/site/content/docs/5.0/guidelines/navigation.md
+++ b/site/content/docs/5.0/guidelines/navigation.md
@@ -271,6 +271,31 @@ toc: true
 
 ## Stepped process
 
-{{< callout info >}}
-This feature will be delivered with [#524]({{< param repo >}}/issues/524).
-{{< /callout >}}
+[Documentation]({{< docsref "/components/stepped-process" >}})&nbsp;—&nbsp;
+<span class="d-none d-sm-block d-lg-block">{{< anchor web-nav-stp-001 >}}</span>
+<span class="d-block d-sm-none d-lg-none">{{< anchor web-nav-stp-002 >}}</span>
+
+<div class="row row-cols-1 gy-5 mb-5">
+  <div class="col">
+    <nav class="stepped-process" aria-label="Checkout process">
+      <p class="float-start mt-2 me-2 fw-bold d-sm-none">Step</p>
+      <ol>
+        <li class="stepped-process-item">
+          <a class="stepped-process-link" href="#" title="1. Sign in">Sign in</a>
+        </li>
+        <li class="stepped-process-item active">
+          <a class="stepped-process-link" href="#" title="2. Review" aria-current="step">Review</a>
+        </li>
+        <li class="stepped-process-item">
+          <a class="stepped-process-link" href="#" title="3. Delivery">Delivery</a>
+        </li>
+        <li class="stepped-process-item">
+          <a class="stepped-process-link" href="#" title="4. Payment">Payment</a>
+        </li>
+        <li class="stepped-process-item">
+          <a class="stepped-process-link" href="#" title="5. Place order">Place order</a>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</div>

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -77,6 +77,7 @@
     - title: Progress
     - title: Scrollspy
     - title: Spinners
+    - title: Stepped process
     - title: Toasts
     - title: Tooltips
 


### PR DESCRIPTION
Stepbar is being ported into v5 as "stepped process" component.

Everything has been adapted according to this change

---

Closes #524 

---

- [x] Should match specs (eg. either the Web UI Kit or any pattern from the WAI — or both…)
- [x] Docs added:
  - including the "Sass" part using `scss-docs` shortcode
  - in Design Guidelines probably
  - in Cheatsheet / Cheatsheet RTL examples
- [x] Check (and fix) RTL version
  - [x] Beware of clip-path in RTL, which would need some attention—and maybe the loop setting z-index too, might even be dropped?
- [x] Run linters
- [x] Run compilers
- [x] Run tests
- [x] Cross-browser test:
  - Firefox ESR
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [x] Clean up the branch using `rebase -i`
- [x] Commited with `feat(…): …` message
- [x] Mention it 
  - in Ship List 
  - in Migration Guide (if `back-from-v4`): renamed variables, changes in markup requirement,  etc.

---

- Preview: https://deploy-preview-636--boosted.netlify.app/docs/5.0/components/stepped-process/
- X-ref v4: https://boosted.orange.com/docs/4.6/components/stepbar/