### PR TITLE
GRID - allow fixed unit in container-fluid-margin-widths

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -43,7 +43,7 @@
 @mixin make-container-fluid-widths() {
   @each $breakpoint, $container-margin in $container-fluid-margin-widths {
     @include media-breakpoint-up($breakpoint) {
-      max-width: #{100% - ($container-margin * 2)};
+      max-width: subtract(100%, ($container-margin * 2));
     }
   }
   @include deprecate("The `make-container-fluid-widths` mixin", "v4.6.0", "v5");


### PR DESCRIPTION
feat(grid): use `subtract` function to calculate max-width of fluid container to allow fixed unit in `container-fluid-margin-widths` definition