### PR TITLE
chore(release): resync nuget/*.nuspec files with Bootstrap

### DIFF
--- a/nuget/boosted.nuspec
+++ b/nuget/boosted.nuspec
@@ -2,7 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>boosted</id>
-    <version>5.1.1</version>
+    <!-- pulled from package.json -->
+    <version>5</version>
     <title>Boosted CSS</title>
     <authors>The Boosted Authors, Orange SA</authors>
     <owners>Orange SA</owners>
@@ -15,13 +16,10 @@
     <license type="file">LICENSE.txt</license>
     <copyright>Copyright 2017-2021</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <dependencies>
-      <dependency id="popper.js" version="[1.16.0,2)" />
-    </dependencies>
     <tags>css mobile-first responsive front-end framework web bootstrap</tags>
     <contentFiles>
-        <files include="**/*" buildAction="Content" />
-      </contentFiles>
+      <files include="**/*" buildAction="Content" />
+    </contentFiles>
   </metadata>
   <files>
     <file src="LICENSE.txt" target="" />

--- a/nuget/boosted.sass.nuspec
+++ b/nuget/boosted.sass.nuspec
@@ -2,7 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>boosted.sass</id>
-    <version>5.1.1</version>
+    <!-- pulled from package.json -->
+    <version>5</version>
     <title>Boosted Sass</title>
     <authors>The Boosted Authors, Orange SA</authors>
     <owners>Orange SA</owners>
@@ -15,9 +16,6 @@
     <license type="file">LICENSE.txt</license>
     <copyright>Copyright 2017-2021</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <dependencies>
-      <dependency id="popper.js" version="[1.16.0,2)" />
-    </dependencies>
     <tags>css sass mobile-first responsive front-end framework web bootstrap Orange</tags>
     <contentFiles>
       <files include="**/*" buildAction="Content" />


### PR DESCRIPTION
It is not needed to modify everytime the content of _nuget/*.nuspec_ files with the new version of Boosted since the `nuget/MyGet.ps1` script uses the Boosted version within `package.json`.

Also did some modifications after having compared those files to the ones in Bootstrap.

This needs to be backported to v4.