### PR TITLE
chore(deps): bump mattermost/action-mattermost-notify from 1.0.0 to 1.1.0

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -14,7 +14,7 @@ jobs:
           echo "{\"text\": \"## Boosted ${{ github.event.release.tag_name }} :tada:\n[![${{ github.actor }}](https://github.com/${{ github.actor }}.png =10) **${{ github.actor }}**](https://github.com/${{ github.actor }}/) just released ${{ github.event.release.tag_name }}\n***\n[Changelog](${{ github.event.release.html_url }}) — [Download (zip)](${{ github.event.release.zipball_url }})\"}" > mattermost.json
 
       - name: Notify Mattermost
-        uses: mattermost/action-mattermost-notify@1.0.0
+        uses: mattermost/action-mattermost-notify@1.1.0
         if: github.event_name == 'release'
         env:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}


### PR DESCRIPTION
See https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/762 from Dependabot