### PR TITLE
Various docs improvements around buttons / buttons grou

### DIFF
--- a/site/content/docs/5.0/components/button-group.md
+++ b/site/content/docs/5.0/components/button-group.md
@@ -12,9 +12,9 @@ Wrap a series of buttons with `.btn` in `.btn-group`.
 
 {{< example >}}
 <div class="btn-group" role="group" aria-label="Basic example">
-  <button type="button" class="btn btn-primary">Left</button>
-  <button type="button" class="btn btn-primary">Middle</button>
-  <button type="button" class="btn btn-primary">Right</button>
+  <button type="button" class="btn btn-secondary">Left</button>
+  <button type="button" class="btn btn-secondary">Middle</button>
+  <button type="button" class="btn btn-secondary">Right</button>
 </div>
 {{< /example >}}
 
@@ -29,10 +29,10 @@ In addition, groups and toolbars should be given an explicit label, as most assi
 These classes can also be added to groups of links, as an alternative to the [`.nav` navigation components]({{< docsref "/components/navs-tabs" >}}).
 
 {{< example >}}
-<div class="btn-group">
-  <a href="#" class="btn btn-primary active" aria-current="page">Active link</a>
-  <a href="#" class="btn btn-primary">Link</a>
-  <a href="#" class="btn btn-primary">Link</a>
+<div class="btn-group" role="group">
+  <a href="#" class="btn btn-secondary active" aria-current="page">Active link</a>
+  <a href="#" class="btn btn-secondary">Link</a>
+  <a href="#" class="btn btn-secondary">Link</a>
 </div>
 {{< /example >}}
 
@@ -106,10 +106,10 @@ Feel free to mix input groups with button groups in your toolbars. Similar to th
 {{< example >}}
 <div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar with button groups">
   <div class="btn-group me-2" role="group" aria-label="First group">
-    <button type="button" class="btn btn-outline-secondary">1</button>
-    <button type="button" class="btn btn-outline-secondary">2</button>
-    <button type="button" class="btn btn-outline-secondary">3</button>
-    <button type="button" class="btn btn-outline-secondary">4</button>
+    <button type="button" class="btn btn-secondary">1</button>
+    <button type="button" class="btn btn-secondary">2</button>
+    <button type="button" class="btn btn-secondary">3</button>
+    <button type="button" class="btn btn-secondary">4</button>
   </div>
   <div class="input-group">
     <div class="input-group-text" id="btnGroupAddon">@</div>
@@ -119,10 +119,10 @@ Feel free to mix input groups with button groups in your toolbars. Similar to th
 
 <div class="btn-toolbar justify-content-between" role="toolbar" aria-label="Toolbar with button groups">
   <div class="btn-group" role="group" aria-label="First group">
-    <button type="button" class="btn btn-outline-secondary">1</button>
-    <button type="button" class="btn btn-outline-secondary">2</button>
-    <button type="button" class="btn btn-outline-secondary">3</button>
-    <button type="button" class="btn btn-outline-secondary">4</button>
+    <button type="button" class="btn btn-secondary">1</button>
+    <button type="button" class="btn btn-secondary">2</button>
+    <button type="button" class="btn btn-secondary">3</button>
+    <button type="button" class="btn btn-secondary">4</button>
   </div>
   <div class="input-group">
     <div class="input-group-text" id="btnGroupAddon2">@</div>
@@ -137,21 +137,21 @@ Instead of applying button sizing classes to every button in a group, just add `
 
 <div class="bd-example">
   <div class="btn-group btn-group-lg" role="group" aria-label="Large button group">
-    <button type="button" class="btn btn-outline-dark">Left</button>
-    <button type="button" class="btn btn-outline-dark">Middle</button>
-    <button type="button" class="btn btn-outline-dark">Right</button>
+    <button type="button" class="btn btn-secondary">Left</button>
+    <button type="button" class="btn btn-secondary">Middle</button>
+    <button type="button" class="btn btn-secondary">Right</button>
   </div>
   <br>
   <div class="btn-group" role="group" aria-label="Default button group">
-    <button type="button" class="btn btn-outline-dark">Left</button>
-    <button type="button" class="btn btn-outline-dark">Middle</button>
-    <button type="button" class="btn btn-outline-dark">Right</button>
+    <button type="button" class="btn btn-secondary">Left</button>
+    <button type="button" class="btn btn-secondary">Middle</button>
+    <button type="button" class="btn btn-secondary">Right</button>
   </div>
   <br>
   <div class="btn-group btn-group-sm" role="group" aria-label="Small button group">
-    <button type="button" class="btn btn-outline-dark">Left</button>
-    <button type="button" class="btn btn-outline-dark">Middle</button>
-    <button type="button" class="btn btn-outline-dark">Right</button>
+    <button type="button" class="btn btn-secondary">Left</button>
+    <button type="button" class="btn btn-secondary">Middle</button>
+    <button type="button" class="btn btn-secondary">Right</button>
   </div>
 </div>
 
@@ -167,12 +167,13 @@ Place a `.btn-group` within another `.btn-group` when you want dropdown menus mi
 
 {{< example >}}
 <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
-  <button type="button" class="btn btn-primary">1</button>
-  <button type="button" class="btn btn-primary">2</button>
+  <button type="button" class="btn btn-secondary">1</button>
+  <button type="button" class="btn btn-secondary">2</button>
 
   <div class="btn-group" role="group">
-    <button id="btnGroupDrop1" type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-      Dropdown
+    <button type="button" class="btn btn-secondary">Split button</button>
+    <button id="btnGroupDrop1" type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+      <span class="visually-hidden">Toggle Dropdown</span>
     </button>
     <ul class="dropdown-menu" aria-labelledby="btnGroupDrop1">
       <li><a class="dropdown-item" href="#">Dropdown link</a></li>
@@ -184,7 +185,7 @@ Place a `.btn-group` within another `.btn-group` when you want dropdown menus mi
 
 ## Vertical variation
 
-Make a set of buttons appear vertically stacked rather than horizontally. **Split button dropdowns are not supported here.**
+Make a set of buttons appear vertically stacked rather than horizontally.
 
 <div class="bd-example">
   <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
@@ -199,22 +200,24 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
 
 <div class="bd-example">
   <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
-    <button type="button" class="btn btn-primary">Button</button>
-    <button type="button" class="btn btn-primary">Button</button>
+    <button type="button" class="btn btn-secondary">Button</button>
+    <button type="button" class="btn btn-secondary">Button</button>
     <div class="btn-group" role="group">
-      <button id="btnGroupVerticalDrop1" type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-        Dropdown
+      <button type="button" class="btn btn-secondary">Split button</button>
+      <button id="btnGroupVerticalDrop1" type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+        <span class="visually-hidden">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop1">
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
       </ul>
     </div>
-    <button type="button" class="btn btn-primary">Button</button>
-    <button type="button" class="btn btn-primary">Button</button>
+    <button type="button" class="btn btn-secondary">Button</button>
+    <button type="button" class="btn btn-secondary">Button</button>
     <div class="btn-group" role="group">
-      <button id="btnGroupVerticalDrop2" type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-        Dropdown
+      <button type="button" class="btn btn-secondary">Split button</button>
+      <button id="btnGroupVerticalDrop2" type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+        <span class="visually-hidden">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop2">
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
@@ -222,8 +225,9 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
       </ul>
     </div>
     <div class="btn-group" role="group">
-      <button id="btnGroupVerticalDrop3" type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-        Dropdown
+      <button type="button" class="btn btn-secondary">Split button</button>
+      <button id="btnGroupVerticalDrop3" type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+        <span class="visually-hidden">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop3">
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
@@ -231,8 +235,9 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
       </ul>
     </div>
     <div class="btn-group" role="group">
-      <button id="btnGroupVerticalDrop4" type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-        Dropdown
+      <button type="button" class="btn btn-secondary">Split button</button>
+      <button id="btnGroupVerticalDrop4" type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+        <span class="visually-hidden">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu" aria-labelledby="btnGroupVerticalDrop4">
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
@@ -242,16 +247,7 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
   </div>
 </div>
 
-<div class="bd-example">
-  <div class="btn-group-vertical" role="group" aria-label="Vertical radio toggle button group">
-    <input type="radio" class="btn-check" name="vbtn-radio" id="vbtn-radio1" autocomplete="off" checked>
-    <label class="btn btn-outline-danger" for="vbtn-radio1">Radio 1</label>
-    <input type="radio" class="btn-check" name="vbtn-radio" id="vbtn-radio2" autocomplete="off">
-    <label class="btn btn-outline-danger" for="vbtn-radio2">Radio 2</label>
-    <input type="radio" class="btn-check" name="vbtn-radio" id="vbtn-radio3" autocomplete="off">
-    <label class="btn btn-outline-danger" for="vbtn-radio3">Radio 3</label>
-  </div>
-</div>
+<!-- Boosted mod: toggle buttons group don't support vertical variation -->
 
 ```html
 <div class="btn-group-vertical">

--- a/site/content/docs/5.0/components/dropdowns.md
+++ b/site/content/docs/5.0/components/dropdowns.md
@@ -68,7 +68,7 @@ We use this extra class to reduce the horizontal `padding` on either side of the
 <!-- Boosted mod: do not show button's variants for dropdown -->
 
 <div class="bd-example">
-  <div class="btn-group">
+  <div class="btn-group" role="group">
     <button type="button" class="btn btn-secondary">Secondary</button>
     <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
       <span class="visually-hidden">Toggle Dropdown</span>
@@ -85,7 +85,7 @@ We use this extra class to reduce the horizontal `padding` on either side of the
 
 ```html
 <!-- Example split button -->
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button type="button" class="btn btn-secondary">Action</button>
   <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
     <span class="visually-hidden">Toggle Dropdown</span>
@@ -105,7 +105,7 @@ We use this extra class to reduce the horizontal `padding` on either side of the
 Button dropdowns work with buttons of all sizes, including default and split dropdown buttons.
 
 <div class="bd-example">
-  <div class="btn-group">
+  <div class="btn-group" role="group">
     <button class="btn btn-secondary btn-lg dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
       Large button
     </button>
@@ -117,7 +117,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
       <li><a class="dropdown-item" href="#">Separated link</a></li>
     </ul>
   </div>
-  <div class="btn-group">
+  <div class="btn-group" role="group">
     <button type="button" class="btn btn-lg btn-secondary">Large split button</button>
     <button type="button" class="btn btn-lg btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
       <span class="visually-hidden">Toggle Dropdown</span>
@@ -134,7 +134,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
 
 ```html
 <!-- Large button groups (default and split) -->
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button class="btn btn-secondary btn-lg dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
     Large button
   </button>
@@ -142,7 +142,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
     ...
   </ul>
 </div>
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button class="btn btn-secondary btn-lg" type="button">
     Large split button
   </button>
@@ -156,7 +156,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
 ```
 
 <div class="bd-example">
-  <div class="btn-group">
+  <div class="btn-group" role="group">
     <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
       Small button
     </button>
@@ -168,7 +168,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
       <li><a class="dropdown-item" href="#">Separated link</a></li>
     </ul>
   </div>
-  <div class="btn-group">
+  <div class="btn-group" role="group">
     <button type="button" class="btn btn-sm btn-secondary">Small split button</button>
     <button type="button" class="btn btn-sm btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
       <span class="visually-hidden">Toggle Dropdown</span>
@@ -184,7 +184,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
 </div>
 
 ```html
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
     Small button
   </button>
@@ -192,7 +192,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
     ...
   </ul>
 </div>
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button class="btn btn-secondary btn-sm" type="button">
     Small split button
   </button>
@@ -393,7 +393,7 @@ Trigger dropdown menus at the left of the elements by adding `.dropstart` to the
       <li><a class="dropdown-item" href="#">Separated link</a></li>
     </ul>
   </div>
-  <div class="btn-group">
+  <div class="btn-group" role="group">
     <div class="btn-group dropstart" role="group">
       <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
         <span class="visually-hidden">Toggle Dropleft</span>
@@ -424,7 +424,7 @@ Trigger dropdown menus at the left of the elements by adding `.dropstart` to the
 </div>
 
 <!-- Split dropstart button -->
-<div class="btn-group">
+<div class="btn-group" role="group">
   <div class="btn-group dropstart" role="group">
     <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
       <span class="visually-hidden">Toggle Dropstart</span>
@@ -502,7 +502,7 @@ Add `.dropdown-menu-end` to a `.dropdown-menu` to right align the dropdown menu.
 {{< /callout >}}
 
 {{< example >}}
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
     Right-aligned menu example
   </button>
@@ -521,7 +521,7 @@ If you want to use responsive alignment, disable dynamic positioning by adding t
 To align **right** the dropdown menu with the given breakpoint or larger, add `.dropdown-menu{-sm|-md|-lg|-xl|-xxl}-end`.
 
 {{< example >}}
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
     Left-aligned but right aligned when large screen
   </button>
@@ -536,7 +536,7 @@ To align **right** the dropdown menu with the given breakpoint or larger, add `.
 To align **left** the dropdown menu with the given breakpoint or larger, add `.dropdown-menu-end` and `.dropdown-menu{-sm|-md|-lg|-xl|-xxl}-start`.
 
 {{< example >}}
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
     Right-aligned but left aligned when large screen
   </button>
@@ -555,7 +555,7 @@ Note that you don't need to add a `data-bs-display="static"` attribute to dropdo
 Taking most of the options shown above, here's a small kitchen sink demo of various dropdown alignment options in one place.
 
 {{< example >}}
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
     Dropdown
   </button>
@@ -566,7 +566,7 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </ul>
 </div>
 
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
     Right-aligned menu
   </button>
@@ -577,7 +577,7 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </ul>
 </div>
 
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
     Left-aligned, right-aligned lg
   </button>
@@ -588,7 +588,7 @@ Taking most of the options shown above, here's a small kitchen sink demo of vari
   </ul>
 </div>
 
-<div class="btn-group">
+<div class="btn-group" role="group">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
     Right-aligned, left-aligned lg
   </button>
@@ -745,7 +745,7 @@ Use `data-bs-offset` or `data-bs-reference` to change the location of the dropdo
       <li><a class="dropdown-item" href="#">Something else here</a></li>
     </ul>
   </div>
-  <div class="btn-group">
+  <div class="btn-group" role="group">
     <button type="button" class="btn btn-secondary">Reference</button>
     <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" id="dropdownMenuReference" data-bs-toggle="dropdown" aria-expanded="false" data-bs-reference="parent">
       <span class="visually-hidden">Toggle Dropdown</span>

--- a/site/content/docs/5.0/components/navbar.md
+++ b/site/content/docs/5.0/components/navbar.md
@@ -500,7 +500,7 @@ Here's an example navbar using `.navbar-nav-scroll` with `style="--bs-scroll-hei
       </ul>
       <form class="d-flex">
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-        <button class="btn btn-outline-success" type="submit">Search</button>
+        <button class="btn btn-success" type="submit">Search</button>
       </form>
     </div>
   </div>

--- a/site/content/docs/5.0/examples/album-rtl/index.html
+++ b/site/content/docs/5.0/examples/album-rtl/index.html
@@ -61,9 +61,9 @@ direction: rtl
             <div class="card-body">
               <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">رأي</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">تعديل</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">رأي</button>
+                  <button type="button" class="btn btn-sm btn-secondary">تعديل</button>
                 </div>
                 <small class="text-muted">9 دقائق</small>
               </div>
@@ -76,9 +76,9 @@ direction: rtl
             <div class="card-body">
               <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">رأي</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">تعديل</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">رأي</button>
+                  <button type="button" class="btn btn-sm btn-secondary">تعديل</button>
                 </div>
                 <small class="text-muted">9 دقائق</small>
               </div>
@@ -91,55 +91,9 @@ direction: rtl
             <div class="card-body">
               <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">رأي</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">تعديل</button>
-                </div>
-                <small class="text-muted">9 دقائق</small>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="col">
-          <div class="card shadow-sm">
-            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="ظفري" >}}
-            <div class="card-body">
-              <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
-              <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">رأي</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">تعديل</button>
-                </div>
-                <small class="text-muted">9 دقائق</small>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card shadow-sm">
-            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="ظفري" >}}
-            <div class="card-body">
-              <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
-              <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">رأي</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">تعديل</button>
-                </div>
-                <small class="text-muted">9 دقائق</small>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card shadow-sm">
-            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="ظفري" >}}
-            <div class="card-body">
-              <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
-              <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">رأي</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">تعديل</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">رأي</button>
+                  <button type="button" class="btn btn-sm btn-secondary">تعديل</button>
                 </div>
                 <small class="text-muted">9 دقائق</small>
               </div>
@@ -153,9 +107,9 @@ direction: rtl
             <div class="card-body">
               <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">رأي</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">تعديل</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">رأي</button>
+                  <button type="button" class="btn btn-sm btn-secondary">تعديل</button>
                 </div>
                 <small class="text-muted">9 دقائق</small>
               </div>
@@ -168,9 +122,9 @@ direction: rtl
             <div class="card-body">
               <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">رأي</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">تعديل</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">رأي</button>
+                  <button type="button" class="btn btn-sm btn-secondary">تعديل</button>
                 </div>
                 <small class="text-muted">9 دقائق</small>
               </div>
@@ -183,9 +137,55 @@ direction: rtl
             <div class="card-body">
               <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">رأي</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">تعديل</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">رأي</button>
+                  <button type="button" class="btn btn-sm btn-secondary">تعديل</button>
+                </div>
+                <small class="text-muted">9 دقائق</small>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card shadow-sm">
+            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="ظفري" >}}
+            <div class="card-body">
+              <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
+              <div class="d-flex justify-content-between align-items-center">
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">رأي</button>
+                  <button type="button" class="btn btn-sm btn-secondary">تعديل</button>
+                </div>
+                <small class="text-muted">9 دقائق</small>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card shadow-sm">
+            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="ظفري" >}}
+            <div class="card-body">
+              <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
+              <div class="d-flex justify-content-between align-items-center">
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">رأي</button>
+                  <button type="button" class="btn btn-sm btn-secondary">تعديل</button>
+                </div>
+                <small class="text-muted">9 دقائق</small>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card shadow-sm">
+            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="ظفري" >}}
+            <div class="card-body">
+              <p class="card-text">هذه بطاقة أوسع مع نص داعم أدناه كمقدمة طبيعية لمحتوى إضافي. هذا المحتوى أطول قليلاً.</p>
+              <div class="d-flex justify-content-between align-items-center">
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">رأي</button>
+                  <button type="button" class="btn btn-sm btn-secondary">تعديل</button>
                 </div>
                 <small class="text-muted">9 دقائق</small>
               </div>

--- a/site/content/docs/5.0/examples/album/index.html
+++ b/site/content/docs/5.0/examples/album/index.html
@@ -60,9 +60,9 @@ title: Album example
             <div class="card-body">
               <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">View</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">Edit</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">View</button>
+                  <button type="button" class="btn btn-sm btn-secondary">Edit</button>
                 </div>
                 <small class="text-muted">9 mins</small>
               </div>
@@ -75,9 +75,9 @@ title: Album example
             <div class="card-body">
               <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">View</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">Edit</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">View</button>
+                  <button type="button" class="btn btn-sm btn-secondary">Edit</button>
                 </div>
                 <small class="text-muted">9 mins</small>
               </div>
@@ -90,55 +90,9 @@ title: Album example
             <div class="card-body">
               <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">View</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">Edit</button>
-                </div>
-                <small class="text-muted">9 mins</small>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="col">
-          <div class="card shadow-sm">
-            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="Thumbnail" >}}
-            <div class="card-body">
-              <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-              <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">View</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">Edit</button>
-                </div>
-                <small class="text-muted">9 mins</small>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card shadow-sm">
-            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="Thumbnail" >}}
-            <div class="card-body">
-              <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-              <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">View</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">Edit</button>
-                </div>
-                <small class="text-muted">9 mins</small>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card shadow-sm">
-            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="Thumbnail" >}}
-            <div class="card-body">
-              <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-              <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">View</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">Edit</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">View</button>
+                  <button type="button" class="btn btn-sm btn-secondary">Edit</button>
                 </div>
                 <small class="text-muted">9 mins</small>
               </div>
@@ -152,9 +106,9 @@ title: Album example
             <div class="card-body">
               <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">View</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">Edit</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">View</button>
+                  <button type="button" class="btn btn-sm btn-secondary">Edit</button>
                 </div>
                 <small class="text-muted">9 mins</small>
               </div>
@@ -167,9 +121,9 @@ title: Album example
             <div class="card-body">
               <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">View</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">Edit</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">View</button>
+                  <button type="button" class="btn btn-sm btn-secondary">Edit</button>
                 </div>
                 <small class="text-muted">9 mins</small>
               </div>
@@ -182,9 +136,55 @@ title: Album example
             <div class="card-body">
               <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
               <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group">
-                  <button type="button" class="btn btn-sm btn-outline-secondary">View</button>
-                  <button type="button" class="btn btn-sm btn-outline-secondary">Edit</button>
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">View</button>
+                  <button type="button" class="btn btn-sm btn-secondary">Edit</button>
+                </div>
+                <small class="text-muted">9 mins</small>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card shadow-sm">
+            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="Thumbnail" >}}
+            <div class="card-body">
+              <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+              <div class="d-flex justify-content-between align-items-center">
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">View</button>
+                  <button type="button" class="btn btn-sm btn-secondary">Edit</button>
+                </div>
+                <small class="text-muted">9 mins</small>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card shadow-sm">
+            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="Thumbnail" >}}
+            <div class="card-body">
+              <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+              <div class="d-flex justify-content-between align-items-center">
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">View</button>
+                  <button type="button" class="btn btn-sm btn-secondary">Edit</button>
+                </div>
+                <small class="text-muted">9 mins</small>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card shadow-sm">
+            {{< placeholder width="100%" height="225" background="#55595c" color="#eceeef" class="card-img-top" text="Thumbnail" >}}
+            <div class="card-body">
+              <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+              <div class="d-flex justify-content-between align-items-center">
+                <div class="btn-group" role="group">
+                  <button type="button" class="btn btn-sm btn-secondary">View</button>
+                  <button type="button" class="btn btn-sm btn-secondary">Edit</button>
                 </div>
                 <small class="text-muted">9 mins</small>
               </div>

--- a/site/content/docs/5.0/examples/blog-rtl/index.html
+++ b/site/content/docs/5.0/examples/blog-rtl/index.html
@@ -21,7 +21,7 @@ include_js: false
         <a class="link-secondary" href="#" aria-label="بحث">
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="mx-3" role="img" viewBox="0 0 24 24"><title>بحث</title><circle cx="10.5" cy="10.5" r="7.5"/><path d="M21 21l-5.2-5.2"/></svg>
         </a>
-        <a class="btn btn-sm btn-outline-secondary" href="#">سجل</a>
+        <a class="btn btn-sm btn-secondary" href="#">سجل</a>
       </div>
     </div>
   </header>
@@ -150,8 +150,8 @@ include_js: false
       </article><!-- /.blog-post -->
 
       <nav class="blog-pagination" aria-label="Pagination">
-        <a class="btn btn-outline-primary" href="#">أقدم الوظائف</a>
-        <a class="btn btn-outline-secondary disabled" href="#" tabindex="-1" aria-disabled="true">أحدث المشاركات</a>
+        <a class="btn btn-primary" href="#">أقدم الوظائف</a>
+        <a class="btn btn-secondary disabled" href="#" tabindex="-1" aria-disabled="true">أحدث المشاركات</a>
       </nav>
 
     </div>

--- a/site/content/docs/5.0/examples/blog/index.html
+++ b/site/content/docs/5.0/examples/blog/index.html
@@ -20,7 +20,7 @@ include_js: false
         <a class="link-secondary" href="#" aria-label="Search">
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="mx-3" role="img" viewBox="0 0 24 24"><title>Search</title><circle cx="10.5" cy="10.5" r="7.5"/><path d="M21 21l-5.2-5.2"/></svg>
         </a>
-        <a class="btn btn-sm btn-outline-secondary" href="#">Sign up</a>
+        <a class="btn btn-sm btn-secondary" href="#">Sign up</a>
       </div>
     </div>
   </header>
@@ -148,8 +148,8 @@ include_js: false
       </article><!-- /.blog-post -->
 
       <nav class="blog-pagination" aria-label="Pagination">
-        <a class="btn btn-outline-primary" href="#">Older</a>
-        <a class="btn btn-outline-secondary disabled" href="#" tabindex="-1" aria-disabled="true">Newer</a>
+        <a class="btn btn-primary" href="#">Older</a>
+        <a class="btn btn-secondary disabled" href="#" tabindex="-1" aria-disabled="true">Newer</a>
       </nav>
 
     </div>

--- a/site/content/docs/5.0/examples/carousel-rtl/index.html
+++ b/site/content/docs/5.0/examples/carousel-rtl/index.html
@@ -27,7 +27,7 @@ extra_css:
         </ul>
         <form class="d-flex">
           <input class="form-control me-2" type="search" placeholder="بحث" aria-label="بحث">
-          <button class="btn btn-outline-success" type="submit">بحث</button>
+          <button class="btn btn-success" type="submit">بحث</button>
         </form>
       </div>
     </div>

--- a/site/content/docs/5.0/examples/carousel/index.html
+++ b/site/content/docs/5.0/examples/carousel/index.html
@@ -26,7 +26,7 @@ extra_css:
         </ul>
         <form class="d-flex">
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-          <button class="btn btn-outline-success" type="submit">Search</button>
+          <button class="btn btn-success" type="submit">Search</button>
         </form>
       </div>
     </div>

--- a/site/content/docs/5.0/examples/cheatsheet-rtl/index.html
+++ b/site/content/docs/5.0/examples/cheatsheet-rtl/index.html
@@ -498,7 +498,7 @@ direction: rtl
 
       <div>
         {{< example show_markup="false" class="mt-0" >}}
-        <div class="btn-group">
+        <div class="btn-group" role="group">
           <input type="radio" class="btn-check" name="options" id="option1" autocomplete="off" checked>
           <label class="btn btn-secondary" for="option1">التحقق</label>
 
@@ -513,7 +513,7 @@ direction: rtl
         </div>
         {{< /example >}}
         {{< example show_markup="false" >}}
-        <div class="btn-group">
+        <div class="btn-group" role="group">
           <input type="radio" class="btn-check" name="icons" id="option5" autocomplete="off" checked>
           <label class="btn btn-icon" for="option5">
             <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false">
@@ -538,7 +538,7 @@ direction: rtl
         </div>
         {{< /example >}}
         {{< example show_markup="false" >}}
-        <div class="btn-group">
+        <div class="btn-group" role="group">
           <input type="radio" class="btn-check" name="icons" id="option8" autocomplete="off" checked>
           <label class="btn btn-icon btn-no-outline" for="option8">
             <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false">
@@ -1103,7 +1103,7 @@ direction: rtl
         {{< /example >}}
 
         {{< example show_markup="false" >}}
-        <div class="btn-group">
+        <div class="btn-group" role="group">
           <button type="button" class="btn btn-secondary">Secondary</button>
           <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
             <span class="visually-hidden">تبديل القائمة المنسدلة</span>
@@ -1161,7 +1161,7 @@ direction: rtl
         {{< /example >}}
 
         {{< example show_markup="false" >}}
-        <div class="btn-group">
+        <div class="btn-group" role="group">
           <div class="dropdown">
             <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownRightMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
               قائمة بمحاذاة النهاية
@@ -1456,7 +1456,7 @@ direction: rtl
       </div>
 
       <div>
-      
+
         {{< example show_markup="false" >}}
         <button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" title="عنوان Popover" data-bs-content="وإليك بعض المحتويات الرائعة. إنه ممتع للغاية. حق؟">انقر لتبديل المنبثقة</button>
         {{< /example >}}

--- a/site/content/docs/5.0/examples/cheatsheet/index.html
+++ b/site/content/docs/5.0/examples/cheatsheet/index.html
@@ -494,7 +494,7 @@ extra_js:
 
       <div>
         {{< example show_markup="false" class="mt-0" >}}
-        <div class="btn-group">
+        <div class="btn-group" role="group">
           <input type="radio" class="btn-check" name="options" id="option1" autocomplete="off" checked>
           <label class="btn btn-secondary" for="option1">Checked</label>
 
@@ -509,7 +509,7 @@ extra_js:
         </div>
         {{< /example >}}
         {{< example show_markup="false" >}}
-        <div class="btn-group">
+        <div class="btn-group" role="group">
           <input type="radio" class="btn-check" name="icons" id="option5" autocomplete="off" checked>
           <label class="btn btn-icon" for="option5">
             <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false">
@@ -534,7 +534,7 @@ extra_js:
         </div>
         {{< /example >}}
         {{< example show_markup="false" >}}
-        <div class="btn-group">
+        <div class="btn-group" role="group">
           <input type="radio" class="btn-check" name="icons" id="option8" autocomplete="off" checked>
           <label class="btn btn-icon btn-no-outline" for="option8">
             <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false">
@@ -1097,7 +1097,7 @@ extra_js:
         {{< /example >}}
 
         {{< example show_markup="false" >}}
-        <div class="btn-group">
+        <div class="btn-group" role="group">
           <button type="button" class="btn btn-secondary">Secondary</button>
           <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
             <span class="visually-hidden">Toggle Dropdown</span>
@@ -1155,7 +1155,7 @@ extra_js:
         {{< /example >}}
 
         {{< example show_markup="false" >}}
-        <div class="btn-group">
+        <div class="btn-group" role="group">
           <div class="dropdown">
             <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownRightMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
               End-aligned menu

--- a/site/content/docs/5.0/examples/dashboard-rtl/index.html
+++ b/site/content/docs/5.0/examples/dashboard-rtl/index.html
@@ -108,10 +108,10 @@ extra_js:
         <h1 class="h2">لوحة القيادة</h1>
         <div class="btn-toolbar mb-2 mb-md-0">
           <div class="btn-group me-2">
-            <button type="button" class="btn btn-sm btn-outline-secondary">شارك</button>
-            <button type="button" class="btn btn-sm btn-outline-secondary">تصدير</button>
+            <button type="button" class="btn btn-sm btn-secondary">شارك</button>
+            <button type="button" class="btn btn-sm btn-secondary">تصدير</button>
           </div>
-          <button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle">
+          <button type="button" class="btn btn-sm btn-secondary dropdown-toggle">
             <span data-feather="calendar"></span>
             هذا الاسبوع
           </button>

--- a/site/content/docs/5.0/examples/dashboard/index.html
+++ b/site/content/docs/5.0/examples/dashboard/index.html
@@ -107,10 +107,10 @@ extra_js:
         <h1 class="h2">Dashboard</h1>
         <div class="btn-toolbar mb-2 mb-md-0">
           <div class="btn-group me-2">
-            <button type="button" class="btn btn-sm btn-outline-secondary">Share</button>
-            <button type="button" class="btn btn-sm btn-outline-secondary">Export</button>
+            <button type="button" class="btn btn-sm btn-secondary">Share</button>
+            <button type="button" class="btn btn-sm btn-secondary">Export</button>
           </div>
-          <button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle">
+          <button type="button" class="btn btn-sm btn-secondary dropdown-toggle">
             <span data-feather="calendar"></span>
             This week
           </button>

--- a/site/content/docs/5.0/examples/navbar-fixed/index.html
+++ b/site/content/docs/5.0/examples/navbar-fixed/index.html
@@ -25,7 +25,7 @@ extra_css:
       </ul>
       <form class="d-flex">
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-        <button class="btn btn-outline-success" type="submit">Search</button>
+        <button class="btn btn-success" type="submit">Search</button>
       </form>
     </div>
   </div>

--- a/site/content/docs/5.0/examples/navbar-static/index.html
+++ b/site/content/docs/5.0/examples/navbar-static/index.html
@@ -25,7 +25,7 @@ extra_css:
       </ul>
       <form class="d-flex">
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-        <button class="btn btn-outline-success" type="submit">Search</button>
+        <button class="btn btn-success" type="submit">Search</button>
       </form>
     </div>
   </div>

--- a/site/content/docs/5.0/examples/offcanvas/index.html
+++ b/site/content/docs/5.0/examples/offcanvas/index.html
@@ -40,7 +40,7 @@ body_class: "bg-light"
       </ul>
       <form class="d-flex">
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-        <button class="btn btn-outline-success" type="submit">Search</button>
+        <button class="btn btn-success" type="submit">Search</button>
       </form>
     </div>
   </div>

--- a/site/content/docs/5.0/examples/pricing/index.html
+++ b/site/content/docs/5.0/examples/pricing/index.html
@@ -14,7 +14,7 @@ include_js: false
     <a class="p-2 text-dark" href="#">Support</a>
     <a class="p-2 text-dark" href="#">Pricing</a>
   </nav>
-  <a class="btn btn-outline-primary" href="#">Sign up</a>
+  <a class="btn btn-primary" href="#">Sign up</a>
 </header>
 
 <main class="container">
@@ -37,7 +37,7 @@ include_js: false
           <li>Email support</li>
           <li>Help center access</li>
         </ul>
-        <button type="button" class="w-100 btn btn-lg btn-outline-primary">Sign up for free</button>
+        <button type="button" class="w-100 btn btn-lg btn-primary">Sign up for free</button>
       </div>
     </div>
     </div>

--- a/site/content/docs/5.0/examples/product/index.html
+++ b/site/content/docs/5.0/examples/product/index.html
@@ -25,7 +25,7 @@ extra_css:
     <div class="col-md-5 p-lg-5 mx-auto my-5">
       <h1 class="display-4 fw-normal">Punny headline</h1>
       <p class="lead fw-normal">And an even wittier subheading to boot. Jumpstart your marketing efforts with this example based on Apple’s marketing pages.</p>
-      <a class="btn btn-outline-secondary" href="#">Coming soon</a>
+      <a class="btn btn-secondary" href="#">Coming soon</a>
     </div>
     <div class="product-device shadow-sm d-none d-md-block"></div>
     <div class="product-device product-device-2 shadow-sm d-none d-md-block"></div>

--- a/site/content/docs/5.0/examples/starter-template/index.html
+++ b/site/content/docs/5.0/examples/starter-template/index.html
@@ -34,7 +34,7 @@ extra_css:
       </ul>
       <form class="d-flex">
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-        <button class="btn btn-outline-success" type="submit">Search</button>
+        <button class="btn btn-success" type="submit">Search</button>
       </form>
     </div>
   </div>

--- a/site/content/docs/5.0/examples/sticky-footer-navbar/index.html
+++ b/site/content/docs/5.0/examples/sticky-footer-navbar/index.html
@@ -29,7 +29,7 @@ body_class: "d-flex flex-column h-100"
         </ul>
         <form class="d-flex">
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-          <button class="btn btn-outline-success" type="submit">Search</button>
+          <button class="btn btn-success" type="submit">Search</button>
         </form>
       </div>
     </div>

--- a/site/content/docs/5.0/forms/checks-radios.md
+++ b/site/content/docs/5.0/forms/checks-radios.md
@@ -226,12 +226,12 @@ Visually, these checkbox toggle buttons are identical to the [button plugin togg
 
 ### Radio toggle buttons
 
-<!-- Boosted mod: our radio toggle buttons need a `.btn-group` wrapper. -->
+<!-- Boosted mod: our radio toggle buttons need a `.btn-group[role="group"]` wrapper. -->
 
 Boosted requires to group its radio toggle buttons in a [button group]({{< docsref "/components/button-group" >}}) to display properly.
 
 {{< example >}}
-<div class="btn-group">
+<div class="btn-group" role="group">
   <input type="radio" class="btn-check" name="options" id="option1" autocomplete="off" checked>
   <label class="btn btn-secondary" for="option1">Checked</label>
 
@@ -254,7 +254,7 @@ Boosted requires to group its radio toggle buttons in a [button group]({{< docsr
 Add [`.btn-icon`]({{< docsref "/components/buttons" >}}#icon-only) with an [embedded icon]({{< docsref "/extend/icons" >}}) to get consistent squared icon buttons working as toggle.
 
 {{< example >}}
-<div class="btn-group">
+<div class="btn-group" role="group">
   <input type="radio" class="btn-check" name="icons" id="option5" autocomplete="off" checked>
   <label class="btn btn-icon" for="option5">
     <svg width="1.25rem" height="1.25rem" fill="currentColor">
@@ -282,7 +282,7 @@ Add [`.btn-icon`]({{< docsref "/components/buttons" >}}#icon-only) with an [embe
 Drop borders using `.btn-no-outline`, too.
 
 {{< example >}}
-<div class="btn-group">
+<div class="btn-group" role="group">
   <input type="radio" class="btn-check" name="icons" id="option8" autocomplete="off" checked>
   <label class="btn btn-icon btn-no-outline" for="option8">
     <svg width="1.25rem" height="1.25rem" fill="currentColor">

--- a/site/content/docs/5.0/guidelines/buttons.md
+++ b/site/content/docs/5.0/guidelines/buttons.md
@@ -341,7 +341,7 @@ toc: true
       <tr>
         <th scope="row">Selected</th>
         <td>
-          <div class="btn-group">
+          <div class="btn-group" role="group">
             <input type="radio" class="btn-check" name="options" id="option1" autocomplete="off" checked>
             <label class="btn" for="option1">Day</label>
             <input type="radio" class="btn-check" name="options" id="option2" autocomplete="off">
@@ -351,7 +351,7 @@ toc: true
           </div>
         </td>
         <td>
-          <div class="btn-group">
+          <div class="btn-group" role="group">
             <input type="radio" class="btn-check" name="icons" id="option7" autocomplete="off" checked>
             <label class="btn btn-icon" for="option7">
               <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false">
@@ -376,7 +376,7 @@ toc: true
           </div>
         </td>
         <td>
-          <div class="btn-group">
+          <div class="btn-group" role="group">
             <input type="radio" class="btn-check" name="borderless" id="option13" autocomplete="off" checked>
             <label class="btn btn-icon btn-no-outline" for="option13">
               <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false">
@@ -404,7 +404,7 @@ toc: true
       <tr>
         <th scope="row">Disabled</th>
         <td>
-          <div class="btn-group">
+          <div class="btn-group" role="group">
             <input type="radio" class="btn-check" name="disabled-options" id="option4" autocomplete="off" disabled checked>
             <label class="btn" for="option4">Day</label>
             <input type="radio" class="btn-check" name="disabled-options" id="option5" autocomplete="off" disabled>
@@ -414,7 +414,7 @@ toc: true
           </div>
         </td>
         <td>
-          <div class="btn-group">
+          <div class="btn-group" role="group">
             <input type="radio" class="btn-check" name="disabled-icons" id="option10" autocomplete="off" disabled checked>
             <label class="btn btn-icon" for="option10">
               <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false">
@@ -439,7 +439,7 @@ toc: true
           </div>
         </td>
         <td>
-          <div class="btn-group">
+          <div class="btn-group" role="group">
             <input type="radio" class="btn-check" name="disabled-borderless" id="option16" autocomplete="off" disabled checked>
             <label class="btn btn-icon btn-no-outline" for="option16">
               <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false">
@@ -478,7 +478,7 @@ toc: true
     <h3 class="h6">Default</h3>
   </div>
   <div class="col-9">
-    <div class="btn-group">
+    <div class="btn-group" role="group">
       <button type="button" class="btn btn-secondary">Button</button>
       <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
         <span class="visually-hidden">Toggle Dropdown</span>
@@ -496,7 +496,7 @@ toc: true
     <h3 class="h6">Active</h3>
   </div>
   <div class="col-9">
-    <div class="btn-group">
+    <div class="btn-group" role="group">
       <button type="button" class="btn btn-secondary active">Button</button>
       <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
         <span class="visually-hidden">Toggle Dropdown</span>
@@ -514,7 +514,7 @@ toc: true
     <h3 class="h6">Disabled</h3>
   </div>
   <div class="col-9">
-    <div class="btn-group">
+    <div class="btn-group" role="group">
       <button type="button" class="btn btn-secondary" disabled>Button</button>
       <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false" disabled>
         <span class="visually-hidden">Toggle Dropdown</span>


### PR DESCRIPTION
Closes #642 

---

- dropped `.btn-outline-*` missed occurrences
- use split buttons instead of dropdowns in buttons-group docs for visual consistency
- add `role="group"` on `.btn-group` (to partially reverse to Bootstrap)

---

Preview: https://deploy-preview-645--boosted.netlify.app/docs/5.0/components/button-group/