### PR TITLE
Fix release 5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2685,8 +2685,8 @@
       "dev": true
     },
     "boxen": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.2.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.1.tgz",
       "integrity": "sha512-49VBlw+PrWEF51aCmy7QIteYPIFZxSpvqBdP/2itCPPlJ49kj9zg/XPRFrdkne2W+CfwXUls8exMvu1RysZpKA==",
       "dev": true,
       "requires": {
@@ -3224,7 +3224,7 @@
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "to-regex-range": "^5.0.2"
+            "to-regex-range": "^5.0.1"
           }
         },
         "glob-parent": {
@@ -3261,8 +3261,8 @@
           }
         },
         "to-regex-range": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.2.tgz",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
@@ -3490,8 +3490,8 @@
       }
     },
     "configstore": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.2.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
       "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
       "dev": true,
       "requires": {
@@ -5002,8 +5002,8 @@
       }
     },
     "event-target-shim": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.2.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true
     },
@@ -5019,7 +5019,7 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.2",
+        "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
@@ -5336,7 +5336,7 @@
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "to-regex-range": "^5.0.2"
+            "to-regex-range": "^5.0.1"
           }
         },
         "is-number": {
@@ -5356,8 +5356,8 @@
           }
         },
         "to-regex-range": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.2.tgz",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
@@ -7150,7 +7150,7 @@
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "to-regex-range": "^5.0.2"
+            "to-regex-range": "^5.0.1"
           }
         },
         "graceful-fs": {
@@ -7211,8 +7211,8 @@
           "dev": true
         },
         "to-regex-range": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.2.tgz",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
@@ -8288,7 +8288,7 @@
           "requires": {
             "boxen": "^4.2.0",
             "chalk": "^3.0.0",
-            "configstore": "^5.0.2",
+            "configstore": "^5.0.1",
             "has-yarn": "^2.1.0",
             "import-lazy": "^2.1.0",
             "is-ci": "^2.0.0",
@@ -8349,7 +8349,7 @@
       "dev": true,
       "requires": {
         "prepend-http": "^2.0.0",
-        "query-string": "^5.0.2",
+        "query-string": "^5.0.1",
         "sort-keys": "^2.0.0"
       },
       "dependencies": {
@@ -10147,8 +10147,8 @@
       }
     },
     "postcss-sorting": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.2.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
       "integrity": "sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==",
       "dev": true,
       "requires": {
@@ -12036,7 +12036,7 @@
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "to-regex-range": "^5.0.2"
+            "to-regex-range": "^5.0.1"
           }
         },
         "get-stdin": {
@@ -12166,8 +12166,8 @@
           }
         },
         "to-regex-range": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.2.tgz",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
@@ -12228,7 +12228,7 @@
       "requires": {
         "lodash": "^4.17.15",
         "postcss": "^7.0.31",
-        "postcss-sorting": "^5.0.2"
+        "postcss-sorting": "^5.0.1"
       },
       "dependencies": {
         "postcss": {
@@ -12658,7 +12658,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "type-check": {
@@ -12918,7 +12918,7 @@
       "requires": {
         "boxen": "^5.0.0",
         "chalk": "^4.1.0",
-        "configstore": "^5.0.2",
+        "configstore": "^5.0.1",
         "has-yarn": "^2.1.0",
         "import-lazy": "^2.1.0",
         "is-ci": "^2.0.0",


### PR DESCRIPTION
https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/714 was merged containing unwanted modifications in the `package-lock.json`: all 5.0.1 packages were bumped to 5.0.2 (not only the Boosted one).

I've preferred to create a new PR with a new commit to identify the problem rather than reverting the merge. Indeed, the next steps had not been done already: creating the tag, etc.

I've added a precision into the [DoD for release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/DoD-for-release) to avoid repeating the error in the future.