### PR TITLE
fix(doc): update broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,5 +205,5 @@ Thanks to [Netlify](https://www.netlify.com/), we are able to deploy pre-release
 
 Code and documentation copyright 2011-2021 the [Bootstrap Authors](https://github.com/twbs/bootstrap/graphs/contributors) and [Twitter, Inc.](https://twitter.com) Code released under the [MIT License](https://github.com/twbs/bootstrap/blob/main/LICENSE). Docs released under [Creative Commons](https://creativecommons.org/licenses/by/3.0/).
 
-Boosted code and documentation copyright 2015-2021 the [Boosted Authors](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/graphs/contributors) and [Orange SA.](https://orange.com) Code released under the [MIT License](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/LICENSE). Docs released under [Creative Commons](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/docs/LICENSE).
+Boosted code and documentation copyright 2015-2021 the [Boosted Authors](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/graphs/contributors) and [Orange SA.](https://orange.com) Code released under the [MIT License](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/LICENSE). Docs released under [Creative Commons](https://creativecommons.org/licenses/by/3.0/).
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
   <a href="https://boosted.orange.com/docs/5.1/"><strong>Visit Boosted</strong></a>
   <br>
   <br>
-  <a href="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/new?template=bug.md">Report bug</a>
+  <a href="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/new?template=bug_report.md&labels=bug">Report bug</a>
   ·
-  <a href="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/new?template=feature.md&labels=feature">Request feature</a>
+  <a href="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/new?template=feature_request.md&labels=feature">Request feature</a>
 </p>
 
 


### PR DESCRIPTION
Update the links to the issue templates and replace the Creative Commons license internal link by an external link to creativecommons.org.