### PR TITLE
Remove concurrency, wait and timeout configurations in pa11y

### DIFF
--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -1,13 +1,10 @@
 {
   "standard": "WCAG2AA",
   "level": "error",
-  "concurrency": 1,
   "defaults": {
-    "wait": 3000,
     "runners": [
       "axe"
     ],
-    "timeout": 100000,
     "hideElements": ".bd-search, [id*='tarteaucitron'], #TableOfContents, .text-primary, .navbar-light .navbar-brand, .accordion-button:not(.collapsed), .active, [aria-current], select:disabled, [disabled] label, [disabled] + label, .modal, .bd-example nav, .badge.rounded-pill.bg-info.text-white, .exclude-from-pa11y-analysis, a.disabled, .form-check.form-switch",
     "ignore": [
       "heading-order",


### PR DESCRIPTION
All recent PRs are red for the pa11y execution. This PR is a proposal to remove `wait`, `concurrency` and `timeout` values from the configuration. Seems to be better that way.