### PR TITLE
fix accordions padding / margin inconsistency 

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -307,7 +307,7 @@
     a {
       display: flex;
       width: add(100%, $card-accordion-spacer * 2);
-      padding: $card-spacer-y;
+      padding: $card-accordion-spacer;
       margin: 0 -#{$card-accordion-spacer};
       @include font-size($h3-font-size);
       line-height: $h3-line-height;
@@ -338,7 +338,7 @@
 
     .btn-sm {
       width: add(100%, $card-spacer-y * 2);
-      padding: map-get($spacers, 2);
+      padding: $card-spacer-y;
       margin: 0 -#{$card-spacer-y};
       @include font-size($h5-font-size);
       line-height: $h5-line-height;
@@ -347,7 +347,7 @@
 
     .btn-lg {
       width: add(100%, map-get($spacers, 3) * 2);
-      padding: $card-accordion-spacer;
+      padding: map-get($spacers, 3);
       margin: 0 -#{map-get($spacers, 3)};
       @include font-size($h2-font-size);
       line-height: $h2-line-height;
@@ -364,7 +364,7 @@
   }
 
   .card-body {
-    padding: 0 1.5rem 0 0;
+    padding: 0 1.5rem 0 .125rem;
     margin: 0 0 $spacer;
   }
 }

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -364,7 +364,7 @@
   }
 
   .card-body {
-    padding: 0 1.5rem 0 .125rem;
+    padding: 0 1.5rem 0 0;
     margin: 0 0 $spacer;
   }
 }

--- a/site/content/docs/4.6/components/collapse.md
+++ b/site/content/docs/4.6/components/collapse.md
@@ -133,7 +133,7 @@ You may use [buttons' sizes utilities]({{< docsref "/components/buttons#sizes" >
       <div class="card">
         <div class="card-header" id="headingOne-3">
           <h2 class="mb-0">
-            <button class="btn btn-link btn-sm" type="button" data-toggle="collapse" data-target="#collapseOne-3" aria-expanded="true" aria-controls="collapseOne-3">
+            <button class="btn btn-link btn-sm text-left" type="button" data-toggle="collapse" data-target="#collapseOne-3" aria-expanded="true" aria-controls="collapseOne-3">
               Collapsible Group Item #1
             </button>
           </h2>
@@ -147,7 +147,7 @@ You may use [buttons' sizes utilities]({{< docsref "/components/buttons#sizes" >
       <div class="card">
         <div class="card-header" id="headingTwo-3">
           <h2 class="mb-0">
-            <button class="btn btn-link btn-sm collapsed" type="button" data-toggle="collapse" data-target="#collapseTwo-3" aria-expanded="false" aria-controls="collapseTwo-3">
+            <button class="btn btn-link btn-sm text-left collapsed" type="button" data-toggle="collapse" data-target="#collapseTwo-3" aria-expanded="false" aria-controls="collapseTwo-3">
               Collapsible Group Item #2
             </button>
           </h2>
@@ -161,7 +161,7 @@ You may use [buttons' sizes utilities]({{< docsref "/components/buttons#sizes" >
       <div class="card">
         <div class="card-header" id="headingThree-3">
           <h2 class="mb-0">
-            <button class="btn btn-link btn-sm collapsed" type="button" data-toggle="collapse" data-target="#collapseThree-3" aria-expanded="false" aria-controls="collapseThree-3">
+            <button class="btn btn-link btn-sm text-left collapsed" type="button" data-toggle="collapse" data-target="#collapseThree-3" aria-expanded="false" aria-controls="collapseThree-3">
               Collapsible Group Item #3
             </button>
           </h2>
@@ -179,7 +179,7 @@ You may use [buttons' sizes utilities]({{< docsref "/components/buttons#sizes" >
       <div class="card">
         <div class="card-header" id="headingOne-4">
           <h2 class="mb-0">
-            <button class="btn btn-link btn-lg" type="button" data-toggle="collapse" data-target="#collapseOne-4" aria-expanded="true" aria-controls="collapseOne-4">
+            <button class="btn btn-link btn-lg text-left" type="button" data-toggle="collapse" data-target="#collapseOne-4" aria-expanded="true" aria-controls="collapseOne-4">
               Collapsible Group Item #1
             </button>
           </h2>
@@ -193,7 +193,7 @@ You may use [buttons' sizes utilities]({{< docsref "/components/buttons#sizes" >
       <div class="card">
         <div class="card-header" id="headingTwo-4">
           <h2 class="mb-0">
-            <button class="btn btn-link btn-lg collapsed" type="button" data-toggle="collapse" data-target="#collapseTwo-4" aria-expanded="false" aria-controls="collapseTwo-4">
+            <button class="btn btn-link btn-lg text-left collapsed" type="button" data-toggle="collapse" data-target="#collapseTwo-4" aria-expanded="false" aria-controls="collapseTwo-4">
               Collapsible Group Item #2
             </button>
           </h2>
@@ -207,7 +207,7 @@ You may use [buttons' sizes utilities]({{< docsref "/components/buttons#sizes" >
       <div class="card">
         <div class="card-header" id="headingThree-4">
           <h2 class="mb-0">
-            <button class="btn btn-link btn-lg collapsed" type="button" data-toggle="collapse" data-target="#collapseThree-4" aria-expanded="false" aria-controls="collapseThree-4">
+            <button class="btn btn-link btn-lg text-left collapsed" type="button" data-toggle="collapse" data-target="#collapseThree-4" aria-expanded="false" aria-controls="collapseThree-4">
               Collapsible Group Item #3
             </button>
           </h2>


### PR DESCRIPTION
add a padding to `.card-body` to keep content aligned with accordion title fix #656 