### PR TITLE
Fix (scrollspy): Replace navbar and nested nav examples

### DIFF
--- a/site/assets/scss/_alerts.scss
+++ b/site/assets/scss/_alerts.scss
@@ -1,0 +1,11 @@
+.bd-ods-incompatibility-alert {
+  .alert-heading ~ p {
+    &:not(:first-of-type) {
+      margin-top: map-get($spacers, 1);
+    }
+
+    > a {
+      font-weight: 700;
+    }
+  }
+}

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -252,7 +252,7 @@
 .scrollspy-example {
   position: relative;
   height: 200px;
-  margin-top: .5rem;
+  margin-top: 1.25rem;
   overflow: auto;
 }
 

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -252,7 +252,7 @@
 .scrollspy-example {
   position: relative;
   height: 200px;
-  margin-top: 1.25rem;
+  margin-top: .5rem;
   overflow: auto;
 }
 

--- a/site/assets/scss/docs.scss
+++ b/site/assets/scss/docs.scss
@@ -56,6 +56,7 @@ $enable-cssgrid: true; // stylelint-disable-line scss/dollar-variable-default
 @import "algolia";
 
 // Boosted mod
+@import "alerts";
 @import "mixins";
 @import "boosted";
 @import "tarteaucitron";

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -27,7 +27,7 @@ If you're making a scrollable container (other than the `<body>`), be sure to ha
 Scroll the area below the nav and watch the active class change. The dropdown items will be highlighted as well.
 
 <div class="bd-example">
-  <nav role="navigation" id="nav-example1" class="nav">
+  <nav id="nav-example1" class="nav">
     <ul class="nav nav-pills">
       <li class="nav-item">
         <a class="nav-link" aria-current="page" href="#scrollspyHeading1">First</a>
@@ -61,7 +61,7 @@ Scroll the area below the nav and watch the active class change. The dropdown it
 </div>
 
 ```html
-<nav role="navigation" id="nav-example1" class="nav">
+<nav id="nav-example1" class="nav">
   <ul class="nav nav-pills">
     <li class="nav-item">
       <a class="nav-link" aria-current="page" href="#scrollspyHeading1">First</a>
@@ -102,7 +102,7 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
 <div class="bd-example">
   <div class="row">
     <div class="col-4">
-      <nav role="navigation" id="nav-example2" class="nav flex-column">
+      <nav id="nav-example2" class="nav flex-column">
         <nav class="nav nav-pills flex-column">
           <a class="nav-link" href="#item-1" aria-current="page">Item 1</a>
           <nav class="nav nav-pills flex-column">
@@ -141,7 +141,7 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
 
 ```html
  <div class="col-4">
-  <nav role="navigation" id="nav-example2" class="nav flex-column">
+  <nav id="nav-example2" class="nav flex-column">
     <nav class="nav nav-pills flex-column">
       <a class="nav-link" href="#item-1" aria-current="page">Item 1</a>
       <nav class="nav nav-pills flex-column">

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -6,14 +6,11 @@ group: components
 toc: true
 ---
 
-<div class="alert alert-danger" role="alert">
-  <span class="alert-icon"><span class="visually-hidden">Success</span></span>
-  <div>
-    <h4 class="alert-heading mb-1">Incompatibility with Orange Design System</h4>
-    <p class="mb-1">This component gathers technical utilities linked to the Navbar component and most of those examples are not compatible with the Orange Design System.</p>
-    <p>Refer to <a class="fw-bold" href='/docs/{{<param docs_version>}}/components/navbar/'>Orange NavBar</a> and <a class="fw-bold" href='/docs/{{<param docs_version>}}/components/navs-tabs/'>Nav & tabs</a></p>
-  </div>
-</div>
+{{< ods-incompatibility-alert >}}
+This component gathers technical utilities linked to the Navbar component and most of those examples are not compatible with the Orange Design System.
+
+Refer to [Orange navbar]({{< docsref "/components/orange-navbar" >}}) and [Nav & tabs]({{< docsref "/components/navs-tabs" >}}).
+{{< /ods-incompatibility-alert >}}
 
 ## How it works
 
@@ -159,7 +156,7 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
 ```html
 <div class="row">
   <div class="col-4 col-lg-3">
-    <nav id="navbar-example3" class="navbar navbar-light flex-column align-items-stretch p-3">
+    <nav id="navbar-example3" class="navbar navbar-light flex-column align-items-stretch">
       <a class="navbar-brand align-self-start" href="#">
         <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" width="50" height="50" role="img" alt="Boosted" loading="lazy">
       </a>
@@ -179,7 +176,7 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
     </nav>
   </div>
   <div class="col-8 col-lg-9">
-    <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" tabindex="0">
+    <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" class="scrollspy-example-2" tabindex="0">
       <h4 id="item-1">Item 1</h4>
       <p>...</p>
       <h5 id="item-1-1">Item 1-1</h5>
@@ -197,7 +194,6 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
     </div>
   </div>
 </div>
-
 ```
 
 ## Example with list-group

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -22,15 +22,18 @@ When successfully implemented, your nav or list group will update accordingly, m
 If you're making a scrollable container (other than the `<body>`), be sure to have a `height` set and `overflow-y: scroll;` applied to it—alongside a `tabindex="0"` to ensure keyboard access.
 {{< /callout >}}
 
-## Example in nav
+## Example in navbar
 
-Scroll the area below the nav and watch the active class change. The dropdown items will be highlighted as well.
+Scroll the area below the navbar and watch the active class change. The dropdown items will be highlighted as well.
 
 <div class="bd-example">
-  <nav id="nav-example1" class="nav">
+  <nav id="navbar-example2" class="navbar px-3">
+    <a class="navbar-brand" href="#">
+      <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" width="50" height="50" role="img" alt="Boosted" loading="lazy">
+    </a>
     <ul class="nav nav-pills">
       <li class="nav-item">
-        <a class="nav-link" aria-current="page" href="#scrollspyHeading1">First</a>
+        <a class="nav-link" href="#scrollspyHeading1">First</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="#scrollspyHeading2">Second</a>
@@ -46,7 +49,7 @@ Scroll the area below the nav and watch the active class change. The dropdown it
       </li>
     </ul>
   </nav>
-  <div data-bs-spy="scroll" data-bs-target="#nav-example1" data-bs-offset="0" class="scrollspy-example" tabindex="0">
+  <div data-bs-spy="scroll" data-bs-target="#navbar-example2" data-bs-offset="0" class="scrollspy-example" tabindex="0">
     <h4 id="scrollspyHeading1">First heading</h4>
     <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
     <h4 id="scrollspyHeading2">Second heading</h4>
@@ -61,10 +64,13 @@ Scroll the area below the nav and watch the active class change. The dropdown it
 </div>
 
 ```html
-<nav id="nav-example1" class="nav">
+<nav id="navbar-example2" class="navbar px-3">
+  <a class="navbar-brand" href="#">
+    <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" width="50" height="50" role="img" alt="Boosted" loading="lazy">
+  </a>
   <ul class="nav nav-pills">
     <li class="nav-item">
-      <a class="nav-link" aria-current="page" href="#scrollspyHeading1">First</a>
+      <a class="nav-link" href="#scrollspyHeading1">First</a>
     </li>
     <li class="nav-item">
       <a class="nav-link" href="#scrollspyHeading2">Second</a>
@@ -80,8 +86,7 @@ Scroll the area below the nav and watch the active class change. The dropdown it
     </li>
   </ul>
 </nav>
-
-<div data-bs-spy="scroll" data-bs-target="#nav-example1" data-bs-offset="0" class="scrollspy-example" tabindex="0">
+<div data-bs-spy="scroll" data-bs-target="#navbar-example2" data-bs-offset="0" class="scrollspy-example" tabindex="0">
   <h4 id="scrollspyHeading1">First heading</h4>
   <p>...</p>
   <h4 id="scrollspyHeading2">Second heading</h4>
@@ -101,10 +106,13 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
 
 <div class="bd-example">
   <div class="row">
-    <div class="col-4">
-      <nav id="nav-example2" class="nav flex-column">
+    <div class="col-4 col-lg-3">
+      <nav id="navbar-example3" class="navbar navbar-light flex-column align-items-stretch">
+        <a class="navbar-brand align-self-start" href="#">
+          <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" width="50" height="50" role="img" alt="Boosted" loading="lazy">
+        </a>
         <nav class="nav nav-pills flex-column">
-          <a class="nav-link" href="#item-1" aria-current="page">Item 1</a>
+          <a class="nav-link" href="#item-1">Item 1</a>
           <nav class="nav nav-pills flex-column">
             <a class="nav-link ms-3 my-1" href="#item-1-1">Item 1-1</a>
             <a class="nav-link ms-3 my-1" href="#item-1-2">Item 1-2</a>
@@ -118,8 +126,8 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
         </nav>
       </nav>
     </div>
-    <div class="col-8">
-      <div data-bs-spy="scroll" data-bs-target="#nav-example2" data-bs-offset="0" class="scrollspy-example-2" tabindex="0">
+    <div class="col-8 col-lg-9">
+      <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" class="scrollspy-example-2" tabindex="0">
         <h4 id="item-1">Item 1</h4>
         <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
         <h5 id="item-1-1">Item 1-1</h5>
@@ -140,42 +148,47 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
 </div>
 
 ```html
- <div class="col-4">
-  <nav id="nav-example2" class="nav flex-column">
-    <nav class="nav nav-pills flex-column">
-      <a class="nav-link" href="#item-1" aria-current="page">Item 1</a>
+<div class="row">
+  <div class="col-4 col-lg-3">
+    <nav id="navbar-example3" class="navbar navbar-light flex-column align-items-stretch p-3">
+      <a class="navbar-brand align-self-start" href="#">
+        <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" width="50" height="50" role="img" alt="Boosted" loading="lazy">
+      </a>
       <nav class="nav nav-pills flex-column">
-        <a class="nav-link ms-3 my-1" href="#item-1-1">Item 1-1</a>
-        <a class="nav-link ms-3 my-1" href="#item-1-2">Item 1-2</a>
-      </nav>
-      <a class="nav-link" href="#item-2">Item 2</a>
-      <a class="nav-link" href="#item-3">Item 3</a>
-      <nav class="nav nav-pills flex-column">
-        <a class="nav-link ms-3 my-1" href="#item-3-1">Item 3-1</a>
-        <a class="nav-link ms-3 my-1" href="#item-3-2">Item 3-2</a>
+        <a class="nav-link" href="#item-1">Item 1</a>
+        <nav class="nav nav-pills flex-column">
+          <a class="nav-link ms-3 my-1" href="#item-1-1">Item 1-1</a>
+          <a class="nav-link ms-3 my-1" href="#item-1-2">Item 1-2</a>
+        </nav>
+        <a class="nav-link" href="#item-2">Item 2</a>
+        <a class="nav-link" href="#item-3">Item 3</a>
+        <nav class="nav nav-pills flex-column">
+          <a class="nav-link ms-3 my-1" href="#item-3-1">Item 3-1</a>
+          <a class="nav-link ms-3 my-1" href="#item-3-2">Item 3-2</a>
+        </nav>
       </nav>
     </nav>
-  </nav>
-</div>
-
-<div class="col-8">
-  <div data-bs-spy="scroll" data-bs-target="#nav-example2" data-bs-offset="0" tabindex="0">
-    <h4 id="item-1">Item 1</h4>
-    <p>...</p>
-    <h5 id="item-1-1">Item 1-1</h5>
-    <p>...</p>
-    <h5 id="item-1-2">Item 1-2</h5>
-    <p>...</p>
-    <h4 id="item-2">Item 2</h4>
-    <p>...</p>
-    <h4 id="item-3">Item 3</h4>
-    <p>...</p>
-    <h5 id="item-3-1">Item 3-1</h5>
-    <p>...</p>
-    <h5 id="item-3-2">Item 3-2</h5>
-    <p>...</p>
+  </div>
+  <div class="col-8 col-lg-9">
+    <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" tabindex="0">
+      <h4 id="item-1">Item 1</h4>
+      <p>...</p>
+      <h5 id="item-1-1">Item 1-1</h5>
+      <p>...</p>
+      <h5 id="item-1-2">Item 1-2</h5>
+      <p>...</p>
+      <h4 id="item-2">Item 2</h4>
+      <p>...</p>
+      <h4 id="item-3">Item 3</h4>
+      <p>...</p>
+      <h5 id="item-3-1">Item 3-1</h5>
+      <p>...</p>
+      <h5 id="item-3-2">Item 3-2</h5>
+      <p>...</p>
+    </div>
   </div>
 </div>
+
 ```
 
 ## Example with list-group

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -41,7 +41,7 @@ Scroll the area below the nav and watch the active class change. The dropdown it
           <li><a class="dropdown-item" href="#scrollspyHeading3">Third</a></li>
           <li><a class="dropdown-item" href="#scrollspyHeading4">Fourth</a></li>
           <li><hr class="dropdown-divider"></li>
-          <li><a class="dropdown-item" href="#scrollspyHeading5">Fith</a></li>
+          <li><a class="dropdown-item" href="#scrollspyHeading5">Fifth</a></li>
         </ul>
       </li>
     </ul>
@@ -75,7 +75,7 @@ Scroll the area below the nav and watch the active class change. The dropdown it
         <li><a class="dropdown-item" href="#scrollspyHeading3">Third</a></li>
         <li><a class="dropdown-item" href="#scrollspyHeading4">Fourth</a></li>
         <li><hr class="dropdown-divider"></li>
-        <li><a class="dropdown-item" href="#scrollspyHeading5">Fith</a></li>
+        <li><a class="dropdown-item" href="#scrollspyHeading5">Fifth</a></li>
       </ul>
     </li>
   </ul>

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -11,7 +11,7 @@ toc: true
   <div>
     <h4 class="alert-heading mb-1">Incompatibility with Orange Design System</h4>
     <p class="mb-1">This component gathers technical utilities linked to the Navbar component and most of those examples are not compatible with the Orange Design System.</p>
-    <p>Refer to <a class="fw-bold" href='http://localhost:9001/docs/5.1/components/navbar/'>Orange NavBar</a> and <a class="fw-bold" href='http://localhost:9001/docs/5.1/components/navbar/'>Nav & tabs</a></p>
+    <p>Refer to <a class="fw-bold" href='/docs/{{<param docs_version>}}/components/navbar/'>Orange NavBar</a> and <a class="fw-bold" href='/docs/{{<param docs_version>}}/components/navs-tabs/'>Nav & tabs</a></p>
   </div>
 </div>
 

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -6,6 +6,15 @@ group: components
 toc: true
 ---
 
+<div class="alert alert-danger" role="alert">
+  <span class="alert-icon"><span class="visually-hidden">Success</span></span>
+  <div>
+    <h4 class="alert-heading mb-1">Incompatibility with Orange Design System</h4>
+    <p class="mb-1">This component gathers technical utilities linked to the Navbar component and most of those examples are not compatible with the Orange Design System.</p>
+    <p>Refer to <a class="fw-bold" href='http://localhost:9001/docs/5.1/components/navbar/'>Orange NavBar</a> and <a class="fw-bold" href='http://localhost:9001/docs/5.1/components/navbar/'>Nav & tabs</a></p>
+  </div>
+</div>
+
 ## How it works
 
 Scrollspy has a few requirements to function properly:

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -22,18 +22,15 @@ When successfully implemented, your nav or list group will update accordingly, m
 If you're making a scrollable container (other than the `<body>`), be sure to have a `height` set and `overflow-y: scroll;` applied to it—alongside a `tabindex="0"` to ensure keyboard access.
 {{< /callout >}}
 
-## Example in navbar
+## Example in nav
 
-Scroll the area below the navbar and watch the active class change. The dropdown items will be highlighted as well.
+Scroll the area below the nav and watch the active class change. The dropdown items will be highlighted as well.
 
 <div class="bd-example">
-  <nav id="navbar-example2" class="navbar px-3">
-    <a class="navbar-brand" href="#">
-      <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" width="50" height="50" role="img" alt="Boosted" loading="lazy">
-    </a>
+  <nav role="navigation" id="nav-example1" class="nav">
     <ul class="nav nav-pills">
       <li class="nav-item">
-        <a class="nav-link" href="#scrollspyHeading1">First</a>
+        <a class="nav-link" aria-current="page" href="#scrollspyHeading1">First</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="#scrollspyHeading2">Second</a>
@@ -44,12 +41,12 @@ Scroll the area below the navbar and watch the active class change. The dropdown
           <li><a class="dropdown-item" href="#scrollspyHeading3">Third</a></li>
           <li><a class="dropdown-item" href="#scrollspyHeading4">Fourth</a></li>
           <li><hr class="dropdown-divider"></li>
-          <li><a class="dropdown-item" href="#three">three</a></li>
+          <li><a class="dropdown-item" href="#scrollspyHeading5">Fith</a></li>
         </ul>
       </li>
     </ul>
   </nav>
-  <div data-bs-spy="scroll" data-bs-target="#navbar-example2" data-bs-offset="0" class="scrollspy-example" tabindex="0">
+  <div data-bs-spy="scroll" data-bs-target="#nav-example1" data-bs-offset="0" class="scrollspy-example" tabindex="0">
     <h4 id="scrollspyHeading1">First heading</h4>
     <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
     <h4 id="scrollspyHeading2">Second heading</h4>
@@ -64,13 +61,10 @@ Scroll the area below the navbar and watch the active class change. The dropdown
 </div>
 
 ```html
-<nav id="navbar-example2" class="navbar px-3">
-  <a class="navbar-brand" href="#">
-    <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" width="50" height="50" role="img" alt="Boosted" loading="lazy">
-  </a>
+<nav role="navigation" id="nav-example1" class="nav">
   <ul class="nav nav-pills">
     <li class="nav-item">
-      <a class="nav-link" href="#scrollspyHeading1">First</a>
+      <a class="nav-link" aria-current="page" href="#scrollspyHeading1">First</a>
     </li>
     <li class="nav-item">
       <a class="nav-link" href="#scrollspyHeading2">Second</a>
@@ -81,12 +75,13 @@ Scroll the area below the navbar and watch the active class change. The dropdown
         <li><a class="dropdown-item" href="#scrollspyHeading3">Third</a></li>
         <li><a class="dropdown-item" href="#scrollspyHeading4">Fourth</a></li>
         <li><hr class="dropdown-divider"></li>
-        <li><a class="dropdown-item" href="#scrollspyHeading5">Fifth</a></li>
+        <li><a class="dropdown-item" href="#scrollspyHeading5">Fith</a></li>
       </ul>
     </li>
   </ul>
 </nav>
-<div data-bs-spy="scroll" data-bs-target="#navbar-example2" data-bs-offset="0" class="scrollspy-example" tabindex="0">
+
+<div data-bs-spy="scroll" data-bs-target="#nav-example1" data-bs-offset="0" class="scrollspy-example" tabindex="0">
   <h4 id="scrollspyHeading1">First heading</h4>
   <p>...</p>
   <h4 id="scrollspyHeading2">Second heading</h4>
@@ -106,13 +101,10 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
 
 <div class="bd-example">
   <div class="row">
-    <div class="col-4 col-lg-2">
-      <nav id="navbar-example3" class="navbar navbar-light bg-light flex-column align-items-stretch p-3">      
-        <a class="navbar-brand align-self-start" href="#">
-          <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" width="50" height="50" role="img" alt="Boosted" loading="lazy">
-        </a>
+    <div class="col-4">
+      <nav role="navigation" id="nav-example2" class="nav flex-column">
         <nav class="nav nav-pills flex-column">
-          <a class="nav-link" href="#item-1">Item 1</a>
+          <a class="nav-link" href="#item-1" aria-current="page">Item 1</a>
           <nav class="nav nav-pills flex-column">
             <a class="nav-link ms-3 my-1" href="#item-1-1">Item 1-1</a>
             <a class="nav-link ms-3 my-1" href="#item-1-2">Item 1-2</a>
@@ -126,8 +118,8 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
         </nav>
       </nav>
     </div>
-    <div class="col-8 col-lg-10">
-      <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" class="scrollspy-example-2" tabindex="0">
+    <div class="col-8">
+      <div data-bs-spy="scroll" data-bs-target="#nav-example2" data-bs-offset="0" class="scrollspy-example-2" tabindex="0">
         <h4 id="item-1">Item 1</h4>
         <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
         <h5 id="item-1-1">Item 1-1</h5>
@@ -148,40 +140,41 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
 </div>
 
 ```html
-<nav id="navbar-example3" class="navbar navbar-light bg-light flex-column align-items-stretch p-3">
-  <a class="navbar-brand align-self-start" href="#">
-    <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" width="50" height="50" role="img" alt="Boosted" loading="lazy">
-  </a>
-  <nav class="nav nav-pills flex-column">
-    <a class="nav-link" href="#item-1">Item 1</a>
+ <div class="col-4">
+  <nav role="navigation" id="nav-example2" class="nav flex-column">
     <nav class="nav nav-pills flex-column">
-      <a class="nav-link ms-3 my-1" href="#item-1-1">Item 1-1</a>
-      <a class="nav-link ms-3 my-1" href="#item-1-2">Item 1-2</a>
-    </nav>
-    <a class="nav-link" href="#item-2">Item 2</a>
-    <a class="nav-link" href="#item-3">Item 3</a>
-    <nav class="nav nav-pills flex-column">
-      <a class="nav-link ms-3 my-1" href="#item-3-1">Item 3-1</a>
-      <a class="nav-link ms-3 my-1" href="#item-3-2">Item 3-2</a>
+      <a class="nav-link" href="#item-1" aria-current="page">Item 1</a>
+      <nav class="nav nav-pills flex-column">
+        <a class="nav-link ms-3 my-1" href="#item-1-1">Item 1-1</a>
+        <a class="nav-link ms-3 my-1" href="#item-1-2">Item 1-2</a>
+      </nav>
+      <a class="nav-link" href="#item-2">Item 2</a>
+      <a class="nav-link" href="#item-3">Item 3</a>
+      <nav class="nav nav-pills flex-column">
+        <a class="nav-link ms-3 my-1" href="#item-3-1">Item 3-1</a>
+        <a class="nav-link ms-3 my-1" href="#item-3-2">Item 3-2</a>
+      </nav>
     </nav>
   </nav>
-</nav>
+</div>
 
-<div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" tabindex="0">
-  <h4 id="item-1">Item 1</h4>
-  <p>...</p>
-  <h5 id="item-1-1">Item 1-1</h5>
-  <p>...</p>
-  <h5 id="item-1-2">Item 1-2</h5>
-  <p>...</p>
-  <h4 id="item-2">Item 2</h4>
-  <p>...</p>
-  <h4 id="item-3">Item 3</h4>
-  <p>...</p>
-  <h5 id="item-3-1">Item 3-1</h5>
-  <p>...</p>
-  <h5 id="item-3-2">Item 3-2</h5>
-  <p>...</p>
+<div class="col-8">
+  <div data-bs-spy="scroll" data-bs-target="#nav-example2" data-bs-offset="0" tabindex="0">
+    <h4 id="item-1">Item 1</h4>
+    <p>...</p>
+    <h5 id="item-1-1">Item 1-1</h5>
+    <p>...</p>
+    <h5 id="item-1-2">Item 1-2</h5>
+    <p>...</p>
+    <h4 id="item-2">Item 2</h4>
+    <p>...</p>
+    <h4 id="item-3">Item 3</h4>
+    <p>...</p>
+    <h5 id="item-3-1">Item 3-1</h5>
+    <p>...</p>
+    <h5 id="item-3-2">Item 3-2</h5>
+    <p>...</p>
+  </div>
 </div>
 ```
 

--- a/site/layouts/shortcodes/ods-incompatibility-alert.html
+++ b/site/layouts/shortcodes/ods-incompatibility-alert.html
@@ -1,0 +1,11 @@
+{{- /*
+  Usage: `ods-incompatibility-alert`
+*/ -}}
+
+<div class="bd-ods-incompatibility-alert alert alert-danger" role="alert">
+  <span class="alert-icon"><span class="visually-hidden">Danger</span></span>
+  <div>
+    <h4 class="alert-heading mb-1">Incompatibility with Orange Design System</h4>
+    {{ .Inner | markdownify }}
+  </div>
+</div>


### PR DESCRIPTION
The 2 examples concerned in the issue shall be modified. In Bootstrap 5 and so far in Boosted 5, they are based on `navbar` (horizontal and vertical) component. As these cases don't exist in Orange Design system, here's a first proposal for replacing these 2 new examples based this time on `nav` component.

Preview: https://deploy-preview-923--boosted.netlify.app/docs/5.1/components/scrollspy/
