### PR TITLE
2 fixes in v5 documentation

### DIFF
--- a/site/content/docs/5.0/getting-started/rtl.md
+++ b/site/content/docs/5.0/getting-started/rtl.md
@@ -44,7 +44,7 @@ You can see the above requirements reflected in this modified RTL starter templa
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Preconnect to CDN: remove if not needed -->
-    <link href="https://cdn.jsdelivr.net" rel="preconnect" crossorigin="anonymous"
+    <link href="https://cdn.jsdelivr.net" rel="preconnect" crossorigin="anonymous">
 
     <!--
       Neue Helvetica is a trademark of Monotype Imaging Inc. registered in the U.S.

--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -9,7 +9,7 @@
     <main class="bd-main order-1">
       <div class="bd-intro pt-md-4 ps-lg-4">
         <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
-          <a class="d-inline-block mb-2 mb-md-0 fw-bold" href="{{ .Site.Params.repo }}/blob/main/site/content/{{ .Page.File.Path | replaceRE `\\` "/" }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">View on GitHub</a>
+          <a class="d-inline-block mb-2 mb-md-0 fw-bold" href="{{ .Site.Params.repo }}/blob/v5-dev/site/content/{{ .Page.File.Path | replaceRE `\\` "/" }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">View on GitHub</a>
           <h1 class="bd-title" id="content">{{ .Title | markdownify }}</h1>
         </div>
         <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>


### PR DESCRIPTION
- In https://boosted.orange.com/docs/5.0/about/overview/ for example, the 'View on GitHub' link goes to https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.0/about/overview.md (`main` branch) instead of https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/v5-dev/site/content/docs/5.0/about/overview.md (`v5-dev` branch)
- Add a missing character (`>`) in RTL starter template