### PR TITLE
fix(#728): add rtlcss_hash into generate-sri.js in order to update th…

### DIFF
--- a/build/generate-sri.js
+++ b/build/generate-sri.js
@@ -32,6 +32,10 @@ const files = [
     configPropertyName: 'css_hash'
   },
   {
+    file: 'dist/css/boosted-rtl.min.css',
+    configPropertyName: 'rtlcss_hash'
+  },
+  {
     file: 'dist/css/orangeIcons.min.css',
     configPropertyName: 'iconcss_hash'
   },

--- a/config.yml
+++ b/config.yml
@@ -66,7 +66,7 @@ params:
     css:               "https://cdn.jsdelivr.net/npm/boosted@4.6.0/dist/css/boosted.min.css"
     css_hash:          "sha384-gqlCljYk+czxYG/OEUHPObOqdFdx4RFpXrAy+z6dbWdeD1ybOujFGA+lKVLnXtxx"
     rtlcss:            "https://cdn.jsdelivr.net/npm/boosted@4.6.0/dist/css/boosted-rtl.min.css"
-    rtlcss_hash:       "sha384-hJxq6SSxAKmw1m05Nn88CYZPfEVrgnLSYPW4/qrFYe5kT+Z2p/mpjaaoMUyvGXtk"
+    rtlcss_hash:       "sha384-mrKuu3shyS5p78eE2DQobpok1z4dU6isk/NpbjATicFx98Ca00JmSXXN0hl1xUJ6"
     iconcss:           "https://cdn.jsdelivr.net/npm/boosted@4.6.0/dist/css/orangeIcons.min.css"
     iconcss_hash:      "sha384-7/+XhgsfiKJOYwQYLCI6P8bz89YJEKD2GLErv3KrHbxQ4wPcJ9JcqVZVKAglgBJP"
     helveticacss:      "https://cdn.jsdelivr.net/npm/boosted@4.6.0/dist/css/orangeHelvetica.min.css"


### PR DESCRIPTION
…e integrity automatically

Closes #728 

* Fixed the _generate-sri.js_ file
* Run `npm run release-sri`

We obtain `rtlcss_hash:       "sha384-mrKuu3shyS5p78eE2DQobpok1z4dU6isk/NpbjATicFx98Ca00JmSXXN0hl1xUJ6` which is the same integrity than in https://www.srihash.org/.

![Capture d’écran 2021-07-08 à 16 04 31](https://user-images.githubusercontent.com/17381666/124935724-35aeb600-e006-11eb-8ac8-86c66a6cd997.png)
