### PR TITLE
docs(style): fix display of nested `<ul><li>`

### DIFF
--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -22,12 +22,12 @@
   > ol li {
     margin-bottom: .25rem;
 
-    // stylelint-disable selector-max-type
-    > ul {
+    // stylelint-disable selector-max-type, selector-max-compound-selectors
+    > p ~ ul {
       margin-top: -.5rem;
       margin-bottom: 1rem;
     }
-    // stylelint-enable selector-max-type
+    // stylelint-enable selector-max-type, selector-max-compound-selectors
   }
 
   // Override Bootstrap defaults


### PR DESCRIPTION
Coming from https://github.com/twbs/bootstrap/pull/34223

The result can be seen here: https://deploy-preview-693--boosted.netlify.app/docs/5.0/content/reboot/ and there: https://deploy-preview-693--boosted.netlify.app/docs/5.0/migration/