### PR TITLE
fix(docs): some '[comment]: boosted mod' appear in the documentation

### DIFF
--- a/site/content/docs/4.6/components/alerts.md
+++ b/site/content/docs/4.6/components/alerts.md
@@ -93,7 +93,8 @@ Alerts come with a smaller variant: `.alert-sm`.
 
 Alerts can also contain additional HTML elements like headings, paragraphs and dividers.
 
-[comment]: #Boosted mod
+<!-- Boosted mod -->
+
 As of Boosted, it's recommended to wrap your additional content in a `<div>` to ensure proper alignment — and, for headings, to always use the `.alert-heading` class.
 
 {{< example >}}

--- a/site/content/docs/4.6/components/breadcrumb.md
+++ b/site/content/docs/4.6/components/breadcrumb.md
@@ -51,7 +51,8 @@ The separator can be removed by setting `$breadcrumb-divider` to `none`:
 $breadcrumb-divider: none;
 ```
 
-[comment]: #Boosted mod
+<!-- Boosted mod -->
+
 ## Backgrounds
 
 To customize breadcrumb, simply use our [background utilities]({{< docsref "/utilities/colors#background-color" >}}).

--- a/site/content/docs/4.6/components/pagination.md
+++ b/site/content/docs/4.6/components/pagination.md
@@ -12,7 +12,8 @@ We use a large block of connected links for our pagination, making links hard to
 
 In addition, as pages likely have more than one such navigation section, it's advisable to provide a descriptive `aria-label` for the `<nav>` to reflect its purpose. For example, if the pagination component is used to navigate between a set of search results, an appropriate label could be `aria-label="Search results pages"`.
 
-[comment]: boosted mod
+<!-- Boosted mod -->
+
 Make sure to use class `.has-label` on previous and next links as shown in the example below to use chevron + label layout.
 
 {{< example >}}
@@ -28,7 +29,8 @@ Make sure to use class `.has-label` on previous and next links as shown in the e
 
 ## Working with icons
 
-[comment]: boosted mod
+<!-- Boosted mod -->
+
 Looking to use an icon or symbol in place of text for some pagination links? Be sure to provide proper screen reader support with **visually hidden text** and a `title` attribute.
 
 {{< example >}}

--- a/site/content/docs/4.6/layout/grid.md
+++ b/site/content/docs/4.6/layout/grid.md
@@ -53,9 +53,8 @@ See how aspects of the Boosted grid system work across multiple devices with a h
 
 We include a security margin for container fluid. The goal is to fit exactly the desired content width at the targetted resolution.
  
-<!-- Boosted mod -->
+<!-- Boosted mod: Orange grid custom BP values -->
 
-[comment]: # Orange grid custom BP values
 <table class="table table-bordered table-striped">
   <thead>
     <tr>


### PR DESCRIPTION
In some parts of the 4.6 documentation, we can see the following string `[comment]: #Boosted mod ` that shouldn't be there. This PR transforms those strings into comments as seen in other markdown files in the project.

Example: https://boosted.orange.com/docs/4.6/components/alerts/#additional-content