### PR TITLE
docs(version): automatically retrieve latest version in version selector

### DIFF
--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -3,7 +3,7 @@
     <span class="d-none d-lg-inline">Boosted&nbsp;</span> v{{ .Site.Params.docs_version }}
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item active" aria-current="true" href="/docs/{{ .Site.Params.docs_version }}/">Latest (5.0.x)</a></li>
+    <li><a class="dropdown-item active" aria-current="true" href="/docs/{{ .Site.Params.docs_version }}/">Latest ({{ .Site.Params.docs_version }}.x)</a></li>
     <li><hr class="dropdown-divider m-0"></li>
     <li><a class="dropdown-item" href="https://boosted.orange.com/docs/4.6/">v4.6.x</a></li>
     <li><hr class="dropdown-divider m-0"></li>


### PR DESCRIPTION
To avoid having 5.0.x instead of 5.1.x in the version selector

![Capture d’écran 2021-09-06 à 16 57 51](https://user-images.githubusercontent.com/17381666/132235673-76987f3f-3abe-43fc-9c52-4ea8ea6f164f.png)

If you think it is the correct way of doing that, I could propose this fix to Bootstrap too