### PR TITLE
fix dropdowns on `.bg-dark`

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -64,6 +64,12 @@
   border: $dropdown-border-width solid $dropdown-border-color;
   @include border-radius($dropdown-border-radius);
   @include box-shadow($dropdown-box-shadow);
+  // Boosted mod
+  .bg-dark & {
+    color: $dropdown-bg;
+    background-color: $dropdown-color;
+  }
+  // End mod
 }
 
 @each $breakpoint in map-keys($grid-breakpoints) {
@@ -177,6 +183,12 @@
     color: $dropdown-link-hover-color;
     text-decoration: none;
     @include gradient-bg($dropdown-link-hover-bg);
+    // Boosted mod
+    .bg-dark & {
+      color: $dropdown-link-hover-bg;
+      @include gradient-bg($dropdown-link-hover-color);
+    }
+    // End mod
   }
 
   &.active,
@@ -184,6 +196,12 @@
     color: $dropdown-link-active-color;
     text-decoration: none;
     @include gradient-bg($dropdown-link-active-bg);
+    // Boosted mod
+    .bg-dark & {
+      color: $dropdown-link-active-bg;
+      @include gradient-bg($dropdown-link-active-color);
+    }
+    // End mod
   }
 
   &.disabled,

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -14,7 +14,25 @@
   background-color: $dropdown-bg;
   border-color: $dropdown-border-color;
 
-  .bg-dark &:not(.dropdown-toggle-split),
+  .bg-dark &:not(.dropdown-toggle-split) {
+    border-color: $gray-700;
+
+    &:hover {
+      border-color: $dropdown-bg;
+    }
+  }
+
+  .show > &.btn {
+    background-color: $dropdown-bg;
+    border-color: $dropdown-color;
+
+    .bg-dark &:not(.dropdown-toggle-split) {
+      color: $dropdown-bg;
+      background-color: $dropdown-color;
+      border-color: $dropdown-bg;
+    }
+  }
+
   .navbar-dark &:not(.dropdown-toggle-split) {
     color: $dropdown-bg;
     background-color: $dropdown-color;
@@ -68,6 +86,7 @@
   .bg-dark & {
     color: $dropdown-bg;
     background-color: $dropdown-color;
+    border-color: $gray-700;
   }
   // End mod
 }

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -18,7 +18,7 @@
   .navbar-dark &:not(.dropdown-toggle-split) {
     color: $dropdown-bg;
     background-color: $dropdown-color;
-    border-color: $gray-700;
+    border-color: $dropdown-border-color-dark;
 
     &:hover {
       border-color: $dropdown-link-hover-color;
@@ -67,7 +67,7 @@
   // Boosted mod
   .bg-dark & {
     background-color: $dropdown-color;
-    border-color: $gray-700;
+    border-color: $dropdown-border-color-dark;
   }
   // End mod
 }

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -14,27 +14,7 @@
   background-color: $dropdown-bg;
   border-color: $dropdown-border-color;
 
-  .bg-dark &:not(.dropdown-toggle-split) {
-    &.btn-secondary.btn-inverse {
-      border-color: $gray-700;
-    }
-
-    &:hover {
-      border-color: $dropdown-bg;
-    }
-  }
-
-  .show > &.btn {
-    background-color: $dropdown-bg;
-    border-color: $dropdown-color;
-
-    .bg-dark &:not(.dropdown-toggle-split) {
-      color: $dropdown-bg;
-      background-color: $dropdown-color;
-      border-color: $dropdown-bg;
-    }
-  }
-
+  .bg-dark &:not(.dropdown-toggle-split),
   .navbar-dark &:not(.dropdown-toggle-split) {
     color: $dropdown-bg;
     background-color: $dropdown-color;
@@ -86,7 +66,6 @@
   @include box-shadow($dropdown-box-shadow);
   // Boosted mod
   .bg-dark & {
-    color: $dropdown-bg;
     background-color: $dropdown-color;
     border-color: $gray-700;
   }

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -15,7 +15,9 @@
   border-color: $dropdown-border-color;
 
   .bg-dark &:not(.dropdown-toggle-split) {
-    border-color: $gray-700;
+    &.btn-secondary.btn-inverse {
+      border-color: $gray-700;
+    }
 
     &:hover {
       border-color: $dropdown-bg;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -905,6 +905,7 @@ $dropdown-font-size:                $font-size-base !default;
 $dropdown-color:                    $body-color !default;
 $dropdown-bg:                       $white !default;
 $dropdown-border-color:             $gray-500 !default;
+$dropdown-border-color-dark:        $gray-700 !default; // Boosted mod
 $dropdown-border-radius:            $border-radius !default;
 $dropdown-border-width:             $border-width !default;
 $dropdown-inner-border-radius:      0 !default; // Boosted mod


### PR DESCRIPTION
Fix issue #657

Invert color of `.dropdown-menu`, and \.dropdown-menu-item` when hovered or active on `.bg-dark`  fix #657 