### PR TITLE
Update Core Team members list and change automatic assignee

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-*.js    @Nurovek
-*.css   @Nurovek
-*.scss  @Nurovek
+*.js    @julien-deramond
+*.css   @julien-deramond
+*.scss  @julien-deramond

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       timezone: Europe/Athens
     open-pull-requests-limit: 10
     reviewers:
-      - Nurovek
+      - julien-deramond
     labels:
       - dependencies
       - v5

--- a/site/data/core-team.yml
+++ b/site/data/core-team.yml
@@ -9,3 +9,12 @@
 
 - name: Kevin Le Diouron
   user: Nurovek
+
+- name: Julien Déramond
+  user: julien-deramond
+
+- name: Yannick Cornaille
+  user: yannickcornaille
+
+- name: Isabelle Chanclou
+  user: isabellechanclou


### PR DESCRIPTION
* Add new members of the core team 🎉 
* Changing assignee for Dependabot and others since I'm responsible of the backlog/maintenance for the moment. We will see in the next weeks/months how to distribute the actions according to the fields of competence of everyone 😃  