### PR TITLE
Layouts: add a top margin to the doc footer

### DIFF
--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -2,7 +2,7 @@
   {{ partial "docs-subnav" . }}
 
   <div class="container-xxl bd-layout">
-    <aside class="bd-sidebar border-end border-light border-1">
+    <aside class="bd-sidebar">
       {{ partial "docs-sidebar" . }}
     </aside>
 
@@ -17,9 +17,9 @@
       </div>
 
       {{ if (eq .Page.Params.toc true) }}
-        <div class="bd-toc mt-4 mb-5 my-md-0 py-md-4 border-start border-light border-1">
-          <strong class="d-block h6 my-2 ps-lg-3 pb-2 border-bottom border-light border-1">On this page</strong>
-          <div class="ps-lg-3">{{ .TableOfContents }}</div>
+        <div class="bd-toc mt-4 mb-5 my-md-0 py-md-4 ps-xl-3 mb-lg-5">
+          <strong class="d-block h6 my-2 pb-2 border-bottom border-light border-1">On this page</strong>
+          {{ .TableOfContents }}
         </div>
       {{ end }}
 

--- a/site/layouts/_default/guidelines.html
+++ b/site/layouts/_default/guidelines.html
@@ -11,7 +11,7 @@
     {{ partial "guidelines-subnav" . }}
 
     <div class="container-xxl bd-layout">
-      <aside class="bd-sidebar border-end border-light border-1">
+      <aside class="bd-sidebar">
         {{ partial "guidelines-sidebar" . }}
       </aside>
 
@@ -23,9 +23,9 @@
         </div>
 
         {{ if (eq .Page.Params.toc true) }}
-          <div class="bd-toc mt-4 mb-5 my-md-0 py-md-4 border-start border-light border-1">
-            <strong class="d-block h6 my-2 ps-lg-3 pb-2 border-bottom border-light border-1">On this page</strong>
-            <div class="ps-lg-3">{{ .TableOfContents }}</div>
+          <div class="bd-toc mt-4 mb-5 my-md-0 py-md-4 ps-xl-3 mb-lg-5">
+            <strong class="d-block h6 my-2 pb-2 border-bottom border-light border-1">On this page</strong>
+            {{ .TableOfContents }}
           </div>
         {{ end }}
 

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -1,4 +1,4 @@
-<footer class="bd-footer py-3 py-md-4 bg-dark">
+<footer class="bd-footer py-3 py-md-4 mt-5 bg-dark">
   <div class="container py-1">
     <div class="row">
       <div class="col-lg-3 mb-3">


### PR DESCRIPTION
Add a top margin to the doc footer to avoid this rendering when the side menu is non collapsed and we scroll:

![Screenshot from 2021-11-25 08-06-11](https://user-images.githubusercontent.com/17381666/143395410-47833ae4-8a15-4afa-90a5-1ba7db9be2fe.png)

New rendering:
![Screenshot from 2021-11-25 08-10-46](https://user-images.githubusercontent.com/17381666/143395906-c6037d63-e573-434e-957b-ba1cd24b81d9.png)


