### PR TITLE
Fix (button): vertical alignment of icons within buttons in Firefox (#773)

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -50,12 +50,13 @@
   [class*="svg-"],
   [class*="icon-"] {
     display: inline-block;
-    transform: translateY(1px);
   }
 
   &:not(.btn-icon) {
     [class*="svg-"],
     [class*="icon-"] {
+      position: relative;
+      top: 1px;
       margin-right: $border-width * 3;
     }
   }

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -50,6 +50,7 @@
   [class*="svg-"],
   [class*="icon-"] {
     display: inline-block;
+    transform: translateY(1px);
   }
 
   &:not(.btn-icon) {


### PR DESCRIPTION
Signed-off-by: Isabelle Chanclou <isabelle.chanclou@orange.com>

In Firefox, the button icon is situated 1px too high compared to the same in Chrome or design specifications.
It occurs only in the ::before container. Otherwise, the icon is of the exact same height of 20px.
I propose a go around solution (didn't found out an other one) that seems to solve the problem. Thanks for checking if it is acceptable or not.