### PR TITLE
fix(cookies): display cookie consent banner on Firefox

### DIFF
--- a/site/assets/js/tac.js
+++ b/site/assets/js/tac.js
@@ -59,7 +59,6 @@ if (typeof tarteaucitron !== 'undefined') {
     cookieslist: true,
     highPrivacy: false,
     showIcon: false,
-    handleBrowserDNTRequest: true,
     useExternalCss: true,
     mandatory: false
   })


### PR DESCRIPTION
On https://boosted.orange.com/ in incognito mode you won't see the cookie consent banner at the bottom of the screen.
This PR proposes to fix this issue.
In local mode, you can test it by opening http://localhost:9001 in incognito mode.
