### PR TITLE
Quantity Selector

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./dist/css/boosted-reboot.min.css",
-      "maxSize": "3.3 kB"
+      "maxSize": "3.31 kB"
     },
     {
       "path": "./dist/css/boosted-utilities.css",
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "29.3 kB"
+      "maxSize": "29.74 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",
-      "maxSize": "27.0 kB"
+      "maxSize": "27.46 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/js/boosted.bundle.min.js",
-      "maxSize": "23.85 kB"
+      "maxSize": "24.02 kB"
     },
     {
       "path": "./dist/js/boosted.esm.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -58,7 +58,7 @@
     },
     {
       "path": "./dist/js/boosted.min.js",
-      "maxSize": "17.24 kB"
+      "maxSize": "17.25 kB"
     }
   ],
   "ci": {

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,15 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "29.23 kB"
+      "maxSize": "29.3 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",
+<<<<<<< HEAD
       "maxSize": "26.85 kB"
+=======
+      "maxSize": "27.0 kB"
+>>>>>>> 830d6a464 (Fix bundlewatch conflict)
     },
     {
       "path": "./dist/js/boosted.bundle.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/js/boosted.bundle.min.js",
-      "maxSize": "23.85 kB"
+      "maxSize": "24.02 kB"
     },
     {
       "path": "./dist/js/boosted.esm.js",
@@ -46,15 +46,15 @@
     },
     {
       "path": "./dist/js/boosted.esm.min.js",
-      "maxSize": "19.3 kB"
+      "maxSize": "19.49 kB"
     },
     {
       "path": "./dist/js/boosted.js",
-      "maxSize": "32.0 kB"
+      "maxSize": "32.04 kB"
     },
     {
       "path": "./dist/js/boosted.min.js",
-      "maxSize": "17.1 kB"
+      "maxSize": "17.24 kB"
     }
   ],
   "ci": {

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "29.3 kB"
+      "maxSize": "29.32 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "29.4 kB"
+      "maxSize": "29.23 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",
-      "maxSize": "27.1 kB"
+      "maxSize": "26.85 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.js",
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/js/boosted.bundle.min.js",
-      "maxSize": "23.8 kB"
+      "maxSize": "23.85 kB"
     },
     {
       "path": "./dist/js/boosted.esm.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/js/boosted.bundle.min.js",
-      "maxSize": "24.05 kB"
+      "maxSize": "23.85 kB"
     },
     {
       "path": "./dist/js/boosted.esm.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -42,19 +42,19 @@
     },
     {
       "path": "./dist/js/boosted.bundle.min.js",
-      "maxSize": "24.05 kB"
+      "maxSize": "24.1 kB"
     },
     {
       "path": "./dist/js/boosted.esm.js",
-      "maxSize": "31.25 kB"
+      "maxSize": "31.3 kB"
     },
     {
       "path": "./dist/js/boosted.esm.min.js",
-      "maxSize": "19.49 kB"
+      "maxSize": "19.5 kB"
     },
     {
       "path": "./dist/js/boosted.js",
-      "maxSize": "32.04 kB"
+      "maxSize": "32.1 kB"
     },
     {
       "path": "./dist/js/boosted.min.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/js/boosted.bundle.min.js",
-      "maxSize": "24.02 kB"
+      "maxSize": "24.05 kB"
     },
     {
       "path": "./dist/js/boosted.esm.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,15 +26,11 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "29.32 kB"
+      "maxSize": "29.3 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",
-<<<<<<< HEAD
-      "maxSize": "26.85 kB"
-=======
       "maxSize": "27.0 kB"
->>>>>>> 830d6a464 (Fix bundlewatch conflict)
     },
     {
       "path": "./dist/js/boosted.bundle.js",
@@ -42,23 +38,23 @@
     },
     {
       "path": "./dist/js/boosted.bundle.min.js",
-      "maxSize": "24.1 kB"
+      "maxSize": "24.05 kB"
     },
     {
       "path": "./dist/js/boosted.esm.js",
-      "maxSize": "31.3 kB"
+      "maxSize": "31.25 kB"
     },
     {
       "path": "./dist/js/boosted.esm.min.js",
-      "maxSize": "19.5 kB"
+      "maxSize": "19.49 kB"
     },
     {
       "path": "./dist/js/boosted.js",
-      "maxSize": "32.1 kB"
+      "maxSize": "32.04 kB"
     },
     {
       "path": "./dist/js/boosted.min.js",
-      "maxSize": "17.25 kB"
+      "maxSize": "17.24 kB"
     }
   ],
   "ci": {

--- a/js/index.esm.js
+++ b/js/index.esm.js
@@ -15,6 +15,7 @@ export { default as Dropdown } from './src/dropdown'
 export { default as Modal } from './src/modal'
 export { default as Offcanvas } from './src/offcanvas'
 export { default as Popover } from './src/popover'
+export { default as QuantitySelector } from './src/quantity-selector' // Boosted mod
 export { default as ScrollSpy } from './src/scrollspy'
 export { default as Tab } from './src/tab'
 export { default as Toast } from './src/toast'

--- a/js/index.umd.js
+++ b/js/index.umd.js
@@ -13,6 +13,7 @@ import Dropdown from './src/dropdown'
 import Modal from './src/modal'
 import Offcanvas from './src/offcanvas'
 import Popover from './src/popover'
+import QuantitySelector from './src/quantity-selector' // Boosted mod
 import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
@@ -28,6 +29,7 @@ export default {
   Modal,
   Offcanvas,
   Popover,
+  QuantitySelector, // Boosted mod
   ScrollSpy,
   Tab,
   Toast,

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -92,7 +92,7 @@ class QuantitySelector extends BaseComponent {
     counterInput.dispatchEvent(eventChange)
   }
 
-  static ValueChange(event) {
+  static CheckIfDisabledOnChange(event) {
     const parent = event.target.closest(SELECTOR_INPUT_GROUP)
     const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
     const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)
@@ -140,7 +140,7 @@ EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
     QuantitySelector.getOrCreateInstance(el).ValueOnLoad(el)
   }
 })
-EventHandler.on(document, EVENT_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT, QuantitySelector.ValueChange)
+EventHandler.on(document, EVENT_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT, QuantitySelector.CheckIfDisabledOnChange)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_UP_BUTTON, QuantitySelector.StepUp)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_DOWN_BUTTON, QuantitySelector.StepDown)
 

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -41,95 +41,95 @@ class QuantitySelector extends BaseComponent {
   // Static
   static StepUp(event) {
     event.preventDefault()
-    const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
-    const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
-    const BTN_UP = PARENT.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const BTN_DOWN = PARENT.querySelector(SELECTOR_STEP_DOWN_BUTTON)
+    const parent = event.target.closest(SELECTOR_INPUT_GROUP)
+    const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
+    const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)
+    const btnDown = parent.querySelector(SELECTOR_STEP_DOWN_BUTTON)
 
-    const MAX = COUNTER_INPUT.getAttribute('max')
-    const STEP = Number(COUNTER_INPUT.getAttribute('step'))
-    const ROUND = Number(COUNTER_INPUT.getAttribute('data-bs-round'))
+    const max = counterInput.getAttribute('max')
+    const step = Number(counterInput.getAttribute('step'))
+    const round = Number(counterInput.getAttribute('data-bs-round'))
 
-    if (Number(COUNTER_INPUT.value) < MAX) {
-      COUNTER_INPUT.value = (Number(COUNTER_INPUT.value) + STEP).toFixed(ROUND).toString()
-    } else if (Number(COUNTER_INPUT.value) + STEP > MAX) {
-      BTN_UP.setAttribute('disabled', '')
+    if (Number(counterInput.value) < max) {
+      counterInput.value = (Number(counterInput.value) + step).toFixed(round).toString()
+    } else if (Number(counterInput.value) + step > max) {
+      btnUp.setAttribute('disabled', '')
     }
 
-    if (BTN_DOWN.hasAttribute('disabled', '')) {
-      BTN_DOWN.removeAttribute('disabled', '')
+    if (btnDown.hasAttribute('disabled', '')) {
+      btnDown.removeAttribute('disabled', '')
     }
 
-    if (Number(COUNTER_INPUT.value) + STEP > MAX) {
+    if (Number(counterInput.value) + step > max) {
+      btnUp.setAttribute('disabled', '')
+    }
+  }
+
+  // Public
+  ValueOnLoad(element) {
+    const counterInput = element.querySelector(SELECTOR_COUNTER_INPUT)
+    const BTN_UP = element.querySelector(SELECTOR_STEP_UP_BUTTON)
+    const BTN_DOWN = element.querySelector(SELECTOR_STEP_DOWN_BUTTON)
+
+    const MIN = counterInput.getAttribute('min')
+    const MAX = counterInput.getAttribute('max')
+    const STEP = Number(counterInput.getAttribute('step'))
+
+    if (Number(counterInput.value) - STEP < MIN) {
+      BTN_DOWN.setAttribute('disabled', '')
+    }
+
+    if (Number(counterInput.value) + STEP > MAX) {
       BTN_UP.setAttribute('disabled', '')
     }
   }
 
   static StepDown(event) {
     event.preventDefault()
-    const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
-    const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
-    const BTN_UP = PARENT.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const BTN_DOWN = PARENT.querySelector(SELECTOR_STEP_DOWN_BUTTON)
+    const parent = event.target.closest(SELECTOR_INPUT_GROUP)
+    const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
+    const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)
+    const btnDown = parent.querySelector(SELECTOR_STEP_DOWN_BUTTON)
 
-    const MIN = COUNTER_INPUT.getAttribute('min')
-    const STEP = Number(COUNTER_INPUT.getAttribute('step'))
-    const ROUND = Number(COUNTER_INPUT.getAttribute('data-bs-round'))
+    const min = counterInput.getAttribute('min')
+    const step = Number(counterInput.getAttribute('step'))
+    const round = Number(counterInput.getAttribute('data-bs-round'))
 
-    if (Number(COUNTER_INPUT.value) > MIN) {
-      COUNTER_INPUT.value = (Number(COUNTER_INPUT.value) - STEP).toFixed(ROUND).toString()
-    } else if (Number(COUNTER_INPUT.value) + STEP < MIN) {
-      BTN_DOWN.setAttribute('disabled', '')
+    if (Number(counterInput.value) > min) {
+      counterInput.value = (Number(counterInput.value) - step).toFixed(round).toString()
+    } else if (Number(counterInput.value) + step < min) {
+      btnDown.setAttribute('disabled', '')
     }
 
-    if (BTN_UP.hasAttribute('disabled', '')) {
-      BTN_UP.removeAttribute('disabled', '')
+    if (btnUp.hasAttribute('disabled', '')) {
+      btnUp.removeAttribute('disabled', '')
     }
 
-    if (Number(COUNTER_INPUT.value) - STEP < MIN) {
-      BTN_DOWN.setAttribute('disabled', '')
+    if (Number(counterInput.value) - step < min) {
+      btnDown.setAttribute('disabled', '')
     }
   }
 
   static ValueChange(event) {
     event.preventDefault()
-    const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
-    const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
-    const BTN_UP = PARENT.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const BTN_DOWN = PARENT.querySelector(SELECTOR_STEP_DOWN_BUTTON)
+    const parent = event.target.closest(SELECTOR_INPUT_GROUP)
+    const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
+    const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)
+    const btnDown = parent.querySelector(SELECTOR_STEP_DOWN_BUTTON)
 
-    const MIN = COUNTER_INPUT.getAttribute('min')
-    const MAX = COUNTER_INPUT.getAttribute('max')
-    const STEP = Number(COUNTER_INPUT.getAttribute('step'))
+    const min = counterInput.getAttribute('min')
+    const max = counterInput.getAttribute('max')
+    const STEP = Number(counterInput.getAttribute('step'))
 
-    BTN_UP.removeAttribute('disabled', '')
-    BTN_DOWN.removeAttribute('disabled', '')
+    btnUp.removeAttribute('disabled', '')
+    btnDown.removeAttribute('disabled', '')
 
-    if (Number(COUNTER_INPUT.value) - STEP < MIN) {
-      BTN_DOWN.setAttribute('disabled', '')
+    if (Number(counterInput.value) - STEP < min) {
+      btnDown.setAttribute('disabled', '')
     }
 
-    if (Number(COUNTER_INPUT.value) + STEP > MAX) {
-      BTN_UP.setAttribute('disabled', '')
-    }
-  }
-
-  // Public
-  ValueOnLoad(el) {
-    const COUNTER_INPUT = el.querySelector(SELECTOR_COUNTER_INPUT)
-    const BTN_UP = el.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const BTN_DOWN = el.querySelector(SELECTOR_STEP_DOWN_BUTTON)
-
-    const MIN = COUNTER_INPUT.getAttribute('min')
-    const MAX = COUNTER_INPUT.getAttribute('max')
-    const STEP = Number(COUNTER_INPUT.getAttribute('step'))
-
-    if (Number(COUNTER_INPUT.value) - STEP < MIN) {
-      BTN_DOWN.setAttribute('disabled', '')
-    }
-
-    if (Number(COUNTER_INPUT.value) + STEP > MAX) {
-      BTN_UP.setAttribute('disabled', '')
+    if (Number(counterInput.value) + STEP > max) {
+      btnUp.setAttribute('disabled', '')
     }
   }
 }

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -1,0 +1,79 @@
+/**
+ * --------------------------------------------------------------------------
+ * Boosted (v5.1.3): quantity-selector.js
+ * Licensed under MIT (https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/LICENSE)
+ * --------------------------------------------------------------------------
+ */
+
+import { defineJQueryPlugin } from './util/index'
+import EventHandler from './dom/event-handler'
+import BaseComponent from './base-component'
+
+/**
+ * Constants
+ */
+
+const NAME = 'quantityselector'
+const DATA_KEY = 'bs.quantityselector'
+const EVENT_KEY = `.${DATA_KEY}`
+const DATA_API_KEY = '.data-api'
+const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
+const SELECTOR_STEP_UP_BUTTON = '[data-bs-step="up"]'
+const SELECTOR_STEP_DOWN_BUTTON = '[data-bs-step="down"]'
+const SELECTOR_COUNTER_INPUT = '[data-bs-step="counter"]'
+const SELECTOR_INPUT_GROUP = '.input-group'
+
+/**
+ * Class definition
+ */
+
+class QuantitySelector extends BaseComponent {
+  // Getters
+  static get NAME() {
+    return NAME
+  }
+
+  // Public
+  static StepUp(event) {
+    event.preventDefault()
+    const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
+    const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
+
+    const MAX = COUNTER_INPUT.getAttribute('max')
+    const STEP = Number(COUNTER_INPUT.getAttribute('step'))
+    const ROUND = Number(COUNTER_INPUT.getAttribute('data-bs-round'))
+
+    if (Number(COUNTER_INPUT.value) < MAX) {
+      COUNTER_INPUT.value = (Number(COUNTER_INPUT.value) + STEP).toFixed(ROUND).toString()
+    }
+  }
+
+  static StepDown(event) {
+    event.preventDefault()
+    const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
+    const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
+
+    const MIN = COUNTER_INPUT.getAttribute('min')
+    const STEP = Number(COUNTER_INPUT.getAttribute('step'))
+    const ROUND = Number(COUNTER_INPUT.getAttribute('data-bs-round'))
+
+    if (Number(COUNTER_INPUT.value) > MIN) {
+      COUNTER_INPUT.value = (Number(COUNTER_INPUT.value) - STEP).toFixed(ROUND).toString()
+    }
+  }
+}
+
+/**
+ * Data API implementation
+ */
+
+EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_UP_BUTTON, QuantitySelector.StepUp)
+EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_DOWN_BUTTON, QuantitySelector.StepDown)
+
+/**
+ * jQuery
+ */
+
+defineJQueryPlugin(QuantitySelector)
+
+export default QuantitySelector

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -114,7 +114,7 @@ class QuantitySelector extends BaseComponent {
     }
   }
 
-  // Static
+  // Public
   ValueOnLoad(el) {
     const COUNTER_INPUT = el.querySelector(SELECTOR_COUNTER_INPUT)
     const BTN_UP = el.querySelector(SELECTOR_STEP_UP_BUTTON)

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -8,7 +8,6 @@
 import { defineJQueryPlugin } from './util/index'
 import EventHandler from './dom/event-handler'
 import BaseComponent from './base-component'
-import SelectorEngine from './dom/selector-engine'
 
 /**
  * Constants
@@ -18,11 +17,7 @@ const NAME = 'quantityselector'
 const DATA_KEY = 'bs.quantityselector'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
-
-const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
-const EVENT_CHANGE_DATA_API = `change${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
-
 const SELECTOR_STEP_UP_BUTTON = '[data-bs-step="up"]'
 const SELECTOR_STEP_DOWN_BUTTON = '[data-bs-step="down"]'
 const SELECTOR_COUNTER_INPUT = '[data-bs-step="counter"]'
@@ -38,13 +33,11 @@ class QuantitySelector extends BaseComponent {
     return NAME
   }
 
-  // Static
+  // Public
   static StepUp(event) {
     event.preventDefault()
     const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
     const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
-    const BTN_UP = PARENT.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const BTN_DOWN = PARENT.querySelector(SELECTOR_STEP_DOWN_BUTTON)
 
     const MAX = COUNTER_INPUT.getAttribute('max')
     const STEP = Number(COUNTER_INPUT.getAttribute('step'))
@@ -52,16 +45,6 @@ class QuantitySelector extends BaseComponent {
 
     if (Number(COUNTER_INPUT.value) < MAX) {
       COUNTER_INPUT.value = (Number(COUNTER_INPUT.value) + STEP).toFixed(ROUND).toString()
-    } else if (Number(COUNTER_INPUT.value) + STEP > MAX) {
-      BTN_UP.setAttribute('disabled', '')
-    }
-
-    if (BTN_DOWN.hasAttribute('disabled', '')) {
-      BTN_DOWN.removeAttribute('disabled', '')
-    }
-
-    if (Number(COUNTER_INPUT.value) + STEP > MAX) {
-      BTN_UP.setAttribute('disabled', '')
     }
   }
 
@@ -69,8 +52,6 @@ class QuantitySelector extends BaseComponent {
     event.preventDefault()
     const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
     const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
-    const BTN_UP = PARENT.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const BTN_DOWN = PARENT.querySelector(SELECTOR_STEP_DOWN_BUTTON)
 
     const MIN = COUNTER_INPUT.getAttribute('min')
     const STEP = Number(COUNTER_INPUT.getAttribute('step'))
@@ -78,58 +59,6 @@ class QuantitySelector extends BaseComponent {
 
     if (Number(COUNTER_INPUT.value) > MIN) {
       COUNTER_INPUT.value = (Number(COUNTER_INPUT.value) - STEP).toFixed(ROUND).toString()
-    } else if (Number(COUNTER_INPUT.value) + STEP < MIN) {
-      BTN_DOWN.setAttribute('disabled', '')
-    }
-
-    if (BTN_UP.hasAttribute('disabled', '')) {
-      BTN_UP.removeAttribute('disabled', '')
-    }
-
-    if (Number(COUNTER_INPUT.value) - STEP < MIN) {
-      BTN_DOWN.setAttribute('disabled', '')
-    }
-  }
-
-  static ValueChange(event) {
-    event.preventDefault()
-    const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
-    const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
-    const BTN_UP = PARENT.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const BTN_DOWN = PARENT.querySelector(SELECTOR_STEP_DOWN_BUTTON)
-
-    const MIN = COUNTER_INPUT.getAttribute('min')
-    const MAX = COUNTER_INPUT.getAttribute('max')
-    const STEP = Number(COUNTER_INPUT.getAttribute('step'))
-
-    BTN_UP.removeAttribute('disabled', '')
-    BTN_DOWN.removeAttribute('disabled', '')
-
-    if (Number(COUNTER_INPUT.value) - STEP < MIN) {
-      BTN_DOWN.setAttribute('disabled', '')
-    }
-
-    if (Number(COUNTER_INPUT.value) + STEP > MAX) {
-      BTN_UP.setAttribute('disabled', '')
-    }
-  }
-
-  // Public
-  ValueOnLoad(el) {
-    const COUNTER_INPUT = el.querySelector(SELECTOR_COUNTER_INPUT)
-    const BTN_UP = el.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const BTN_DOWN = el.querySelector(SELECTOR_STEP_DOWN_BUTTON)
-
-    const MIN = COUNTER_INPUT.getAttribute('min')
-    const MAX = COUNTER_INPUT.getAttribute('max')
-    const STEP = Number(COUNTER_INPUT.getAttribute('step'))
-
-    if (Number(COUNTER_INPUT.value) - STEP < MIN) {
-      BTN_DOWN.setAttribute('disabled', '')
-    }
-
-    if (Number(COUNTER_INPUT.value) + STEP > MAX) {
-      BTN_UP.setAttribute('disabled', '')
     }
   }
 }
@@ -138,12 +67,6 @@ class QuantitySelector extends BaseComponent {
  * Data API implementation
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
-  for (const el of SelectorEngine.find(SELECTOR_INPUT_GROUP)) {
-    QuantitySelector.getOrCreateInstance(el).ValueOnLoad(el)
-  }
-})
-EventHandler.on(document, EVENT_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT, QuantitySelector.ValueChange)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_UP_BUTTON, QuantitySelector.StepUp)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_DOWN_BUTTON, QuantitySelector.StepDown)
 

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -38,6 +38,25 @@ class QuantitySelector extends BaseComponent {
     return NAME
   }
 
+  // Public
+  ValueOnLoad(element) {
+    const counterInput = element.querySelector(SELECTOR_COUNTER_INPUT)
+    const btnUp = element.querySelector(SELECTOR_STEP_UP_BUTTON)
+    const btnDown = element.querySelector(SELECTOR_STEP_DOWN_BUTTON)
+
+    const min = counterInput.getAttribute('min')
+    const max = counterInput.getAttribute('max')
+    const step = Number(counterInput.getAttribute('step'))
+
+    if (Number(counterInput.value) - step < min) {
+      btnDown.setAttribute('disabled', '')
+    }
+
+    if (Number(counterInput.value) + step > max) {
+      btnUp.setAttribute('disabled', '')
+    }
+  }
+
   // Static
   static StepUp(event) {
     event.preventDefault()
@@ -62,25 +81,6 @@ class QuantitySelector extends BaseComponent {
 
     if (Number(counterInput.value) + step > max) {
       btnUp.setAttribute('disabled', '')
-    }
-  }
-
-  // Public
-  ValueOnLoad(element) {
-    const counterInput = element.querySelector(SELECTOR_COUNTER_INPUT)
-    const BTN_UP = element.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const BTN_DOWN = element.querySelector(SELECTOR_STEP_DOWN_BUTTON)
-
-    const MIN = counterInput.getAttribute('min')
-    const MAX = counterInput.getAttribute('max')
-    const STEP = Number(counterInput.getAttribute('step'))
-
-    if (Number(counterInput.value) - STEP < MIN) {
-      BTN_DOWN.setAttribute('disabled', '')
-    }
-
-    if (Number(counterInput.value) + STEP > MAX) {
-      BTN_UP.setAttribute('disabled', '')
     }
   }
 
@@ -119,16 +119,16 @@ class QuantitySelector extends BaseComponent {
 
     const min = counterInput.getAttribute('min')
     const max = counterInput.getAttribute('max')
-    const STEP = Number(counterInput.getAttribute('step'))
+    const step = Number(counterInput.getAttribute('step'))
 
     btnUp.removeAttribute('disabled', '')
     btnDown.removeAttribute('disabled', '')
 
-    if (Number(counterInput.value) - STEP < min) {
+    if (Number(counterInput.value) - step < min) {
       btnDown.setAttribute('disabled', '')
     }
 
-    if (Number(counterInput.value) + STEP > max) {
+    if (Number(counterInput.value) + step > max) {
       btnUp.setAttribute('disabled', '')
     }
   }

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -59,7 +59,6 @@ class QuantitySelector extends BaseComponent {
 
   // Static
   static StepUp(event) {
-    event.preventDefault()
     const parent = event.target.closest(SELECTOR_INPUT_GROUP)
     const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
     const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)
@@ -68,6 +67,8 @@ class QuantitySelector extends BaseComponent {
     const max = counterInput.getAttribute('max')
     const step = Number(counterInput.getAttribute('step'))
     const round = Number(counterInput.getAttribute('data-bs-round'))
+
+    const eventChange = new Event('change')
 
     if (Number(counterInput.value) < max) {
       counterInput.value = (Number(counterInput.value) + step).toFixed(round).toString()
@@ -82,10 +83,11 @@ class QuantitySelector extends BaseComponent {
     if (Number(counterInput.value) + step > max) {
       btnUp.setAttribute('disabled', '')
     }
+
+    counterInput.dispatchEvent(eventChange)
   }
 
   static StepDown(event) {
-    event.preventDefault()
     const parent = event.target.closest(SELECTOR_INPUT_GROUP)
     const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
     const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)
@@ -94,6 +96,8 @@ class QuantitySelector extends BaseComponent {
     const min = counterInput.getAttribute('min')
     const step = Number(counterInput.getAttribute('step'))
     const round = Number(counterInput.getAttribute('data-bs-round'))
+
+    const eventChange = new Event('change')
 
     if (Number(counterInput.value) > min) {
       counterInput.value = (Number(counterInput.value) - step).toFixed(round).toString()
@@ -108,10 +112,11 @@ class QuantitySelector extends BaseComponent {
     if (Number(counterInput.value) - step < min) {
       btnDown.setAttribute('disabled', '')
     }
+
+    counterInput.dispatchEvent(eventChange)
   }
 
   static ValueChange(event) {
-    event.preventDefault()
     const parent = event.target.closest(SELECTOR_INPUT_GROUP)
     const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
     const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -61,8 +61,6 @@ class QuantitySelector extends BaseComponent {
   static StepUp(event) {
     const parent = event.target.closest(SELECTOR_INPUT_GROUP)
     const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
-    const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const btnDown = parent.querySelector(SELECTOR_STEP_DOWN_BUTTON)
 
     const max = counterInput.getAttribute('max')
     const step = Number(counterInput.getAttribute('step'))
@@ -72,16 +70,6 @@ class QuantitySelector extends BaseComponent {
 
     if (Number(counterInput.value) < max) {
       counterInput.value = (Number(counterInput.value) + step).toFixed(round).toString()
-    } else if (Number(counterInput.value) + step > max) {
-      btnUp.setAttribute('disabled', '')
-    }
-
-    if (btnDown.hasAttribute('disabled', '')) {
-      btnDown.removeAttribute('disabled', '')
-    }
-
-    if (Number(counterInput.value) + step > max) {
-      btnUp.setAttribute('disabled', '')
     }
 
     counterInput.dispatchEvent(eventChange)
@@ -90,8 +78,6 @@ class QuantitySelector extends BaseComponent {
   static StepDown(event) {
     const parent = event.target.closest(SELECTOR_INPUT_GROUP)
     const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
-    const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)
-    const btnDown = parent.querySelector(SELECTOR_STEP_DOWN_BUTTON)
 
     const min = counterInput.getAttribute('min')
     const step = Number(counterInput.getAttribute('step'))
@@ -101,22 +87,12 @@ class QuantitySelector extends BaseComponent {
 
     if (Number(counterInput.value) > min) {
       counterInput.value = (Number(counterInput.value) - step).toFixed(round).toString()
-    } else if (Number(counterInput.value) + step < min) {
-      btnDown.setAttribute('disabled', '')
-    }
-
-    if (btnUp.hasAttribute('disabled', '')) {
-      btnUp.removeAttribute('disabled', '')
-    }
-
-    if (Number(counterInput.value) - step < min) {
-      btnDown.setAttribute('disabled', '')
     }
 
     counterInput.dispatchEvent(eventChange)
   }
 
-  static ValueChange(event) {
+  static CheckIfDisabled(event) {
     const parent = event.target.closest(SELECTOR_INPUT_GROUP)
     const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
     const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)
@@ -164,7 +140,7 @@ EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
     QuantitySelector.getOrCreateInstance(el).ValueOnLoad(el)
   }
 })
-EventHandler.on(document, EVENT_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT, QuantitySelector.ValueChange)
+EventHandler.on(document, EVENT_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT, QuantitySelector.CheckIfDisabled)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_UP_BUTTON, QuantitySelector.StepUp)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_DOWN_BUTTON, QuantitySelector.StepDown)
 

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -8,6 +8,7 @@
 import { defineJQueryPlugin } from './util/index'
 import EventHandler from './dom/event-handler'
 import BaseComponent from './base-component'
+import SelectorEngine from './dom/selector-engine'
 
 /**
  * Constants
@@ -18,8 +19,8 @@ const DATA_KEY = 'bs.quantityselector'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
 
-const EVENT_LOAD_DATA_API = `input${EVENT_KEY}${DATA_API_KEY}`
-const EVENT_ON_CHANGE_DATA_API = `change${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_CHANGE_DATA_API = `change${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_STEP_UP_BUTTON = '[data-bs-step="up"]'
@@ -112,14 +113,37 @@ class QuantitySelector extends BaseComponent {
       BTN_UP.setAttribute('disabled', '')
     }
   }
+
+  // Static
+  ValueOnLoad(el) {
+    const COUNTER_INPUT = el.querySelector(SELECTOR_COUNTER_INPUT)
+    const BTN_UP = el.querySelector(SELECTOR_STEP_UP_BUTTON)
+    const BTN_DOWN = el.querySelector(SELECTOR_STEP_DOWN_BUTTON)
+
+    const MIN = COUNTER_INPUT.getAttribute('min')
+    const MAX = COUNTER_INPUT.getAttribute('max')
+    const STEP = Number(COUNTER_INPUT.getAttribute('step'))
+
+    if (Number(COUNTER_INPUT.value) - STEP < MIN) {
+      BTN_DOWN.setAttribute('disabled', '')
+    }
+
+    if (Number(COUNTER_INPUT.value) + STEP > MAX) {
+      BTN_UP.setAttribute('disabled', '')
+    }
+  }
 }
 
 /**
  * Data API implementation
  */
 
-EventHandler.on(document, EVENT_LOAD_DATA_API, SELECTOR_COUNTER_INPUT.value, QuantitySelector.ValueChange)
-EventHandler.on(document, EVENT_ON_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT.value, QuantitySelector.ValueChange)
+EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+  for (const el of SelectorEngine.find(SELECTOR_INPUT_GROUP)) {
+    QuantitySelector.getOrCreateInstance(el).ValueOnLoad(el)
+  }
+})
+EventHandler.on(document, EVENT_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT, QuantitySelector.ValueChange)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_UP_BUTTON, QuantitySelector.StepUp)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_DOWN_BUTTON, QuantitySelector.StepDown)
 

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -135,14 +135,15 @@ class QuantitySelector extends BaseComponent {
  * Data API implementation
  */
 
+EventHandler.on(document, EVENT_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT, QuantitySelector.CheckIfDisabledOnChange)
+EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_UP_BUTTON, QuantitySelector.StepUp)
+EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_DOWN_BUTTON, QuantitySelector.StepDown)
+
 EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
   for (const el of SelectorEngine.find(SELECTOR_INPUT_GROUP)) {
     QuantitySelector.getOrCreateInstance(el).ValueOnLoad(el)
   }
 })
-EventHandler.on(document, EVENT_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT, QuantitySelector.CheckIfDisabledOnChange)
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_UP_BUTTON, QuantitySelector.StepUp)
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_DOWN_BUTTON, QuantitySelector.StepDown)
 
 /**
  * jQuery

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -18,6 +18,8 @@ const DATA_KEY = 'bs.quantityselector'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
 
+const EVENT_LOAD_DATA_API = `input${EVENT_KEY}${DATA_API_KEY}`
+const EVENT_ON_CHANGE_DATA_API = `change${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_STEP_UP_BUTTON = '[data-bs-step="up"]'
@@ -40,6 +42,8 @@ class QuantitySelector extends BaseComponent {
     event.preventDefault()
     const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
     const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
+    const BTN_UP = PARENT.querySelector(SELECTOR_STEP_UP_BUTTON)
+    const BTN_DOWN = PARENT.querySelector(SELECTOR_STEP_DOWN_BUTTON)
 
     const MAX = COUNTER_INPUT.getAttribute('max')
     const STEP = Number(COUNTER_INPUT.getAttribute('step'))
@@ -47,6 +51,16 @@ class QuantitySelector extends BaseComponent {
 
     if (Number(COUNTER_INPUT.value) < MAX) {
       COUNTER_INPUT.value = (Number(COUNTER_INPUT.value) + STEP).toFixed(ROUND).toString()
+    } else if (Number(COUNTER_INPUT.value) + STEP > MAX) {
+      BTN_UP.setAttribute('disabled', '')
+    }
+
+    if (BTN_DOWN.hasAttribute('disabled', '')) {
+      BTN_DOWN.removeAttribute('disabled', '')
+    }
+
+    if (Number(COUNTER_INPUT.value) + STEP > MAX) {
+      BTN_UP.setAttribute('disabled', '')
     }
   }
 
@@ -54,6 +68,8 @@ class QuantitySelector extends BaseComponent {
     event.preventDefault()
     const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
     const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
+    const BTN_UP = PARENT.querySelector(SELECTOR_STEP_UP_BUTTON)
+    const BTN_DOWN = PARENT.querySelector(SELECTOR_STEP_DOWN_BUTTON)
 
     const MIN = COUNTER_INPUT.getAttribute('min')
     const STEP = Number(COUNTER_INPUT.getAttribute('step'))
@@ -61,6 +77,39 @@ class QuantitySelector extends BaseComponent {
 
     if (Number(COUNTER_INPUT.value) > MIN) {
       COUNTER_INPUT.value = (Number(COUNTER_INPUT.value) - STEP).toFixed(ROUND).toString()
+    } else if (Number(COUNTER_INPUT.value) + STEP < MIN) {
+      BTN_DOWN.setAttribute('disabled', '')
+    }
+
+    if (BTN_UP.hasAttribute('disabled', '')) {
+      BTN_UP.removeAttribute('disabled', '')
+    }
+
+    if (Number(COUNTER_INPUT.value) - STEP < MIN) {
+      BTN_DOWN.setAttribute('disabled', '')
+    }
+  }
+
+  static ValueChange(event) {
+    event.preventDefault()
+    const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)
+    const COUNTER_INPUT = PARENT.querySelector(SELECTOR_COUNTER_INPUT)
+    const BTN_UP = PARENT.querySelector(SELECTOR_STEP_UP_BUTTON)
+    const BTN_DOWN = PARENT.querySelector(SELECTOR_STEP_DOWN_BUTTON)
+
+    const MIN = COUNTER_INPUT.getAttribute('min')
+    const MAX = COUNTER_INPUT.getAttribute('max')
+    const STEP = Number(COUNTER_INPUT.getAttribute('step'))
+
+    BTN_UP.removeAttribute('disabled', '')
+    BTN_DOWN.removeAttribute('disabled', '')
+
+    if (Number(COUNTER_INPUT.value) - STEP < MIN) {
+      BTN_DOWN.setAttribute('disabled', '')
+    }
+
+    if (Number(COUNTER_INPUT.value) + STEP > MAX) {
+      BTN_UP.setAttribute('disabled', '')
     }
   }
 }
@@ -69,6 +118,8 @@ class QuantitySelector extends BaseComponent {
  * Data API implementation
  */
 
+EventHandler.on(document, EVENT_LOAD_DATA_API, SELECTOR_COUNTER_INPUT.value, QuantitySelector.ValueChange)
+EventHandler.on(document, EVENT_ON_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT.value, QuantitySelector.ValueChange)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_UP_BUTTON, QuantitySelector.StepUp)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_DOWN_BUTTON, QuantitySelector.StepDown)
 

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -132,6 +132,22 @@ class QuantitySelector extends BaseComponent {
       btnUp.setAttribute('disabled', '')
     }
   }
+
+  static jQueryInterface(config) {
+    return this.each(function () {
+      const data = QuantitySelector.getOrCreateInstance(this, config)
+
+      if (typeof config !== 'string') {
+        return
+      }
+
+      if (typeof data[config] === 'undefined') {
+        throw new TypeError(`No method named "${config}"`)
+      }
+
+      data[config]()
+    })
+  }
 }
 
 /**

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -17,7 +17,9 @@ const NAME = 'quantityselector'
 const DATA_KEY = 'bs.quantityselector'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
+
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
+
 const SELECTOR_STEP_UP_BUTTON = '[data-bs-step="up"]'
 const SELECTOR_STEP_DOWN_BUTTON = '[data-bs-step="down"]'
 const SELECTOR_COUNTER_INPUT = '[data-bs-step="counter"]'
@@ -33,7 +35,7 @@ class QuantitySelector extends BaseComponent {
     return NAME
   }
 
-  // Public
+  // Static
   static StepUp(event) {
     event.preventDefault()
     const PARENT = event.target.closest(SELECTOR_INPUT_GROUP)

--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -92,7 +92,7 @@ class QuantitySelector extends BaseComponent {
     counterInput.dispatchEvent(eventChange)
   }
 
-  static CheckIfDisabled(event) {
+  static ValueChange(event) {
     const parent = event.target.closest(SELECTOR_INPUT_GROUP)
     const counterInput = parent.querySelector(SELECTOR_COUNTER_INPUT)
     const btnUp = parent.querySelector(SELECTOR_STEP_UP_BUTTON)
@@ -140,7 +140,7 @@ EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
     QuantitySelector.getOrCreateInstance(el).ValueOnLoad(el)
   }
 })
-EventHandler.on(document, EVENT_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT, QuantitySelector.CheckIfDisabled)
+EventHandler.on(document, EVENT_CHANGE_DATA_API, SELECTOR_COUNTER_INPUT, QuantitySelector.ValueChange)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_UP_BUTTON, QuantitySelector.StepUp)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_STEP_DOWN_BUTTON, QuantitySelector.StepDown)
 

--- a/js/tests/unit/quantity-selector.spec.js
+++ b/js/tests/unit/quantity-selector.spec.js
@@ -39,7 +39,7 @@ describe('QuantitySelector', () => {
   it('should take care of element either passed as a CSS selector or DOM element (Step Up button)', () => {
     fixtureEl.innerHTML = [
       '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" aria-label="Quantity selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
       '  </button>',
@@ -60,7 +60,7 @@ describe('QuantitySelector', () => {
   it('should take care of element either passed as a CSS selector or DOM element (Step Down button)', () => {
     fixtureEl.innerHTML = [
       '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" aria-label="Quantity selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
       '  </button>',
@@ -81,7 +81,7 @@ describe('QuantitySelector', () => {
   it('should increment by one step on click on Step Up button', () => {
     fixtureEl.innerHTML = [
       '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="9" min="0" max="10" step="1" aria-label="Quantity selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="9" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
       '  </button>',
@@ -153,5 +153,107 @@ describe('QuantitySelector', () => {
     buttonStepUpEl.click()
 
     expect(inputEl.value).toBe('1.8') // 1.25 + .5 = 1.75 and with data-bs-round="1" = 1.8
+  })
+
+  it('should decrement a decimal value by 1 step on click on Step Down button but not resulting as a negative value', () => {
+    fixtureEl.innerHTML = [
+      '<div class="input-group quantity-selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
+      '    <span class="visually-hidden">Step down</span>',
+      '  </button>',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
+      '    <span class="visually-hidden">Step up</span>',
+      '  </button>',
+      '</div>'
+    ].join('')
+
+    const buttonStepDownEl = fixtureEl.querySelector('[data-bs-step="down"]')
+    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
+
+    expect(inputEl.value).toBe('1.5')
+
+    buttonStepDownEl.click()
+
+    expect(inputEl.value).toBe('0.5')
+
+    expect(buttonStepDownEl.disabled).toBeTruthy()
+  })
+
+  it('should increment a decimal value by 1 step on click on Step Up button but not resulting as a negative value', () => {
+    fixtureEl.innerHTML = [
+      '<div class="input-group quantity-selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="8.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
+      '    <span class="visually-hidden">Step down</span>',
+      '  </button>',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
+      '    <span class="visually-hidden">Step up</span>',
+      '  </button>',
+      '</div>'
+    ].join('')
+
+    const buttonStepUpEl = fixtureEl.querySelector('[data-bs-step="up"]')
+    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
+
+    expect(inputEl.value).toBe('8.5')
+
+    buttonStepUpEl.click()
+
+    expect(inputEl.value).toBe('9.5')
+
+    expect(buttonStepUpEl.disabled).toBeTruthy()
+  })
+
+  it('should disable click on Step Down button on load to prevent a value out of range', done => {
+    fixtureEl.innerHTML = [
+      '<div class="input-group quantity-selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
+      '    <span class="visually-hidden">Step down</span>',
+      '  </button>',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
+      '    <span class="visually-hidden">Step up</span>',
+      '  </button>',
+      '</div>'
+    ].join('')
+
+    const buttonStepDownEl = fixtureEl.querySelector('[data-bs-step="down"]')
+    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
+
+    expect(inputEl.value).toBe('0.5')
+
+    buttonStepDownEl.click()
+
+    setTimeout(() => {
+      expect(buttonStepDownEl.disabled).toBeTruthy()
+      done()
+    }, 10)
+  })
+
+  it('should disable click on Step Up button on load to prevent a value out of range', done => {
+    fixtureEl.innerHTML = [
+      '<div class="input-group quantity-selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="9.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
+      '    <span class="visually-hidden">Step down</span>',
+      '  </button>',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
+      '    <span class="visually-hidden">Step up</span>',
+      '  </button>',
+      '</div>'
+    ].join('')
+
+    const buttonStepUpEl = fixtureEl.querySelector('[data-bs-step="up"]')
+    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
+
+    expect(inputEl.value).toBe('9.5')
+
+    buttonStepUpEl.click()
+
+    setTimeout(() => {
+      expect(buttonStepUpEl.disabled).toBeTruthy()
+      done()
+    }, 10)
   })
 })

--- a/js/tests/unit/quantity-selector.spec.js
+++ b/js/tests/unit/quantity-selector.spec.js
@@ -1,0 +1,86 @@
+import QuantitySelector from '../../src/quantity-selector'
+import { clearFixture, getFixture } from '../helpers/fixture'
+
+describe('QuantitySelector', () => {
+  let fixtureEl
+
+  beforeAll(() => {
+    fixtureEl = getFixture()
+  })
+
+  afterEach(() => {
+    clearFixture()
+  })
+
+  describe('VERSION', () => {
+    it('should return plugin version', () => {
+      expect(QuantitySelector.VERSION).toEqual(jasmine.any(String))
+    })
+  })
+
+  describe('Default', () => {
+    it('should return plugin default config', () => {
+      expect(QuantitySelector.Default).toEqual(jasmine.any(Object))
+    })
+  })
+
+  describe('DefaultType', () => {
+    it('should return plugin default type config', () => {
+      expect(QuantitySelector.DefaultType).toEqual(jasmine.any(Object))
+    })
+  })
+
+  describe('DATA_KEY', () => {
+    it('should return plugin data key', () => {
+      expect(QuantitySelector.DATA_KEY).toEqual('bs.quantityselector')
+    })
+  })
+
+  it('should take care of element either passed as a CSS selector or DOM element - Step Up button', () => {
+    fixtureEl.innerHTML = '<button data-bs-step="up"></button>'
+    const buttonEl = fixtureEl.querySelector('[data-bs-step="up"]')
+    const buttonBySelector = new QuantitySelector('[data-bs-step="up"]')
+    const buttonByElement = new QuantitySelector(buttonEl)
+
+    expect(buttonBySelector._element).toEqual(buttonEl)
+    expect(buttonByElement._element).toEqual(buttonEl)
+  })
+
+  it('should take care of element either passed as a CSS selector or DOM element - Step Down button', () => {
+    fixtureEl.innerHTML = '<button data-bs-step="down"></button>'
+    const buttonEl = fixtureEl.querySelector('[data-bs-step="down"]')
+    const buttonBySelector = new QuantitySelector('[data-bs-step="down"]')
+    const buttonByElement = new QuantitySelector(buttonEl)
+
+    expect(buttonBySelector._element).toEqual(buttonEl)
+    expect(buttonByElement._element).toEqual(buttonEl)
+  })
+
+  it('should increment by one step on click on StepUp button', () => {
+    fixtureEl.innerHTML = '<button data-bs-step="up"></button>'
+    const buttonEl = fixtureEl.querySelector('[data-bs-step="up"]')
+    fixtureEl.innerHTML = '<input data-bs-step="counter"></input>'
+    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
+    const counterStep = inputEl.getAttribute('step')
+    const counterMax = inputEl.getAttribute('max')
+    const counterValue = inputEl.value
+
+    buttonEl.click()
+
+    expect(inputEl.value === counterValue + counterStep || inputEl.value === counterMax)
+  })
+
+  it('should decrement by one step on click on StepDown button', () => {
+    fixtureEl.innerHTML = '<button data-bs-step="down"></button>'
+    const buttonEl = fixtureEl.querySelector('[data-bs-step="down"]')
+    fixtureEl.innerHTML = '<input data-bs-step="counter"></input>'
+    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
+    const counterStep = inputEl.getAttribute('step')
+    const counterMin = inputEl.getAttribute('min')
+    const counterValue = inputEl.value
+
+    buttonEl.click()
+
+    expect(inputEl.value === counterValue - counterStep || inputEl.value === counterMin)
+  })
+})

--- a/js/tests/unit/quantity-selector.spec.js
+++ b/js/tests/unit/quantity-selector.spec.js
@@ -36,224 +36,51 @@ describe('QuantitySelector', () => {
     })
   })
 
-  it('should take care of element either passed as a CSS selector or DOM element (Step Up button)', () => {
-    fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
-      '    <span class="visually-hidden">Step down</span>',
-      '  </button>',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
-      '    <span class="visually-hidden">Step up</span>',
-      '  </button>',
-      '</div>'
-    ].join('')
+  it('should take care of element either passed as a CSS selector or DOM element - Step Up button', () => {
+    fixtureEl.innerHTML = '<button data-bs-step="up"></button>'
+    const buttonEl = fixtureEl.querySelector('[data-bs-step="up"]')
+    const buttonBySelector = new QuantitySelector('[data-bs-step="up"]')
+    const buttonByElement = new QuantitySelector(buttonEl)
 
-    const buttonStepUpEl = fixtureEl.querySelector('[data-bs-step="up"]')
-    const buttonStepUpBySelector = new QuantitySelector('[data-bs-step="up"]')
-    const buttonStepUpByElement = new QuantitySelector(buttonStepUpEl)
-
-    expect(buttonStepUpBySelector._element).toEqual(buttonStepUpEl)
-    expect(buttonStepUpByElement._element).toEqual(buttonStepUpEl)
+    expect(buttonBySelector._element).toEqual(buttonEl)
+    expect(buttonByElement._element).toEqual(buttonEl)
   })
 
-  it('should take care of element either passed as a CSS selector or DOM element (Step Down button)', () => {
-    fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
-      '    <span class="visually-hidden">Step down</span>',
-      '  </button>',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
-      '    <span class="visually-hidden">Step up</span>',
-      '  </button>',
-      '</div>'
-    ].join('')
+  it('should take care of element either passed as a CSS selector or DOM element - Step Down button', () => {
+    fixtureEl.innerHTML = '<button data-bs-step="down"></button>'
+    const buttonEl = fixtureEl.querySelector('[data-bs-step="down"]')
+    const buttonBySelector = new QuantitySelector('[data-bs-step="down"]')
+    const buttonByElement = new QuantitySelector(buttonEl)
 
-    const buttonStepDownEl = fixtureEl.querySelector('[data-bs-step="down"]')
-    const buttonStepDownBySelector = new QuantitySelector('[data-bs-step="down"]')
-    const buttonStepDownByElement = new QuantitySelector(buttonStepDownEl)
-
-    expect(buttonStepDownBySelector._element).toEqual(buttonStepDownEl)
-    expect(buttonStepDownByElement._element).toEqual(buttonStepDownEl)
+    expect(buttonBySelector._element).toEqual(buttonEl)
+    expect(buttonByElement._element).toEqual(buttonEl)
   })
 
-  it('should increment by one step on click on Step Up button', () => {
-    fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="9" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
-      '    <span class="visually-hidden">Step down</span>',
-      '  </button>',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
-      '    <span class="visually-hidden">Step up</span>',
-      '  </button>',
-      '</div>'
-    ].join('')
-
-    const buttonStepUpEl = fixtureEl.querySelector('[data-bs-step="up"]')
+  it('should increment by one step on click on StepUp button', () => {
+    fixtureEl.innerHTML = '<button data-bs-step="up"></button>'
+    const buttonEl = fixtureEl.querySelector('[data-bs-step="up"]')
+    fixtureEl.innerHTML = '<input data-bs-step="counter"></input>'
     const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
+    const counterStep = inputEl.getAttribute('step')
+    const counterMax = inputEl.getAttribute('max')
+    const counterValue = inputEl.value
 
-    expect(inputEl.value).toBe('9')
+    buttonEl.click()
 
-    buttonStepUpEl.click()
-
-    expect(inputEl.value).toBe('10')
-
-    buttonStepUpEl.click()
-
-    expect(inputEl.value).toBe('10')
+    expect(inputEl.value === counterValue + counterStep || inputEl.value === counterMax)
   })
 
-  it('should decrement by one step on click on Step Down button', () => {
-    fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
-      '    <span class="visually-hidden">Step down</span>',
-      '  </button>',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
-      '    <span class="visually-hidden">Step up</span>',
-      '  </button>',
-      '</div>'
-    ].join('')
-
-    const buttonStepDownEl = fixtureEl.querySelector('[data-bs-step="down"]')
+  it('should decrement by one step on click on StepDown button', () => {
+    fixtureEl.innerHTML = '<button data-bs-step="down"></button>'
+    const buttonEl = fixtureEl.querySelector('[data-bs-step="down"]')
+    fixtureEl.innerHTML = '<input data-bs-step="counter"></input>'
     const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
+    const counterStep = inputEl.getAttribute('step')
+    const counterMin = inputEl.getAttribute('min')
+    const counterValue = inputEl.value
 
-    expect(inputEl.value).toBe('1')
+    buttonEl.click()
 
-    buttonStepDownEl.click()
-
-    expect(inputEl.value).toBe('0')
-
-    buttonStepDownEl.click()
-
-    expect(inputEl.value).toBe('0')
-  })
-
-  it('should increment a decimal value by 0.5 step on click on Step Up button and round it', () => {
-    fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1.25" min="0" max="10" step="0.5" data-bs-round="1" aria-label="Quantity selector">',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
-      '    <span class="visually-hidden">Step down</span>',
-      '  </button>',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
-      '    <span class="visually-hidden">Step up</span>',
-      '  </button>',
-      '</div>'
-    ].join('')
-
-    const buttonStepUpEl = fixtureEl.querySelector('[data-bs-step="up"]')
-    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
-
-    expect(inputEl.value).toBe('1.25')
-
-    buttonStepUpEl.click()
-
-    expect(inputEl.value).toBe('1.8') // 1.25 + .5 = 1.75 and with data-bs-round="1" = 1.8
-  })
-
-  it('should decrement a decimal value by 1 step on click on Step Down button but not resulting as a negative value', () => {
-    fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
-      '    <span class="visually-hidden">Step down</span>',
-      '  </button>',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
-      '    <span class="visually-hidden">Step up</span>',
-      '  </button>',
-      '</div>'
-    ].join('')
-
-    const buttonStepDownEl = fixtureEl.querySelector('[data-bs-step="down"]')
-    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
-
-    expect(inputEl.value).toBe('1.5')
-
-    buttonStepDownEl.click()
-
-    expect(inputEl.value).toBe('0.5')
-
-    expect(buttonStepDownEl.disabled).toBeTruthy()
-  })
-
-  it('should increment a decimal value by 1 step on click on Step Up button but not resulting as a negative value', () => {
-    fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="8.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
-      '    <span class="visually-hidden">Step down</span>',
-      '  </button>',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
-      '    <span class="visually-hidden">Step up</span>',
-      '  </button>',
-      '</div>'
-    ].join('')
-
-    const buttonStepUpEl = fixtureEl.querySelector('[data-bs-step="up"]')
-    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
-
-    expect(inputEl.value).toBe('8.5')
-
-    buttonStepUpEl.click()
-
-    expect(inputEl.value).toBe('9.5')
-
-    expect(buttonStepUpEl.disabled).toBeTruthy()
-  })
-
-  it('should disable click on Step Down button on load to prevent a value out of range', done => {
-    fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
-      '    <span class="visually-hidden">Step down</span>',
-      '  </button>',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
-      '    <span class="visually-hidden">Step up</span>',
-      '  </button>',
-      '</div>'
-    ].join('')
-
-    const buttonStepDownEl = fixtureEl.querySelector('[data-bs-step="down"]')
-    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
-
-    expect(inputEl.value).toBe('0.5')
-
-    buttonStepDownEl.click()
-
-    setTimeout(() => {
-      expect(buttonStepDownEl.disabled).toBeTruthy()
-      done()
-    }, 10)
-  })
-
-  it('should disable click on Step Up button on load to prevent a value out of range', done => {
-    fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
-      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="9.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
-      '    <span class="visually-hidden">Step down</span>',
-      '  </button>',
-      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
-      '    <span class="visually-hidden">Step up</span>',
-      '  </button>',
-      '</div>'
-    ].join('')
-
-    const buttonStepUpEl = fixtureEl.querySelector('[data-bs-step="up"]')
-    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
-
-    expect(inputEl.value).toBe('9.5')
-
-    buttonStepUpEl.click()
-
-    setTimeout(() => {
-      expect(buttonStepUpEl.disabled).toBeTruthy()
-      done()
-    }, 10)
+    expect(inputEl.value === counterValue - counterStep || inputEl.value === counterMin)
   })
 })

--- a/js/tests/unit/quantity-selector.spec.js
+++ b/js/tests/unit/quantity-selector.spec.js
@@ -1,5 +1,5 @@
 import QuantitySelector from '../../src/quantity-selector'
-import { clearFixture, getFixture, createEvent } from '../helpers/fixture'
+import { clearFixture, getFixture, createEvent, jQueryMock } from '../helpers/fixture'
 
 describe('QuantitySelector', () => {
   let fixtureEl
@@ -33,6 +33,49 @@ describe('QuantitySelector', () => {
   describe('DATA_KEY', () => {
     it('should return plugin data key', () => {
       expect(QuantitySelector.DATA_KEY).toEqual('bs.quantityselector')
+    })
+  })
+
+  describe('jQueryInterface', () => {
+    it('should create a quantity selector', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+
+      jQueryMock.fn.quantity_selector = QuantitySelector.jQueryInterface
+      jQueryMock.elements = [div]
+
+      jQueryMock.fn.quantity_selector.call(jQueryMock)
+
+      expect(QuantitySelector.getInstance(div)).not.toBeNull()
+    })
+
+    it('should not re create a quantity selector', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const quantity_selector = new QuantitySelector(div)
+
+      jQueryMock.fn.quantity_selector = QuantitySelector.jQueryInterface
+      jQueryMock.elements = [div]
+
+      jQueryMock.fn.quantity_selector.call(jQueryMock)
+
+      expect(QuantitySelector.getInstance(div)).toEqual(quantity_selector)
+    })
+
+    it('should throw error on undefined method', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const action = 'undefinedMethod'
+
+      jQueryMock.fn.quantity_selector = QuantitySelector.jQueryInterface
+      jQueryMock.elements = [div]
+
+      expect(() => {
+        jQueryMock.fn.quantity_selector.call(jQueryMock, action)
+      }).toThrowError(TypeError, `No method named "${action}"`)
     })
   })
 

--- a/js/tests/unit/quantity-selector.spec.js
+++ b/js/tests/unit/quantity-selector.spec.js
@@ -36,51 +36,122 @@ describe('QuantitySelector', () => {
     })
   })
 
-  it('should take care of element either passed as a CSS selector or DOM element - Step Up button', () => {
-    fixtureEl.innerHTML = '<button data-bs-step="up"></button>'
-    const buttonEl = fixtureEl.querySelector('[data-bs-step="up"]')
-    const buttonBySelector = new QuantitySelector('[data-bs-step="up"]')
-    const buttonByElement = new QuantitySelector(buttonEl)
+  it('should take care of element either passed as a CSS selector or DOM element (Step Up button)', () => {
+    fixtureEl.innerHTML = [
+      '<div class="input-group quantity-selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" aria-label="Quantity selector">',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
+      '    <span class="visually-hidden">Step down</span>',
+      '  </button>',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
+      '    <span class="visually-hidden">Step up</span>',
+      '  </button>',
+      '</div>'
+    ].join('')
 
-    expect(buttonBySelector._element).toEqual(buttonEl)
-    expect(buttonByElement._element).toEqual(buttonEl)
+    const buttonStepUpEl = fixtureEl.querySelector('[data-bs-step="up"]')
+    const buttonStepUpBySelector = new QuantitySelector('[data-bs-step="up"]')
+    const buttonStepUpByElement = new QuantitySelector(buttonStepUpEl)
+
+    expect(buttonStepUpBySelector._element).toEqual(buttonStepUpEl)
+    expect(buttonStepUpByElement._element).toEqual(buttonStepUpEl)
   })
 
-  it('should take care of element either passed as a CSS selector or DOM element - Step Down button', () => {
-    fixtureEl.innerHTML = '<button data-bs-step="down"></button>'
-    const buttonEl = fixtureEl.querySelector('[data-bs-step="down"]')
-    const buttonBySelector = new QuantitySelector('[data-bs-step="down"]')
-    const buttonByElement = new QuantitySelector(buttonEl)
+  it('should take care of element either passed as a CSS selector or DOM element (Step Down button)', () => {
+    fixtureEl.innerHTML = [
+      '<div class="input-group quantity-selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" aria-label="Quantity selector">',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
+      '    <span class="visually-hidden">Step down</span>',
+      '  </button>',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
+      '    <span class="visually-hidden">Step up</span>',
+      '  </button>',
+      '</div>'
+    ].join('')
 
-    expect(buttonBySelector._element).toEqual(buttonEl)
-    expect(buttonByElement._element).toEqual(buttonEl)
+    const buttonStepDownEl = fixtureEl.querySelector('[data-bs-step="down"]')
+    const buttonStepDownBySelector = new QuantitySelector('[data-bs-step="down"]')
+    const buttonStepDownByElement = new QuantitySelector(buttonStepDownEl)
+
+    expect(buttonStepDownBySelector._element).toEqual(buttonStepDownEl)
+    expect(buttonStepDownByElement._element).toEqual(buttonStepDownEl)
   })
 
-  it('should increment by one step on click on StepUp button', () => {
-    fixtureEl.innerHTML = '<button data-bs-step="up"></button>'
-    const buttonEl = fixtureEl.querySelector('[data-bs-step="up"]')
-    fixtureEl.innerHTML = '<input data-bs-step="counter"></input>'
+  it('should increment by one step on click on Step Up button', () => {
+    fixtureEl.innerHTML = [
+      '<div class="input-group quantity-selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="9" min="0" max="10" step="1" aria-label="Quantity selector">',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
+      '    <span class="visually-hidden">Step down</span>',
+      '  </button>',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
+      '    <span class="visually-hidden">Step up</span>',
+      '  </button>',
+      '</div>'
+    ].join('')
+
+    const buttonStepUpEl = fixtureEl.querySelector('[data-bs-step="up"]')
     const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
-    const counterStep = inputEl.getAttribute('step')
-    const counterMax = inputEl.getAttribute('max')
-    const counterValue = inputEl.value
 
-    buttonEl.click()
+    expect(inputEl.value).toBe('9')
 
-    expect(inputEl.value === counterValue + counterStep || inputEl.value === counterMax)
+    buttonStepUpEl.click()
+
+    expect(inputEl.value).toBe('10')
+
+    buttonStepUpEl.click()
+
+    expect(inputEl.value).toBe('10')
   })
 
-  it('should decrement by one step on click on StepDown button', () => {
-    fixtureEl.innerHTML = '<button data-bs-step="down"></button>'
-    const buttonEl = fixtureEl.querySelector('[data-bs-step="down"]')
-    fixtureEl.innerHTML = '<input data-bs-step="counter"></input>'
+  it('should decrement by one step on click on Step Down button', () => {
+    fixtureEl.innerHTML = [
+      '<div class="input-group quantity-selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
+      '    <span class="visually-hidden">Step down</span>',
+      '  </button>',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
+      '    <span class="visually-hidden">Step up</span>',
+      '  </button>',
+      '</div>'
+    ].join('')
+
+    const buttonStepDownEl = fixtureEl.querySelector('[data-bs-step="down"]')
     const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
-    const counterStep = inputEl.getAttribute('step')
-    const counterMin = inputEl.getAttribute('min')
-    const counterValue = inputEl.value
 
-    buttonEl.click()
+    expect(inputEl.value).toBe('1')
 
-    expect(inputEl.value === counterValue - counterStep || inputEl.value === counterMin)
+    buttonStepDownEl.click()
+
+    expect(inputEl.value).toBe('0')
+
+    buttonStepDownEl.click()
+
+    expect(inputEl.value).toBe('0')
+  })
+
+  it('should increment by 0.5 step on click on Step Up button', () => {
+    fixtureEl.innerHTML = [
+      '<div class="input-group quantity-selector">',
+      '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1.25" min="0" max="10" step="0.5" data-bs-round="1" aria-label="Quantity selector">',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
+      '    <span class="visually-hidden">Step down</span>',
+      '  </button>',
+      '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">',
+      '    <span class="visually-hidden">Step up</span>',
+      '  </button>',
+      '</div>'
+    ].join('')
+
+    const buttonStepUpEl = fixtureEl.querySelector('[data-bs-step="up"]')
+    const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
+
+    expect(inputEl.value).toBe('1.25')
+
+    buttonStepUpEl.click()
+
+    expect(inputEl.value).toBe('1.8') // 1.25 + .5 = 1.75 and with data-bs-round="1" = 1.8
   })
 })

--- a/js/tests/unit/quantity-selector.spec.js
+++ b/js/tests/unit/quantity-selector.spec.js
@@ -1,5 +1,5 @@
 import QuantitySelector from '../../src/quantity-selector'
-import { clearFixture, getFixture } from '../helpers/fixture'
+import { clearFixture, getFixture, createEvent } from '../helpers/fixture'
 
 describe('QuantitySelector', () => {
   let fixtureEl
@@ -221,12 +221,14 @@ describe('QuantitySelector', () => {
     const buttonStepDownEl = fixtureEl.querySelector('[data-bs-step="down"]')
     const inputEl = fixtureEl.querySelector('[data-bs-step="counter"]')
 
-    expect(inputEl.value).toBe('0.5')
+    const loadEvent = createEvent('load')
+    window.dispatchEvent(loadEvent)
 
-    buttonStepDownEl.click()
+    expect(inputEl.value).toBe('0.5')
 
     setTimeout(() => {
       expect(buttonStepDownEl.disabled).toBeTruthy()
+      expect(inputEl.value).toBe('0.5')
       done()
     }, 10)
   })
@@ -249,10 +251,12 @@ describe('QuantitySelector', () => {
 
     expect(inputEl.value).toBe('9.5')
 
-    buttonStepUpEl.click()
+    const loadEvent = createEvent('load')
+    window.dispatchEvent(loadEvent)
 
     setTimeout(() => {
       expect(buttonStepUpEl.disabled).toBeTruthy()
+      expect(inputEl.value).toBe('9.5')
       done()
     }, 10)
   })

--- a/js/tests/unit/quantity-selector.spec.js
+++ b/js/tests/unit/quantity-selector.spec.js
@@ -42,10 +42,10 @@ describe('QuantitySelector', () => {
 
       const div = fixtureEl.querySelector('div')
 
-      jQueryMock.fn.quantity_selector = QuantitySelector.jQueryInterface
+      jQueryMock.fn.quantitySelector = QuantitySelector.jQueryInterface
       jQueryMock.elements = [div]
 
-      jQueryMock.fn.quantity_selector.call(jQueryMock)
+      jQueryMock.fn.quantitySelector.call(jQueryMock)
 
       expect(QuantitySelector.getInstance(div)).not.toBeNull()
     })
@@ -54,14 +54,14 @@ describe('QuantitySelector', () => {
       fixtureEl.innerHTML = '<div></div>'
 
       const div = fixtureEl.querySelector('div')
-      const quantity_selector = new QuantitySelector(div)
+      const quantitySelector = new QuantitySelector(div)
 
-      jQueryMock.fn.quantity_selector = QuantitySelector.jQueryInterface
+      jQueryMock.fn.quantitySelector = QuantitySelector.jQueryInterface
       jQueryMock.elements = [div]
 
-      jQueryMock.fn.quantity_selector.call(jQueryMock)
+      jQueryMock.fn.quantitySelector.call(jQueryMock)
 
-      expect(QuantitySelector.getInstance(div)).toEqual(quantity_selector)
+      expect(QuantitySelector.getInstance(div)).toEqual(quantitySelector)
     })
 
     it('should throw error on undefined method', () => {
@@ -70,11 +70,11 @@ describe('QuantitySelector', () => {
       const div = fixtureEl.querySelector('div')
       const action = 'undefinedMethod'
 
-      jQueryMock.fn.quantity_selector = QuantitySelector.jQueryInterface
+      jQueryMock.fn.quantitySelector = QuantitySelector.jQueryInterface
       jQueryMock.elements = [div]
 
       expect(() => {
-        jQueryMock.fn.quantity_selector.call(jQueryMock, action)
+        jQueryMock.fn.quantitySelector.call(jQueryMock, action)
       }).toThrowError(TypeError, `No method named "${action}"`)
     })
   })

--- a/js/tests/unit/quantity-selector.spec.js
+++ b/js/tests/unit/quantity-selector.spec.js
@@ -132,7 +132,7 @@ describe('QuantitySelector', () => {
     expect(inputEl.value).toBe('0')
   })
 
-  it('should increment by 0.5 step on click on Step Up button', () => {
+  it('should increment a decimal value by 0.5 step on click on Step Up button and round it', () => {
     fixtureEl.innerHTML = [
       '<div class="input-group quantity-selector">',
       '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1.25" min="0" max="10" step="0.5" data-bs-round="1" aria-label="Quantity selector">',

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -8,3 +8,4 @@
 @import "forms/input-group";
 @import "forms/star-rating"; // Boosted mod
 @import "forms/validation";
+@import "forms/quantity-selector"; // Boosted mod

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -360,10 +360,8 @@ $success-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
 $info-icon:             url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 125 125'><path fill='#{$info}' d='M62.5 0a62.5 62.5 0 1 0 0 125 62.5 62.5 0 0 0 0-125zm0 14.7a11 11 0 1 1 0 22 11 11 0 0 1 0-22zM47.8 44.1h25.7v46.2c0 4.7 1.3 6.5 1.8 7.2.8 1 2.3 1.5 4.8 1.6h.8v3.8H47.8v-3.7h.8c2.3-.1 4-.8 5-2 .4-.4 1-2 1-7V57c0-4.8-.6-6.6-1.2-7.3-.8-1-2.4-1.5-4.9-1.6h-.7V44z'/></svg>") !default;
 $warning-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path fill='#{$warning}' d='M15 0a15 15 0 1 0 0 30 15 15 0 0 0 0-30zm.15 5.39h.01c1.12 0 2 .95 1.92 2.06l-.63 10.43c0 .7-.58.97-1.29.97-.72 0-1.28-.27-1.28-.97l-.63-10.46c-.06-1.09.8-2.01 1.9-2.03zm-.3 15.33c.11 0 .21 0 .31.02 2.19.35 2.19 3.5 0 3.84-2.77.44-3.1-3.86-.3-3.86z'/></svg>") !default;
 $danger-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 140 125'><path fill='#{$danger}' d='M70.3 0c-5.8 0-10.8 3.1-13.5 7.8L2.3 101.3l-.2.2A15.6 15.6 0 0 0 15.6 125H125a15.6 15.6 0 0 0 13.5-23.5L83.8 7.8A15.6 15.6 0 0 0 70.3 0zm19.2 50a6.4 6.4 0 0 1 4.4 1.9 6.4 6.4 0 0 1 0 9L79.4 75.6l15 15a6.4 6.4 0 0 1 0 9.2 6.4 6.4 0 0 1-4.5 1.9 6.4 6.4 0 0 1-4.6-2l-15-15-15 15a6.4 6.4 0 0 1-4.6 2 6.4 6.4 0 0 1-4.6-2 6.4 6.4 0 0 1 0-9l15-15L46.8 61a6.4 6.4 0 1 1 9-9.1l14.6 14.5L84.8 52a6.4 6.4 0 0 1 4.7-1.9z'/></svg>") !default;
-$add-icon:              url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><path fill='currentColor' d='M14 6H8V0H6v6H0v2h6v6h2V8h6V6z'/></svg>") !default;
-$remove-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 2'><path fill='currentColor' d='M0 0h14v2H0z'/></svg>") !default;
-$add-icon-sm:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><path d='M10 4H6V0H4v4H0v2h4v4h2V6h4V4z'/></svg>") !default;
-$remove-icon-sm:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 2'><path d='M0 0h10v2H0z'/></svg>") !default;
+$add-icon:              url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><path fill='currentColor' d='M6 0h2v6h6v2H8v6H6V8H0V6h6z'/></svg>") !default;
+$remove-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 2'><path fill='currentColor' d='M0 0v2h14V0H0Z'/></svg>") !default;
 
 //// SVG used several times
 $svg-as-custom-props: (
@@ -1883,26 +1881,19 @@ $step-item-arrow-shape:  polygon(0% 0%, subtract(100%, $border-width) 50%, 0% 10
 
 //// Quantity selector
 // scss-docs-start quantity-selector
-$quantity-selector-width:                 7.5rem !default;
-$quantity-selector-sm-width:              5.5rem !default;
+$quantity-selector-icon-add:              $add-icon !default;
+$quantity-selector-icon-remove:           $remove-icon !default;
 
-$quantity-selector-btn-padding-x:         add($btn-icon-padding-x, 2px) !default;
-$quantity-selector-btn-padding-x-sm:      add($btn-icon-padding-x-sm, 2px) !default;
+$quantity-selector-sm-width:              5.625rem !default;
+$quantity-selector-input-width:           2.75rem !default;
+$quantity-selector-input-sm-width:        2.125rem !default;
 
 $quantity-selector-icon-width:            .875rem !default;
-$quantity-selector-icon-sm-width:         .625rem !default;
-
-$quantity-selector-icon-add:              $add-icon !default;
-$quantity-selector-icon-add-sm:           $add-icon-sm !default;
-$quantity-selector-icon-add-height:       .875rem !default;
-$quantity-selector-icon-sm-add-height:    .625rem !default;
-
-$quantity-selector-icon-remove:           $remove-icon !default;
-$quantity-selector-icon-remove-sm:        $remove-icon-sm !default;
 $quantity-selector-icon-remove-height:    .125rem !default;
-$quantity-selector-icon-sm-remove-height: .125rem !default;
+$quantity-selector-icon-add-height:       .875rem !default;
 
-$quantity-selector-input-max-width:       2.625rem !default;
-$quantity-selector-input-sm-max-width:    2.5rem !default;
+$quantity-selector-icon-sm-width:         .625rem !default;
+$quantity-selector-icon-sm-remove-height: .125rem !default;
+$quantity-selector-icon-sm-add-height:    .625rem !default;
 // scss-docs-end quantity-selector
 // End mod

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -360,8 +360,10 @@ $success-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
 $info-icon:             url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 125 125'><path fill='#{$info}' d='M62.5 0a62.5 62.5 0 1 0 0 125 62.5 62.5 0 0 0 0-125zm0 14.7a11 11 0 1 1 0 22 11 11 0 0 1 0-22zM47.8 44.1h25.7v46.2c0 4.7 1.3 6.5 1.8 7.2.8 1 2.3 1.5 4.8 1.6h.8v3.8H47.8v-3.7h.8c2.3-.1 4-.8 5-2 .4-.4 1-2 1-7V57c0-4.8-.6-6.6-1.2-7.3-.8-1-2.4-1.5-4.9-1.6h-.7V44z'/></svg>") !default;
 $warning-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path fill='#{$warning}' d='M15 0a15 15 0 1 0 0 30 15 15 0 0 0 0-30zm.15 5.39h.01c1.12 0 2 .95 1.92 2.06l-.63 10.43c0 .7-.58.97-1.29.97-.72 0-1.28-.27-1.28-.97l-.63-10.46c-.06-1.09.8-2.01 1.9-2.03zm-.3 15.33c.11 0 .21 0 .31.02 2.19.35 2.19 3.5 0 3.84-2.77.44-3.1-3.86-.3-3.86z'/></svg>") !default;
 $danger-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 140 125'><path fill='#{$danger}' d='M70.3 0c-5.8 0-10.8 3.1-13.5 7.8L2.3 101.3l-.2.2A15.6 15.6 0 0 0 15.6 125H125a15.6 15.6 0 0 0 13.5-23.5L83.8 7.8A15.6 15.6 0 0 0 70.3 0zm19.2 50a6.4 6.4 0 0 1 4.4 1.9 6.4 6.4 0 0 1 0 9L79.4 75.6l15 15a6.4 6.4 0 0 1 0 9.2 6.4 6.4 0 0 1-4.5 1.9 6.4 6.4 0 0 1-4.6-2l-15-15-15 15a6.4 6.4 0 0 1-4.6 2 6.4 6.4 0 0 1-4.6-2 6.4 6.4 0 0 1 0-9l15-15L46.8 61a6.4 6.4 0 1 1 9-9.1l14.6 14.5L84.8 52a6.4 6.4 0 0 1 4.7-1.9z'/></svg>") !default;
-$add-icon:              url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><path fill='currentColor' d='M6 0h2v6h6v2H8v6H6V8H0V6h6z'/></svg>") !default;
-$remove-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 2'><path fill='currentColor' d='M0 0v2h14V0H0Z'/></svg>") !default;
+$add-icon:              url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><path fill='currentColor' d='M14 6H8V0H6v6H0v2h6v6h2V8h6V6z'/></svg>") !default;
+$remove-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 2'><path fill='currentColor' d='M0 0h14v2H0z'/></svg>") !default;
+$add-icon-sm:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><path d='M10 4H6V0H4v4H0v2h4v4h2V6h4V4z'/></svg>") !default;
+$remove-icon-sm:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 2'><path d='M0 0h10v2H0z'/></svg>") !default;
 
 //// SVG used several times
 $svg-as-custom-props: (
@@ -934,6 +936,8 @@ $form-label-disabled-color:             $gray-500 !default; // Boosted mod
 // scss-docs-start form-input-variables
 $input-padding-y:                       $input-btn-padding-y !default;
 $input-padding-x:                       $spacer * .5 !default;
+$input-padding-y-sm:                    divide($input-padding-y, 2) !default;
+$input-padding-x-sm:                    divide($input-padding-y, 2) !default;
 $input-font-family:                     $input-btn-font-family !default;
 $input-font-size:                       $input-btn-font-size !default;
 $input-font-weight:                     $font-weight-bold !default;
@@ -1879,19 +1883,26 @@ $step-item-arrow-shape:  polygon(0% 0%, subtract(100%, $border-width) 50%, 0% 10
 
 //// Quantity selector
 // scss-docs-start quantity-selector
-$quantity-selector-icon-add:              $add-icon !default;
-$quantity-selector-icon-remove:           $remove-icon !default;
+$quantity-selector-width:                 7.5rem !default;
+$quantity-selector-sm-width:              5.5rem !default;
 
-$quantity-selector-sm-width:              5.625rem !default;
-$quantity-selector-input-width:           2.75rem !default;
-$quantity-selector-input-sm-width:        2.125rem !default;
+$quantity-selector-btn-padding-x:         add($btn-icon-padding-x, 2px) !default;
+$quantity-selector-btn-padding-x-sm:      add($btn-icon-padding-x-sm, 2px) !default;
 
 $quantity-selector-icon-width:            .875rem !default;
-$quantity-selector-icon-remove-height:    .125rem !default;
-$quantity-selector-icon-add-height:       .875rem !default;
-
 $quantity-selector-icon-sm-width:         .625rem !default;
-$quantity-selector-icon-sm-remove-height: .125rem !default;
+
+$quantity-selector-icon-add:              $add-icon !default;
+$quantity-selector-icon-add-sm:           $add-icon-sm !default;
+$quantity-selector-icon-add-height:       .875rem !default;
 $quantity-selector-icon-sm-add-height:    .625rem !default;
+
+$quantity-selector-icon-remove:           $remove-icon !default;
+$quantity-selector-icon-remove-sm:        $remove-icon-sm !default;
+$quantity-selector-icon-remove-height:    .125rem !default;
+$quantity-selector-icon-sm-remove-height: .125rem !default;
+
+$quantity-selector-input-max-width:       2.625rem !default;
+$quantity-selector-input-sm-max-width:    2.5rem !default;
 // scss-docs-end quantity-selector
 // End mod

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -936,14 +936,14 @@ $form-label-disabled-color:             $gray-500 !default; // Boosted mod
 // scss-docs-start form-input-variables
 $input-padding-y:                       $input-btn-padding-y !default;
 $input-padding-x:                       $spacer * .5 !default;
-$input-padding-y-sm:                    divide($input-padding-y, 2) !default;
-$input-padding-x-sm:                    divide($input-padding-y, 2) !default;
 $input-font-family:                     $input-btn-font-family !default;
 $input-font-size:                       $input-btn-font-size !default;
 $input-font-weight:                     $font-weight-bold !default;
 $input-line-height:                     $input-btn-line-height !default;
 
-// Boosted mod: no input-sm
+$input-padding-y-sm:                    divide($input-padding-y, 2) !default; // Boosted mod
+$input-padding-x-sm:                    divide($input-padding-y, 2) !default; // Boosted mod
+// Boosted mod: no $input-font-size-sm
 
 $input-padding-y-lg:                    $input-btn-padding-y-lg !default;
 $input-padding-x-lg:                    $input-btn-padding-x-lg !default;
@@ -975,15 +975,13 @@ $input-plaintext-color:                 $body-color !default;
 // Boosted mod: no $input-height-inner-*
 
 $input-height:                          2.5rem !default;
-// Boosted mod: no input-sm
+// Boosted mod: no $input-height-sm
 $input-height-lg:                       3.125rem !default;
 $input-line-height-lg:                  $h5-line-height !default; // Boosted mod
 
 $input-transition:                      border-color $transition-duration $transition-timing, $transition-focus !default;
 
 $form-color-width:                      3rem !default;
-// End mod
-
 // scss-docs-end form-input-variables
 
 // scss-docs-start form-check-variables

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -360,8 +360,10 @@ $success-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
 $info-icon:             url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 125 125'><path fill='#{$info}' d='M62.5 0a62.5 62.5 0 1 0 0 125 62.5 62.5 0 0 0 0-125zm0 14.7a11 11 0 1 1 0 22 11 11 0 0 1 0-22zM47.8 44.1h25.7v46.2c0 4.7 1.3 6.5 1.8 7.2.8 1 2.3 1.5 4.8 1.6h.8v3.8H47.8v-3.7h.8c2.3-.1 4-.8 5-2 .4-.4 1-2 1-7V57c0-4.8-.6-6.6-1.2-7.3-.8-1-2.4-1.5-4.9-1.6h-.7V44z'/></svg>") !default;
 $warning-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path fill='#{$warning}' d='M15 0a15 15 0 1 0 0 30 15 15 0 0 0 0-30zm.15 5.39h.01c1.12 0 2 .95 1.92 2.06l-.63 10.43c0 .7-.58.97-1.29.97-.72 0-1.28-.27-1.28-.97l-.63-10.46c-.06-1.09.8-2.01 1.9-2.03zm-.3 15.33c.11 0 .21 0 .31.02 2.19.35 2.19 3.5 0 3.84-2.77.44-3.1-3.86-.3-3.86z'/></svg>") !default;
 $danger-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 140 125'><path fill='#{$danger}' d='M70.3 0c-5.8 0-10.8 3.1-13.5 7.8L2.3 101.3l-.2.2A15.6 15.6 0 0 0 15.6 125H125a15.6 15.6 0 0 0 13.5-23.5L83.8 7.8A15.6 15.6 0 0 0 70.3 0zm19.2 50a6.4 6.4 0 0 1 4.4 1.9 6.4 6.4 0 0 1 0 9L79.4 75.6l15 15a6.4 6.4 0 0 1 0 9.2 6.4 6.4 0 0 1-4.5 1.9 6.4 6.4 0 0 1-4.6-2l-15-15-15 15a6.4 6.4 0 0 1-4.6 2 6.4 6.4 0 0 1-4.6-2 6.4 6.4 0 0 1 0-9l15-15L46.8 61a6.4 6.4 0 1 1 9-9.1l14.6 14.5L84.8 52a6.4 6.4 0 0 1 4.7-1.9z'/></svg>") !default;
-$add-icon:              url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><path fill='currentColor' d='M6 0h2v6h6v2H8v6H6V8H0V6h6z'/></svg>") !default;
-$remove-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 2'><path fill='currentColor' d='M0 0v2h14V0H0Z'/></svg>") !default;
+$add-icon:              url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><path fill='currentColor' d='M14 6H8V0H6v6H0v2h6v6h2V8h6V6z'/></svg>") !default;
+$remove-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 2'><path fill='currentColor' d='M0 0h14v2H0z'/></svg>") !default;
+$add-icon-sm:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><path d='M10 4H6V0H4v4H0v2h4v4h2V6h4V4z'/></svg>") !default;
+$remove-icon-sm:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 2'><path d='M0 0h10v2H0z'/></svg>") !default;
 
 //// SVG used several times
 $svg-as-custom-props: (
@@ -1881,19 +1883,26 @@ $step-item-arrow-shape:  polygon(0% 0%, subtract(100%, $border-width) 50%, 0% 10
 
 //// Quantity selector
 // scss-docs-start quantity-selector
-$quantity-selector-icon-add:              $add-icon !default;
-$quantity-selector-icon-remove:           $remove-icon !default;
+$quantity-selector-width:                 7.5rem !default;
+$quantity-selector-sm-width:              5.5rem !default;
 
-$quantity-selector-sm-width:              5.625rem !default;
-$quantity-selector-input-width:           2.75rem !default;
-$quantity-selector-input-sm-width:        2.125rem !default;
+$quantity-selector-btn-padding-x:         add($btn-icon-padding-x, 2px) !default;
+$quantity-selector-btn-padding-x-sm:      add($btn-icon-padding-x-sm, 2px) !default;
 
 $quantity-selector-icon-width:            .875rem !default;
-$quantity-selector-icon-remove-height:    .125rem !default;
-$quantity-selector-icon-add-height:       .875rem !default;
-
 $quantity-selector-icon-sm-width:         .625rem !default;
-$quantity-selector-icon-sm-remove-height: .125rem !default;
+
+$quantity-selector-icon-add:              $add-icon !default;
+$quantity-selector-icon-add-sm:           $add-icon-sm !default;
+$quantity-selector-icon-add-height:       .875rem !default;
 $quantity-selector-icon-sm-add-height:    .625rem !default;
+
+$quantity-selector-icon-remove:           $remove-icon !default;
+$quantity-selector-icon-remove-sm:        $remove-icon-sm !default;
+$quantity-selector-icon-remove-height:    .125rem !default;
+$quantity-selector-icon-sm-remove-height: .125rem !default;
+
+$quantity-selector-input-max-width:       2.625rem !default;
+$quantity-selector-input-sm-max-width:    2.5rem !default;
 // scss-docs-end quantity-selector
 // End mod

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -360,6 +360,9 @@ $success-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
 $info-icon:             url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 125 125'><path fill='#{$info}' d='M62.5 0a62.5 62.5 0 1 0 0 125 62.5 62.5 0 0 0 0-125zm0 14.7a11 11 0 1 1 0 22 11 11 0 0 1 0-22zM47.8 44.1h25.7v46.2c0 4.7 1.3 6.5 1.8 7.2.8 1 2.3 1.5 4.8 1.6h.8v3.8H47.8v-3.7h.8c2.3-.1 4-.8 5-2 .4-.4 1-2 1-7V57c0-4.8-.6-6.6-1.2-7.3-.8-1-2.4-1.5-4.9-1.6h-.7V44z'/></svg>") !default;
 $warning-icon:          url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path fill='#{$warning}' d='M15 0a15 15 0 1 0 0 30 15 15 0 0 0 0-30zm.15 5.39h.01c1.12 0 2 .95 1.92 2.06l-.63 10.43c0 .7-.58.97-1.29.97-.72 0-1.28-.27-1.28-.97l-.63-10.46c-.06-1.09.8-2.01 1.9-2.03zm-.3 15.33c.11 0 .21 0 .31.02 2.19.35 2.19 3.5 0 3.84-2.77.44-3.1-3.86-.3-3.86z'/></svg>") !default;
 $danger-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 140 125'><path fill='#{$danger}' d='M70.3 0c-5.8 0-10.8 3.1-13.5 7.8L2.3 101.3l-.2.2A15.6 15.6 0 0 0 15.6 125H125a15.6 15.6 0 0 0 13.5-23.5L83.8 7.8A15.6 15.6 0 0 0 70.3 0zm19.2 50a6.4 6.4 0 0 1 4.4 1.9 6.4 6.4 0 0 1 0 9L79.4 75.6l15 15a6.4 6.4 0 0 1 0 9.2 6.4 6.4 0 0 1-4.5 1.9 6.4 6.4 0 0 1-4.6-2l-15-15-15 15a6.4 6.4 0 0 1-4.6 2 6.4 6.4 0 0 1-4.6-2 6.4 6.4 0 0 1 0-9l15-15L46.8 61a6.4 6.4 0 1 1 9-9.1l14.6 14.5L84.8 52a6.4 6.4 0 0 1 4.7-1.9z'/></svg>") !default;
+$add-icon:              url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 14'><path fill='currentColor' d='M6 0h2v6h6v2H8v6H6V8H0V6h6z'/></svg>") !default;
+$remove-icon:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 2'><path fill='currentColor' d='M0 0v2h14V0H0Z'/></svg>") !default;
+
 //// SVG used several times
 $svg-as-custom-props: (
   "chevron": $chevron-icon,
@@ -368,6 +371,7 @@ $svg-as-custom-props: (
   "success": $success-icon,
   "error":   $danger-icon
 ) !default;
+
 //// Filters
 // see https://codepen.io/sosuke/pen/Pjoqqp
 $invert-filter:         invert(1) !default;
@@ -974,6 +978,8 @@ $input-line-height-lg:                  $h5-line-height !default; // Boosted mod
 $input-transition:                      border-color $transition-duration $transition-timing, $transition-focus !default;
 
 $form-color-width:                      3rem !default;
+// End mod
+
 // scss-docs-end form-input-variables
 
 // scss-docs-start form-check-variables
@@ -1870,4 +1876,22 @@ $step-link-marker-lg:    counter($stepped-process-counter) ".\A0" !default;
 $step-item-arrow-width:  1rem !default;
 $step-item-arrow-shape:  polygon(0% 0%, subtract(100%, $border-width) 50%, 0% 100%) #{"/* rtl:"} polygon(100% 0%, $border-width 50%, 100% 100%) #{"*/"} !default; // Used in clip-path
 // scss-docs-end stepped-process
+
+//// Quantity selector
+// scss-docs-start quantity-selector
+$quantity-selector-icon-add:              $add-icon !default;
+$quantity-selector-icon-remove:           $remove-icon !default;
+
+$quantity-selector-sm-width:              5.625rem !default;
+$quantity-selector-input-width:           2.75rem !default;
+$quantity-selector-input-sm-width:        2.125rem !default;
+
+$quantity-selector-icon-width:            .875rem !default;
+$quantity-selector-icon-remove-height:    .125rem !default;
+$quantity-selector-icon-add-height:       .875rem !default;
+
+$quantity-selector-icon-sm-width:         .625rem !default;
+$quantity-selector-icon-sm-remove-height: .125rem !default;
+$quantity-selector-icon-sm-add-height:    .625rem !default;
+// scss-docs-end quantity-selector
 // End mod

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -1,9 +1,19 @@
 .quantity-selector {
-  width: $quantity-selector-width;
+  width: 7.5em;
+  $validation-messages: "";
+
+  @each $state in map-keys($form-validation-states) {
+    $validation-messages: $validation-messages + ":not(." + unquote($state) + "-tooltip)" + ":not(." + unquote($state) + "-feedback)";
+  }
+
+  > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
+    margin-left: 0;
+  }
 
   .form-control {
-    max-width: $quantity-selector-input-max-width;
-    font-size: $font-size-base;
+    max-width: $quantity-selector-input-width;
+    padding: 0;
+    font-size: $font-size-sm;
     text-align: center;
     transition: none; // stylelint-disable-line property-disallowed-list
     appearance: textfield;
@@ -18,11 +28,6 @@
       margin: 0;
       appearance: none;
     }
-
-    &:disabled {
-      color: $gray-500;
-      background-color: $white;
-    }
   }
 
   button {
@@ -31,23 +36,19 @@
     &:first-of-type {
       @include button-icon($quantity-selector-icon-remove, $size: $quantity-selector-icon-width $quantity-selector-icon-remove-height, $pseudo: "after");
       order: -1;
-      padding-right: $quantity-selector-btn-padding-x;
       border-right: none;
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
-        @include button-icon($quantity-selector-icon-remove-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-remove-height, $pseudo: "after");
-        padding-right: $quantity-selector-btn-padding-x-sm;
+        @include button-icon($quantity-selector-icon-remove, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-remove-height, $pseudo: "after");
       }
     }
 
     &:last-of-type {
       @include button-icon($quantity-selector-icon-add, $size: $quantity-selector-icon-width $quantity-selector-icon-add-height, $pseudo: "after");
-      padding-left: $quantity-selector-btn-padding-x;
       border-left: none;
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
-        @include button-icon($quantity-selector-icon-add-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-add-height, $pseudo: "after");
-        padding-left: $quantity-selector-btn-padding-x-sm;
+        @include button-icon($quantity-selector-icon-add, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-add-height, $pseudo: "after");
       }
     }
   }
@@ -57,8 +58,7 @@
   width: $quantity-selector-sm-width;
 
   .form-control {
-    max-width: $quantity-selector-input-sm-max-width;
-    padding: subtract($input-padding-x-sm, 1px) 0 $input-padding-y-sm; // Boosted mod
-    font-size: $font-size-sm;
+    max-width: $quantity-selector-input-sm-width;
+    font-size: $font-size-base;
   }
 }

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -4,7 +4,7 @@
   .form-control {
     max-width: $quantity-selector-input-max-width;
     text-align: center;
-    transition: none; // stylelint-disable-line property-disallowed-list
+    @include transition(none);
     appearance: textfield;
 
     &:not(:focus) {
@@ -57,7 +57,7 @@
 
   .form-control {
     max-width: $quantity-selector-input-sm-max-width;
-    padding: subtract($input-padding-x-sm, 1px) 0 $input-padding-y-sm; // Boosted mod
+    padding: subtract($input-padding-x-sm, 1px) 0 $input-padding-y-sm;
     font-size: $font-size-sm;
   }
 }

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -1,19 +1,9 @@
 .quantity-selector {
-  width: 7.5em;
-  $validation-messages: "";
-
-  @each $state in map-keys($form-validation-states) {
-    $validation-messages: $validation-messages + ":not(." + unquote($state) + "-tooltip)" + ":not(." + unquote($state) + "-feedback)";
-  }
-
-  > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
-    margin-left: 0;
-  }
+  width: $quantity-selector-width;
 
   .form-control {
-    max-width: $quantity-selector-input-width;
-    padding: 0;
-    font-size: $font-size-sm;
+    max-width: $quantity-selector-input-max-width;
+    font-size: $font-size-base;
     text-align: center;
     transition: none; // stylelint-disable-line property-disallowed-list
     appearance: textfield;
@@ -28,6 +18,11 @@
       margin: 0;
       appearance: none;
     }
+
+    &:disabled {
+      color: $gray-500;
+      background-color: $white;
+    }
   }
 
   button {
@@ -36,19 +31,23 @@
     &:first-of-type {
       @include button-icon($quantity-selector-icon-remove, $size: $quantity-selector-icon-width $quantity-selector-icon-remove-height, $pseudo: "after");
       order: -1;
+      padding-right: $quantity-selector-btn-padding-x;
       border-right: none;
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
-        @include button-icon($quantity-selector-icon-remove, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-remove-height, $pseudo: "after");
+        @include button-icon($quantity-selector-icon-remove-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-remove-height, $pseudo: "after");
+        padding-right: $quantity-selector-btn-padding-x-sm;
       }
     }
 
     &:last-of-type {
       @include button-icon($quantity-selector-icon-add, $size: $quantity-selector-icon-width $quantity-selector-icon-add-height, $pseudo: "after");
+      padding-left: $quantity-selector-btn-padding-x;
       border-left: none;
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
-        @include button-icon($quantity-selector-icon-add, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-add-height, $pseudo: "after");
+        @include button-icon($quantity-selector-icon-add-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-add-height, $pseudo: "after");
+        padding-left: $quantity-selector-btn-padding-x-sm;
       }
     }
   }
@@ -58,7 +57,8 @@
   width: $quantity-selector-sm-width;
 
   .form-control {
-    max-width: $quantity-selector-input-sm-width;
-    font-size: $font-size-base;
+    max-width: $quantity-selector-input-sm-max-width;
+    padding: subtract($input-padding-x-sm, 1px) 0 $input-padding-y-sm; // Boosted mod
+    font-size: $font-size-sm;
   }
 }

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -1,0 +1,64 @@
+.quantity-selector {
+  width: 7.5em;
+  $validation-messages: "";
+
+  @each $state in map-keys($form-validation-states) {
+    $validation-messages: $validation-messages + ":not(." + unquote($state) + "-tooltip)" + ":not(." + unquote($state) + "-feedback)";
+  }
+
+  > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
+    margin-left: 0;
+  }
+
+  .form-control {
+    max-width: $quantity-selector-input-width;
+    padding: 0;
+    font-size: $font-size-sm;
+    text-align: center;
+    transition: none; // stylelint-disable-line property-disallowed-list
+    appearance: textfield;
+
+    &:not(:focus) {
+      border-right: none;
+      border-left: none;
+    }
+
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+      margin: 0;
+      appearance: none;
+    }
+  }
+
+  button {
+    border: $border-width solid $gray-500;
+
+    &:first-of-type {
+      @include button-icon($quantity-selector-icon-remove, $size: $quantity-selector-icon-width $quantity-selector-icon-remove-height, $pseudo: "after");
+      order: -1;
+      border-right: none;
+
+      &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
+        @include button-icon($quantity-selector-icon-remove, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-remove-height, $pseudo: "after");
+      }
+    }
+
+    &:last-of-type {
+      @include button-icon($quantity-selector-icon-add, $size: $quantity-selector-icon-width $quantity-selector-icon-add-height, $pseudo: "after");
+      border-left: none;
+
+      &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
+        @include button-icon($quantity-selector-icon-add, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-add-height, $pseudo: "after");
+      }
+    }
+  }
+}
+
+.quantity-selector-sm {
+  width: $quantity-selector-sm-width;
+
+  .form-control {
+    max-width: $quantity-selector-input-sm-width;
+    font-size: $font-size-base;
+  }
+}

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -3,7 +3,6 @@
 
   .form-control {
     max-width: $quantity-selector-input-max-width;
-    font-size: $font-size-base;
     text-align: center;
     transition: none; // stylelint-disable-line property-disallowed-list
     appearance: textfield;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -75,6 +75,20 @@
       }
     }
 
+    // Boosted mod: Remove border on input for form element QuantitySelector
+    .quantity-selector {
+      .form-control {
+        @include form-validation-state-selector($state) {
+          border-right: none;
+          border-left: none;
+          & ~ button {
+            border-color: $color;
+          }
+        }
+      }
+    }
+    // End mod
+
     // Boosted mod: no icon in background for textarea
 
     .form-select {

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -76,13 +76,14 @@
     }
 
     // Boosted mod: Remove border on input for form element QuantitySelector
-    .quantity-selector .form-control {
-      @include form-validation-state-selector($state) {
-        border-right: none;
-        border-left: none;
-
-        & ~ button {
-          border-color: $color;
+    .quantity-selector {
+      .form-control {
+        @include form-validation-state-selector($state) {
+          border-right: none;
+          border-left: none;
+          & ~ button {
+            border-color: $color;
+          }
         }
       }
     }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -76,14 +76,13 @@
     }
 
     // Boosted mod: Remove border on input for form element QuantitySelector
-    .quantity-selector {
-      .form-control {
-        @include form-validation-state-selector($state) {
-          border-right: none;
-          border-left: none;
-          & ~ button {
-            border-color: $color;
-          }
+    .quantity-selector .form-control {
+      @include form-validation-state-selector($state) {
+        border-right: none;
+        border-left: none;
+
+        & ~ button {
+          border-color: $color;
         }
       }
     }

--- a/site/content/docs/5.1/about/overview.md
+++ b/site/content/docs/5.1/about/overview.md
@@ -25,6 +25,7 @@ Boosted ships with custom accessible components to suit specific needs:
 - [Back to top]({{< docsref "/components/back-to-top" >}})
 - [Orange Navbars]({{< docsref "/components/orange-navbar" >}})
 - [Star rating]({{< docsref "/forms/checks-radios#star-rating" >}})
+- [Quantity selector]({{< docsref "/forms/quantity-selector" >}})
 - [Stepped process]({{< docsref "/components/stepped-process" >}})
 
 

--- a/site/content/docs/5.1/customize/overview.md
+++ b/site/content/docs/5.1/customize/overview.md
@@ -51,5 +51,6 @@ Several Boosted components include embedded SVGs in our CSS to style components 
 - [Carousel controls]({{< docsref "/components/carousel#with-controls" >}})
 - [Navbar toggle buttons]({{< docsref "/components/navbar#responsive-behaviors" >}})
 - [Pagination]({{< docsref "/components/pagination" >}}) <!-- Boosted mod -->
+- [Quantity selector buttons]({{< docsref "/forms/quantity-selector" >}}) <!-- Boosted mod -->
 
 Based on [community conversation](https://github.com/twbs/bootstrap/issues/25394), some options for addressing this in your own codebase include replacing the URLs with locally hosted assets, removing the images and using inline images (not possible in all components), and modifying your CSP. Our recommendation is to carefully review your own security policies and decide on the best path forward, if necessary.

--- a/site/content/docs/5.1/forms/overview.md
+++ b/site/content/docs/5.1/forms/overview.md
@@ -16,6 +16,8 @@ sections:
     description: Replace browser default range inputs with our custom version.
   - title: Input group
     description: Attach labels and buttons to your inputs for increased semantic value.
+  - title: Quantity selector
+    description: Use our custom quantity selector in forms for selecting a number.
   - title: Layout
     description: Create inline, horizontal, or complex grid-based layouts with your forms.
   - title: Validation

--- a/site/content/docs/5.1/forms/quantity-selector.md
+++ b/site/content/docs/5.1/forms/quantity-selector.md
@@ -76,7 +76,7 @@ The `data-bs-round` attribute will help you to define the number of digits to ap
 
 ### Events
 
-Boosted's quantity selector form component exposes one event for hooking into quantity selector functionality.
+Boosted's quantity selector form component exposes the classic `change` event when the value of an input has been changed.
 
 <table class="table">
   <thead>
@@ -88,7 +88,7 @@ Boosted's quantity selector form component exposes one event for hooking into qu
   <tbody>
     <tr>
       <td>
-        <code>change.bs.quantitySelector</code>
+        <code>change</code>
       </td>
       <td>
         Fires immediately when the value inside the input is modified.
@@ -99,7 +99,7 @@ Boosted's quantity selector form component exposes one event for hooking into qu
 
 ```js
 var myQuantitySelector = document.getElementById('inputQuantitySelector')
-myQuantitySelector.addEventListener('change.bs.quantitySelector', function () {
+myQuantitySelector.addEventListener('change', function () {
   // do something...
 })
 ```

--- a/site/content/docs/5.1/forms/quantity-selector.md
+++ b/site/content/docs/5.1/forms/quantity-selector.md
@@ -1,0 +1,80 @@
+---
+layout: docs
+title: Quantity selector
+description: Form element used to select a number.
+group: forms
+toc: true
+---
+
+## Examples
+
+Quantity selector is a form element used to select a number. The default version is the large version. To use the small version, use the contextual class `.quantity-selector-sm`.
+
+You can specify a default value in the `value` attribute of your input.
+
+Value will vary between the values define in the `min` and `max` attributes (negatives values are allowed).
+
+The custom `data-bs-round` attribute will help you to define the number of digits to appear after the decimal point.
+
+{{< example >}}
+<form>
+  <div class="mb-3">
+    <label for="inputQuantitySelector1" class="form-label">Quantity selector large:</label>
+    <div class="input-group quantity-selector w-100">
+      <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">
+        <span class="visually-hidden">Step down</span>
+      </button>
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">
+        <span class="visually-hidden">Step up</span>
+      </button>
+    </div>
+    <div class="quantitySelectorHelp form-text">Lorem ipsum.</div>
+  </div>
+  <div class="mb-3">
+    <label for="inputQuantitySelector2" class="form-label">Quantity selector small:</label>
+    <div class="input-group quantity-selector quantity-selector-sm w-100">
+      <input type="number" id="inputQuantitySelector2" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+      <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelector2" data-bs-step="down">
+        <span class="visually-hidden">Step down</span>
+      </button>
+      <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelector2" data-bs-step="up">
+        <span class="visually-hidden">Step up</span>
+      </button>
+    </div>
+    <div class="quantitySelectorHelp form-text">Lorem ipsum.</div>
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+{{< /example >}}
+
+## Disabled
+
+Add the `disabled` boolean attribute on a select to give it a grayed out appearance and remove pointer events.
+
+{{< example >}}
+<form>
+  <div class="mb-3">
+    <label for="inputQuantitySelector3" class="form-label">Disabled large quantity selector:</label>
+    <div class="input-group quantity-selector">
+      <input type="number" id="inputQuantitySelector3" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector" disabled>
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector3" data-bs-step="down" disabled>
+        <span class="visually-hidden">Step down</span>
+      </button>
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector3" data-bs-step="up" disabled>
+        <span class="visually-hidden">Step up</span>
+      </button>
+    </div>
+    <div class="quantitySelectorHelp form-text">Lorem ipsum.</div>
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+{{< /example >}}
+
+## Sass
+
+### Variables
+
+For more details, please have a look at the exhaustive list of available variables:
+
+{{< scss-docs name="quantity-selector" file="scss/_variables.scss" >}}

--- a/site/content/docs/5.1/forms/quantity-selector.md
+++ b/site/content/docs/5.1/forms/quantity-selector.md
@@ -16,8 +16,6 @@ A default value can be specified with the input `value` attribute.
 
 Value will vary between the values defined for the `min` and `max` attributes (negative value are allowed). `min` and `max` values are customizable.
 
-The custom `data-bs-round` attribute will help you to define the number of digits to appear after the decimal point.
-
 {{< example >}}
 <div class="input-group quantity-selector">
   <input type="number" id="inputQuantitySelector" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
@@ -69,3 +67,22 @@ Add the `disabled` boolean attribute on quantity selector elements to give it a 
 For more details, please have a look at the exhaustive list of available variables:
 
 {{< scss-docs name="quantity-selector" file="scss/_variables.scss" >}}
+
+## Usage
+
+### Via data attributes
+
+The `data-bs-round` attribute will help you to define the number of digits to appear after the decimal point.
+
+
+### Via jQuery
+
+You can easily have access to the input value:
+
+```js
+$(document).ready(function () {
+  $("#inputQuantitySelector").on('change', function() {
+      // do something...
+  });
+});
+```

--- a/site/content/docs/5.1/forms/quantity-selector.md
+++ b/site/content/docs/5.1/forms/quantity-selector.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Quantity selector
-description: Use our custom quantity selector in forms for selecting a number.
+description: Use our custom quantity selector in forms for incremental and decremental display of small numbers.
 group: forms
 toc: true
 ---
@@ -15,6 +15,8 @@ Quantity selector is a form element used to select a number.
 A default value can be specified with the input `value` attribute.
 
 Value will vary between the values defined for the `min` and `max` attributes (negative value are allowed). `min` and `max` values are customizable.
+
+`step` attribute is also customizable and define the interval between values.
 
 {{< example >}}
 <div class="input-group quantity-selector">
@@ -30,7 +32,7 @@ Value will vary between the values defined for the `min` and `max` attributes (n
 
 ## Sizing
 
-You may also use small quantity selectors with the contextual class `.quantity-selector-sm`.
+Set small size using the contextual class `.quantity-selector-sm`.
 
 {{< example >}}
 <div class="input-group quantity-selector quantity-selector-sm">

--- a/site/content/docs/5.1/forms/quantity-selector.md
+++ b/site/content/docs/5.1/forms/quantity-selector.md
@@ -74,15 +74,32 @@ For more details, please have a look at the exhaustive list of available variabl
 
 The `data-bs-round` attribute will help you to define the number of digits to appear after the decimal point.
 
+### Events
 
-### Via jQuery
+Boosted's quantity selector form component exposes one event for hooking into quantity selector functionality.
 
-You can easily have access to the input value:
+<table class="table">
+  <thead>
+    <tr>
+      <th>Method</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>change.bs.quantitySelector</code>
+      </td>
+      <td>
+        Fires immediately when the value inside the input is modified.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ```js
-$(document).ready(function () {
-  $("#inputQuantitySelector").on('change', function() {
-      // do something...
-  });
-});
+var myQuantitySelector = document.getElementById('inputQuantitySelector')
+myQuantitySelector.addEventListener('change.bs.quantitySelector', function () {
+  // do something...
+})
 ```

--- a/site/content/docs/5.1/forms/quantity-selector.md
+++ b/site/content/docs/5.1/forms/quantity-selector.md
@@ -1,65 +1,74 @@
 ---
 layout: docs
 title: Quantity selector
-description: Use our custom quantity selector in forms for selecting a number.
+description: Form element used to select a number.
 group: forms
 toc: true
 ---
 
-## Default
+## Examples
 
-Quantity selector is a form element used to select a number.
+Quantity selector is a form element used to select a number. The default version is the large version. To use the small version, use the contextual class `.quantity-selector-sm`.
 
-**Please note that this component is suitable for incremental and decremental display of small numbers, i.e. numbers with 3-4 digits. We do not recommend using it with larger numbers.**
+You can specify a default value in the `value` attribute of your input.
 
-A default value can be specified with the input `value` attribute.
-
-Value will vary between the values defined for the `min` and `max` attributes (negative value are allowed). `min` and `max` values are customizable.
+Value will vary between the values define in the `min` and `max` attributes (negatives values are allowed).
 
 The custom `data-bs-round` attribute will help you to define the number of digits to appear after the decimal point.
 
 {{< example >}}
-<div class="input-group quantity-selector">
-  <input type="number" id="inputQuantitySelector" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
-  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector" data-bs-step="down">
-    <span class="visually-hidden">Step down</span>
-  </button>
-  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector" data-bs-step="up">
-    <span class="visually-hidden">Step up</span>
-  </button>
-</div>
-{{< /example >}}
-
-## Sizing
-
-You may also use small quantity selectors with the contextual class `.quantity-selector-sm`.
-
-{{< example >}}
-<div class="input-group quantity-selector quantity-selector-sm">
-  <input type="number" id="inputQuantitySelectorSm" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
-  <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelectorSm" data-bs-step="down">
-    <span class="visually-hidden">Step down</span>
-  </button>
-  <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelectorSm" data-bs-step="up">
-    <span class="visually-hidden">Step up</span>
-  </button>
-</div>
+<form>
+  <div class="mb-3">
+    <label for="inputQuantitySelector1" class="form-label">Quantity selector large:</label>
+    <div class="input-group quantity-selector w-100">
+      <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">
+        <span class="visually-hidden">Step down</span>
+      </button>
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">
+        <span class="visually-hidden">Step up</span>
+      </button>
+    </div>
+    <div class="quantitySelectorHelp form-text">Lorem ipsum.</div>
+  </div>
+  <div class="mb-3">
+    <label for="inputQuantitySelector2" class="form-label">Quantity selector small:</label>
+    <div class="input-group quantity-selector quantity-selector-sm w-100">
+      <input type="number" id="inputQuantitySelector2" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+      <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelector2" data-bs-step="down">
+        <span class="visually-hidden">Step down</span>
+      </button>
+      <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelector2" data-bs-step="up">
+        <span class="visually-hidden">Step up</span>
+      </button>
+    </div>
+    <div class="quantitySelectorHelp form-text">Lorem ipsum.</div>
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
 {{< /example >}}
 
 ## Disabled
 
-Add the `disabled` boolean attribute on quantity selector elements to give it a grayed out appearance and remove pointer events.
+Add the `disabled` boolean attribute on a select to give it a grayed out appearance and remove pointer events.
 
 {{< example >}}
-<div class="input-group quantity-selector">
-  <input type="number" id="inputQuantitySelectorDisabled" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector" disabled>
-  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelectorDisabled" data-bs-step="down" disabled>
-    <span class="visually-hidden">Step down</span>
-  </button>
-  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelectorDisabled" data-bs-step="up" disabled>
-    <span class="visually-hidden">Step up</span>
-  </button>
-</div>
+<form>
+  <div class="mb-3">
+    <label for="inputQuantitySelector3" class="form-label">Disabled large quantity selector:</label>
+    <div class="input-group quantity-selector">
+      <input type="number" id="inputQuantitySelector3" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector" disabled>
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector3" data-bs-step="down" disabled>
+        <span class="visually-hidden">Step down</span>
+      </button>
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector3" data-bs-step="up" disabled>
+        <span class="visually-hidden">Step up</span>
+      </button>
+    </div>
+    <div class="quantitySelectorHelp form-text">Lorem ipsum.</div>
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
 {{< /example >}}
 
 ## Sass

--- a/site/content/docs/5.1/forms/quantity-selector.md
+++ b/site/content/docs/5.1/forms/quantity-selector.md
@@ -1,74 +1,63 @@
 ---
 layout: docs
 title: Quantity selector
-description: Form element used to select a number.
+description: Use our custom quantity selector in forms for selecting a number.
 group: forms
 toc: true
 ---
 
-## Examples
+## Default
 
-Quantity selector is a form element used to select a number. The default version is the large version. To use the small version, use the contextual class `.quantity-selector-sm`.
+Quantity selector is a form element used to select a number.
 
-You can specify a default value in the `value` attribute of your input.
+A default value can be specified with the input `value` attribute.
 
-Value will vary between the values define in the `min` and `max` attributes (negatives values are allowed).
+Value will vary between the values defined for the `min` and `max` attributes (negatives values are allowed).
 
 The custom `data-bs-round` attribute will help you to define the number of digits to appear after the decimal point.
 
 {{< example >}}
-<form>
-  <div class="mb-3">
-    <label for="inputQuantitySelector1" class="form-label">Quantity selector large:</label>
-    <div class="input-group quantity-selector w-100">
-      <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
-      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">
-        <span class="visually-hidden">Step down</span>
-      </button>
-      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">
-        <span class="visually-hidden">Step up</span>
-      </button>
-    </div>
-    <div class="quantitySelectorHelp form-text">Lorem ipsum.</div>
-  </div>
-  <div class="mb-3">
-    <label for="inputQuantitySelector2" class="form-label">Quantity selector small:</label>
-    <div class="input-group quantity-selector quantity-selector-sm w-100">
-      <input type="number" id="inputQuantitySelector2" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
-      <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelector2" data-bs-step="down">
-        <span class="visually-hidden">Step down</span>
-      </button>
-      <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelector2" data-bs-step="up">
-        <span class="visually-hidden">Step up</span>
-      </button>
-    </div>
-    <div class="quantitySelectorHelp form-text">Lorem ipsum.</div>
-  </div>
-  <button type="submit" class="btn btn-primary">Submit</button>
-</form>
+<div class="input-group quantity-selector">
+  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">
+    <span class="visually-hidden">Step down</span>
+  </button>
+  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">
+    <span class="visually-hidden">Step up</span>
+  </button>
+</div>
+{{< /example >}}
+
+## Sizing
+
+You may also use small quantity selectors with the contextual class `.quantity-selector-sm`.
+
+{{< example >}}
+<div class="input-group quantity-selector quantity-selector-sm">
+  <input type="number" id="inputQuantitySelector2" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+  <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelector2" data-bs-step="down">
+    <span class="visually-hidden">Step down</span>
+  </button>
+  <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelector2" data-bs-step="up">
+    <span class="visually-hidden">Step up</span>
+  </button>
+</div>
 {{< /example >}}
 
 ## Disabled
 
-Add the `disabled` boolean attribute on a select to give it a grayed out appearance and remove pointer events.
+Add the `disabled` boolean attribute on a quantity selector elements to give it a grayed out appearance and remove pointer events.
 
 {{< example >}}
-<form>
-  <div class="mb-3">
-    <label for="inputQuantitySelector3" class="form-label">Disabled large quantity selector:</label>
-    <div class="input-group quantity-selector">
-      <input type="number" id="inputQuantitySelector3" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector" disabled>
-      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector3" data-bs-step="down" disabled>
-        <span class="visually-hidden">Step down</span>
-      </button>
-      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector3" data-bs-step="up" disabled>
-        <span class="visually-hidden">Step up</span>
-      </button>
-    </div>
-    <div class="quantitySelectorHelp form-text">Lorem ipsum.</div>
-  </div>
-  <button type="submit" class="btn btn-primary">Submit</button>
-</form>
+<div class="input-group quantity-selector">
+  <input type="number" id="inputQuantitySelector3" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector" disabled>
+  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector3" data-bs-step="down" disabled>
+    <span class="visually-hidden">Step down</span>
+  </button>
+  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector3" data-bs-step="up" disabled>
+    <span class="visually-hidden">Step up</span>
+  </button>
+</div>
 {{< /example >}}
 
 ## Sass

--- a/site/content/docs/5.1/forms/quantity-selector.md
+++ b/site/content/docs/5.1/forms/quantity-selector.md
@@ -10,19 +10,21 @@ toc: true
 
 Quantity selector is a form element used to select a number.
 
+**Please note that this component is suitable for incremental and decremental display of small numbers, i.e. numbers with 3-4 digits. We do not recommend using it with larger numbers.**
+
 A default value can be specified with the input `value` attribute.
 
-Value will vary between the values defined for the `min` and `max` attributes (negatives values are allowed).
+Value will vary between the values defined for the `min` and `max` attributes (negative value are allowed). `min` and `max` values are customizable.
 
 The custom `data-bs-round` attribute will help you to define the number of digits to appear after the decimal point.
 
 {{< example >}}
 <div class="input-group quantity-selector">
-  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
-  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">
+  <input type="number" id="inputQuantitySelector" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector" data-bs-step="down">
     <span class="visually-hidden">Step down</span>
   </button>
-  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">
+  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector" data-bs-step="up">
     <span class="visually-hidden">Step up</span>
   </button>
 </div>
@@ -34,11 +36,11 @@ You may also use small quantity selectors with the contextual class `.quantity-s
 
 {{< example >}}
 <div class="input-group quantity-selector quantity-selector-sm">
-  <input type="number" id="inputQuantitySelector2" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
-  <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelector2" data-bs-step="down">
+  <input type="number" id="inputQuantitySelectorSm" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+  <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelectorSm" data-bs-step="down">
     <span class="visually-hidden">Step down</span>
   </button>
-  <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelector2" data-bs-step="up">
+  <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelectorSm" data-bs-step="up">
     <span class="visually-hidden">Step up</span>
   </button>
 </div>
@@ -46,15 +48,15 @@ You may also use small quantity selectors with the contextual class `.quantity-s
 
 ## Disabled
 
-Add the `disabled` boolean attribute on a quantity selector elements to give it a grayed out appearance and remove pointer events.
+Add the `disabled` boolean attribute on quantity selector elements to give it a grayed out appearance and remove pointer events.
 
 {{< example >}}
 <div class="input-group quantity-selector">
-  <input type="number" id="inputQuantitySelector3" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector" disabled>
-  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector3" data-bs-step="down" disabled>
+  <input type="number" id="inputQuantitySelectorDisabled" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector" disabled>
+  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelectorDisabled" data-bs-step="down" disabled>
     <span class="visually-hidden">Step down</span>
   </button>
-  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector3" data-bs-step="up" disabled>
+  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelectorDisabled" data-bs-step="up" disabled>
     <span class="visually-hidden">Step up</span>
   </button>
 </div>

--- a/site/content/docs/5.1/forms/validation.md
+++ b/site/content/docs/5.1/forms/validation.md
@@ -284,13 +284,13 @@ Validation styles are available for the following form controls and components:
   </div>
 
   <div class="mb-3">
-    <label for="inputQuantitySelector1" class="form-label">Quantity selector</label>
+    <label for="inputQuantitySelector" class="form-label">Quantity selector</label>
     <div class="input-group quantity-selector w-100">
-      <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="11" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
-      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">
+      <input type="number" id="inputQuantitySelector" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="11" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector" data-bs-step="down">
         <span class="visually-hidden">Step down</span>
       </button>
-      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector" data-bs-step="up">
         <span class="visually-hidden">Step up</span>
       </button>
       <div class="invalid-feedback">Please enter a valid number.</div>

--- a/site/content/docs/5.1/forms/validation.md
+++ b/site/content/docs/5.1/forms/validation.md
@@ -284,6 +284,20 @@ Validation styles are available for the following form controls and components:
   </div>
 
   <div class="mb-3">
+    <label for="inputQuantitySelector1" class="form-label">Quantity selector</label>
+    <div class="input-group quantity-selector w-100">
+      <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="11" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">
+        <span class="visually-hidden">Step down</span>
+      </button>
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">
+        <span class="visually-hidden">Step up</span>
+      </button>
+      <div class="invalid-feedback">Please enter a valid number.</div>
+    </div>
+  </div>
+
+  <div class="mb-3">
     <button class="btn btn-primary" type="submit" disabled>Submit form</button>
   </div>
 </form>

--- a/site/content/docs/5.1/forms/validation.md
+++ b/site/content/docs/5.1/forms/validation.md
@@ -284,13 +284,13 @@ Validation styles are available for the following form controls and components:
   </div>
 
   <div class="mb-3">
-    <label for="inputQuantitySelector" class="form-label">Quantity selector</label>
+    <label for="inputQuantitySelector1" class="form-label">Quantity selector</label>
     <div class="input-group quantity-selector w-100">
-      <input type="number" id="inputQuantitySelector" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="11" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
-      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector" data-bs-step="down">
+      <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="11" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">
         <span class="visually-hidden">Step down</span>
       </button>
-      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector" data-bs-step="up">
+      <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="up">
         <span class="visually-hidden">Step up</span>
       </button>
       <div class="invalid-feedback">Please enter a valid number.</div>

--- a/site/content/docs/5.1/getting-started/introduction.md
+++ b/site/content/docs/5.1/getting-started/introduction.md
@@ -66,6 +66,7 @@ Curious which components explicitly require our JavaScript and Popper? Click the
 - Modals for displaying, positioning, and scroll behavior
 - Navbar for extending our Collapse plugin to implement responsive behavior
 - Offcanvases for displaying, positioning, and scroll behavior
+- Quantity selector for incrementing/decrementing number value
 - Toasts for displaying and dismissing
 - Tooltips and popovers for displaying and positioning (also requires [Popper](https://popper.js.org/))
 - Scrollspy for scroll behavior and navigation updates

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -52,6 +52,7 @@
     - title: Checks & radios
     - title: Range
     - title: Input group
+    - title: Quantity selector
     - title: Layout
     - title: Validation
 


### PR DESCRIPTION
Closes #113 

Preview: https://deploy-preview-860--boosted.netlify.app/docs/5.1/forms/quantity-selector/

## DoD

### Development

- [x] Should match specs (eg. either the Web UI Kit or any pattern from the WAI — or both…)
- [x] Docs added:
  - including the "Sass" part using `scss-docs` shortcode
  - in Cheatsheet / Cheatsheet RTL examples
  - in /about/overview/#custom-components if it is a new Orange custom component
  - in /gettings-started/introduction/#components if it is a new Orange custom component that requires JavaScript (and Popper)
  - in /customize/overview#csps-and-embedded-svgs if it is a new Orange custom component that includes embedded SVGs in our CSS
  - in /forms/validation/?#supported-elements if it is a new Orange custom component that is a form control
- [x] Check (and fix) RTL version
- [x] Run linters
- [x] Run compilers
- [x] Tests added for JS-side
- [x] Run tests
- [x] Cross-browser test:
  - Firefox ESR
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [x] Clean up the branch using `rebase -i`
- [ ] Commited with `feat(…): …` message
- ~~Mention it in Migration Guide (if `back-from-v4`): renamed variables, changes in markup requirement,  etc.~~

### Reviews

- [x] Code review
- [x] A11y review
- [x] Design review