### PR TITLE
fix: update references of ff00dd to Nurovek

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Tell us about a bug you may have identified in Boosted.
 title: ''
 labels: bug
-assignees: ffoodd
+assignees: Nurovek
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for a new feature in Boosted.
 title: ''
 labels: feature
-assignees: ffoodd
+assignees: Nurovek
 
 ---
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       timezone: Europe/Athens
     open-pull-requests-limit: 10
     reviewers:
-      - ffoodd
+      - Nurovek
     labels:
       - dependencies
       - v5


### PR DESCRIPTION
PR to avoid those emails/notifications

```
Dependabot tried to add @ffoodd as a reviewer to this PR, but received the following error from GitHub:

POST https://api.github.com/repos/Orange-OpenSource/Orange-Boosted-Bootstrap/pulls/755/requested_reviewers: 422 - Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the Orange-OpenSource/Orange-Boosted-Bootstrap repository. // See: https://docs.github.com/rest/reference/pulls#request-reviewers-for-a-pull-request
```