### PR TITLE
Reintroduce Bootstrap Community section in introduction

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -58,7 +58,9 @@ params:
   docs_version:                     "5.1"
   rfs_version:                      "v9.0.6"
   repo:                             "https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap"
-  twitter:                          "orange"
+  twitter:                          "getbootstrap"
+  slack:                            "https://bootstrap-slack.herokuapp.com/"
+  blog:                             "https://blog.getbootstrap.com/"
   icons:                            "https://design.orange.com/icons-libraries/"
   bootstrap:                        "https://getbootstrap.com"
   ods:

--- a/site/content/docs/5.1/getting-started/introduction.md
+++ b/site/content/docs/5.1/getting-started/introduction.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Introduction
-description: Get started with Boosted, the world's most popular framework for building responsive, mobile-first sites, with jsDelivr and a template starter page.
+description: Get started with Boosted, based on Bootstrap, the world's most popular framework for building responsive, mobile-first sites, with jsDelivr and a template starter page.
 group: getting-started
 aliases:
   - "/docs/5.1/getting-started/"
@@ -202,3 +202,15 @@ It should be used for critical resources only.
 ### Reboot
 
 For improved cross-browser rendering, we use [Reboot]({{< docsref "/content/reboot" >}}) to correct inconsistencies across browsers and devices while providing slightly more opinionated resets to common HTML elements.
+
+## Bootstrap Community
+
+Stay up to date on the development of Bootstrap and reach out to the community with these helpful resources.
+
+- Read and subscribe to [The Official Bootstrap Blog]({{< param blog >}}).
+- Join [the official Slack room]({{< param slack >}}).
+- Chat with fellow Bootstrappers in IRC. On the `irc.libera.chat` server, in the `#bootstrap` channel.
+- Implementation help may be found at Stack Overflow (tagged [`bootstrap-5`](https://stackoverflow.com/questions/tagged/bootstrap-5)).
+- Developers should use the keyword `bootstrap` on packages that modify or add to the functionality of Bootstrap when distributing through [npm](https://www.npmjs.com/search?q=keywords:bootstrap) or similar delivery mechanisms for maximum discoverability.
+
+You can also follow [@getbootstrap on Twitter](https://twitter.com/{{< param twitter >}}) for the latest gossip and awesome music videos.


### PR DESCRIPTION
This section was present in [Boosted 4](https://boosted.orange.com/docs/4.6/getting-started/introduction/) and could be useful to reach Bootstrap developers or community.

**Preview**: https://deploy-preview-984--boosted.netlify.app/docs/5.1/getting-started/introduction/#bootstrap-community