### PR TITLE
Buttons with dark background (`.btn-inverse`)

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "27.9 kB"
+      "maxSize": "29.4 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",
-      "maxSize": "25.5 kB"
+      "maxSize": "26.1 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.js",

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -79,27 +79,37 @@
   // Boosted mod
   &:not(:hover):not(:focus):not(:active) {
     border-left-color: transparent;
+
+    &.btn-inverse::before {
+      background-color: $black;
+    }
   }
 
-  &:not(:focus):not(:active)::before {
-    position: absolute;
-    top: -$border-width;
-    bottom: -$border-width;
-    left: -$border-width;
-    width: $border-width;
-    color: $black;
-    content: "";
-    background:
-      linear-gradient(
-        currentColor $border-width,
-        transparent $border-width,
-        transparent $border-width * 2.5,
-        currentColor $border-width * 2.5,
-        currentColor subtract(100%, $border-width * 2.5),
-        transparent subtract(100%, $border-width * 2.5),
-        transparent subtract(100%, $border-width),
-        currentColor subtract(100%, $border-width)
-      );
+  &:not(:focus):not(:active) {
+    &::before {
+      position: absolute;
+      top: -$border-width;
+      bottom: -$border-width;
+      left: -$border-width;
+      width: $border-width;
+      color: $black;
+      content: "";
+      background:
+        linear-gradient(
+          currentColor $border-width,
+          transparent $border-width,
+          transparent $border-width * 2.5,
+          currentColor $border-width * 2.5,
+          currentColor subtract(100%, $border-width * 2.5),
+          transparent subtract(100%, $border-width * 2.5),
+          transparent subtract(100%, $border-width),
+          currentColor subtract(100%, $border-width)
+        );
+    }
+
+    &.btn-inverse::before {
+      color: $white;
+    }
   }
 
   .btn:active + &,

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -81,7 +81,7 @@
 .btn-secondary {
   @include button-variant($white, $black, $disabled-background: $white, $disabled-border: $gray-500, $disabled-color: $gray-500);
   &.btn-inverse {
-    @include button-variant($black, $white, $white, $white, $black, $black, $primary, $primary, $black, transparent, $gray-700, $gray-700);
+    @include button-variant($black, $white, $white, $white, $white, $black, $primary, $primary, $black, transparent, $gray-700, $gray-700);
   }
 }
 

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -130,6 +130,10 @@
   &.disabled {
     color: $gray-500;
   }
+
+  &.btn-inverse:not(:active) {
+    color: $white;
+  }
 }
 // End mod
 

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -72,24 +72,39 @@
 .btn-primary,
 .btn-warning {
   @include button-variant($primary, $primary, $active-background: $white, $active-border: $black);
+  &.btn-inverse {
+    @include button-variant($primary, $primary, $white, $white, $black, $white, $gray-700, $gray-700, $black);
+  }
 }
 
 .btn-light,
 .btn-secondary {
   @include button-variant($white, $black, $disabled-background: $white, $disabled-border: $gray-500, $disabled-color: $gray-500);
+  &.btn-inverse {
+    @include button-variant($black, $white, $white, $white, $primary, $primary, transparent, $gray-700, $gray-700);
+  }
 }
 
 .btn-success {
   @include button-variant($success, $success);
+  &.btn-inverse {
+    @include button-variant($success, $success, $white, $white, $primary, $primary, $gray-700, $gray-700, $black);
+  }
 }
 
 .btn-info,
 .btn-dark {
   @include button-variant($black, $black, $white, $white, $black, $black);
+  &.btn-inverse {
+    @include button-variant($white, $white, $black, $white, $primary, $primary, $gray-700, $gray-700, $black);
+  }
 }
 
 .btn-danger {
   @include button-variant($danger, $danger);
+  &.btn-inverse {
+    @include button-variant($danger, $danger, $white, $white, $primary, $primary, $gray-700, $gray-700, $black);
+  }
 }
 // scss-docs-end btn-variant-loops
 // End mod
@@ -127,8 +142,14 @@
 .btn-link {
   color: $btn-link-color;
   text-decoration: $link-decoration;
+  // Boosted mod
   // stylelint-disable-next-line declaration-no-important
-  border-color: transparent !important; // Boosted mod
+  border-color: transparent !important;
+
+  &.btn-inverse {
+    color: $white;
+  }
+  // End mod
 
   &:hover {
     color: $btn-link-hover-color;
@@ -161,14 +182,14 @@
 }
 
 
-//
 // Boosted mod: icon button
-//
 .btn-icon {
   padding-right: var(--#{$boosted-variable-prefix}icon-spacing);
   padding-left: var(--#{$boosted-variable-prefix}icon-spacing);
 }
+// End mod
 
+// Boosted mod: social button
 .btn-social {
   border-color: currentColor;
   @include border-radius(50%, 50%);
@@ -201,6 +222,15 @@
     --#{$boosted-variable-prefix}network-color: #{map-get($network, "color")};
     --#{$boosted-variable-prefix}network-logo: #{escape-svg(url("data:image/svg+xml,#{map-get($network, "icon")}"))};
 
+    &.btn-inverse {
+      color: $white;
+
+      &:active {
+        color: $black;
+        background-color: $white;
+      }
+    }
+
     &::before {
       mask-size: if(map-has-key($network, "size"), map-get($network, "size"), null);
 
@@ -210,3 +240,4 @@
     }
   }
 }
+// End mod

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -73,7 +73,7 @@
 .btn-warning {
   @include button-variant($primary, $primary, $active-background: $white, $active-border: $black);
   &.btn-inverse {
-    @include button-variant($primary, $primary, $white, $white, $black, $white, $gray-700, $gray-700, $black);
+    @include button-variant($primary, $primary, $black, $white, $white, $black, $black, $white, $white, $gray-700, $gray-700, $black);
   }
 }
 
@@ -81,14 +81,14 @@
 .btn-secondary {
   @include button-variant($white, $black, $disabled-background: $white, $disabled-border: $gray-500, $disabled-color: $gray-500);
   &.btn-inverse {
-    @include button-variant($black, $white, $white, $white, $primary, $primary, transparent, $gray-700, $gray-700);
+    @include button-variant($black, $white, $white, $white, $black, $black, $primary, $primary, $black, transparent, $gray-700, $gray-700);
   }
 }
 
 .btn-success {
   @include button-variant($success, $success);
   &.btn-inverse {
-    @include button-variant($success, $success, $white, $white, $primary, $primary, $gray-700, $gray-700, $black);
+    @include button-variant($success, $success, $black,  $white, $white, $black, $primary, $primary, $black, $gray-700, $gray-700, $black);
   }
 }
 
@@ -96,14 +96,14 @@
 .btn-dark {
   @include button-variant($black, $black, $white, $white, $black, $black);
   &.btn-inverse {
-    @include button-variant($white, $white, $black, $white, $primary, $primary, $gray-700, $gray-700, $black);
+    @include button-variant($white, $white, $black, $black, $white, $white, $primary, $primary, $black, $gray-700, $gray-700, $black);
   }
 }
 
 .btn-danger {
   @include button-variant($danger, $danger);
   &.btn-inverse {
-    @include button-variant($danger, $danger, $white, $white, $primary, $primary, $gray-700, $gray-700, $black);
+    @include button-variant($danger, $danger, $white, $white, $white, $black, $primary, $primary, $black, $gray-700, $gray-700, $black);
   }
 }
 // scss-docs-end btn-variant-loops

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -14,6 +14,23 @@
   background-color: $dropdown-bg;
   border-color: $dropdown-border-color;
 
+  // Boosted mod: dark background
+  .bg-dark &:not(.dropdown-toggle-split),
+  .navbar-dark &:not(.dropdown-toggle-split) {
+    color: $dropdown-bg;
+    background-color: $dropdown-color;
+    border-color: $gray-700;
+
+    &:hover {
+      border-color: $dropdown-link-hover-color;
+    }
+  }
+
+  .btn-group &:not(.btn-inverse) {
+    border-color: $dropdown-color;
+  }
+  // End mod
+
   // Generate the caret automatically
   @include caret();
 }

--- a/site/content/docs/5.1/components/buttons.md
+++ b/site/content/docs/5.1/components/buttons.md
@@ -125,6 +125,52 @@ Supported social networks are declared in a dedicated Sass map—meaning you're 
 
 {{< scss-docs name="social-buttons" file="scss/_variables.scss" >}}
 
+## Dark background
+
+To get the inversed button behavior, simply add `.btn-inverse` to a `<button>` or `<a>`.
+
+{{< example class="bg-dark" >}}
+{{< buttons.inline >}}
+{{- range (index $.Site.Data "theme-colors") }}
+<button type="button" class="btn btn-inverse btn-{{ .name }}">{{ .name | title }}</button>
+{{- end -}}
+{{< /buttons.inline >}}
+
+<button type="button" class="btn btn-inverse btn-link">Link</button>
+{{< /example >}}
+
+{{< example class="bg-dark" >}}
+<button type="button" class="btn btn-inverse btn-primary">
+  <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false" class="me-1">
+    <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#success"/>
+  </svg>
+  Secondary
+</button>
+<button type="button" class="btn btn-icon btn-inverse btn-secondary">
+  <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false">
+    <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#success"/>
+  </svg>
+  <span class="visually-hidden">Secondary</span>
+</button>
+<button type="button" class="btn btn-icon btn-inverse btn-no-outline">
+  <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true" focusable="false">
+    <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#success"/>
+  </svg>
+  <span class="visually-hidden">No outline</span>
+</button>
+{{< /example >}}
+
+{{< example class="bg-dark" >}}
+<a href="#" class="btn btn-icon btn-inverse btn-social btn-twitter"><span class="visually-hidden">Twitter</span></a>
+<a href="#" class="btn btn-icon btn-inverse btn-social btn-facebook"><span class="visually-hidden">Facebook</span></a>
+<a href="#" class="btn btn-icon btn-inverse btn-social btn-instagram"><span class="visually-hidden">Instagram</span></a>
+<a href="#" class="btn btn-icon btn-inverse btn-social btn-whatsapp"><span class="visually-hidden">Whatsapp</span></a>
+<a href="#" class="btn btn-icon btn-inverse btn-social btn-linkedin"><span class="visually-hidden">LinkedIn</span></a>
+<a href="#" class="btn btn-icon btn-inverse btn-social btn-youtube"><span class="visually-hidden">YouTube</span></a>
+<a href="#" class="btn btn-icon btn-inverse btn-social btn-snapchat"><span class="visually-hidden">Snapchat</span></a>
+<a href="#" class="btn btn-icon btn-inverse btn-social btn-pinterest"><span class="visually-hidden">Pinterest</span></a>
+<a href="#" class="btn btn-icon btn-inverse btn-social btn-mail"><span class="visually-hidden">Mail</span></a>
+{{< /example >}}
 <!-- End mod -->
 
 ## Disable text wrapping

--- a/site/content/docs/5.1/components/buttons.md
+++ b/site/content/docs/5.1/components/buttons.md
@@ -127,7 +127,7 @@ Supported social networks are declared in a dedicated Sass map—meaning you're 
 
 ## Dark background
 
-To get the inversed button behavior, simply add `.btn-inverse` to a `<button>` or `<a>`.
+To get the inverted button behavior, simply add `.btn-inverse` to a `<button>` or `<a>`.
 
 {{< example class="bg-dark" >}}
 {{< buttons.inline >}}

--- a/site/content/docs/5.1/components/dropdowns.md
+++ b/site/content/docs/5.1/components/dropdowns.md
@@ -192,13 +192,29 @@ Button dropdowns work with buttons of all sizes, including default and split dro
 
 Opt into darker dropdowns to match a dark navbar or custom style by adding `.dropdown-menu-dark` onto an existing `.dropdown-menu`. No changes are required to the dropdown items.
 
-{{< example >}}
-<div class="dropdown">
-  <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton2" data-bs-toggle="dropdown" aria-expanded="false">
-    Dropdown button
+{{< example class="bg-dark" >}}
+<div class="btn-group" role="group">
+  <div class="dropdown">
+    <button class="btn btn-secondary btn-inverse dropdown-toggle" type="button" id="dropdownMenuButton2" data-bs-toggle="dropdown" aria-expanded="false">
+      Dropdown button
+    </button>
+    <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="dropdownMenuButton2">
+      <li><a class="dropdown-item active" href="#">Action</a></li>
+      <li><a class="dropdown-item" href="#">Another action</a></li>
+      <li><a class="dropdown-item" href="#">Something else here</a></li>
+      <li><hr class="dropdown-divider"></li>
+      <li><a class="dropdown-item" href="#">Separated link</a></li>
+    </ul>
+  </div>
+</div>
+
+<div class="btn-group" role="group">
+  <button type="button" class="btn btn-secondary btn-inverse">Action</button>
+  <button type="button" class="btn btn-secondary btn-inverse dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+    <span class="visually-hidden">Toggle Dropdown</span>
   </button>
-  <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="dropdownMenuButton2">
-    <li><a class="dropdown-item active" href="#">Action</a></li>
+  <ul class="dropdown-menu">
+    <li><a class="dropdown-item" href="#">Action</a></li>
     <li><a class="dropdown-item" href="#">Another action</a></li>
     <li><a class="dropdown-item" href="#">Something else here</a></li>
     <li><hr class="dropdown-divider"></li>


### PR DESCRIPTION
This PR reintegrates `.btn-inverse` to handle buttons with dark background based on the `v4-dev` source code.

Note: for dropdowns, this PR only fixes the button and not the dropdown menu

**Live previews**:
* [Buttons](https://deploy-preview-1010--boosted.netlify.app/docs/5.1/components/buttons/) (non-regression)
* [Dark background buttons](https://deploy-preview-1010--boosted.netlify.app/docs/5.1/components/buttons/#dark-background)
* [Dropdowns](https://deploy-preview-1010--boosted.netlify.app/docs/5.1/components/dropdowns/) (non-regression)
* [Dark dropdowns](https://deploy-preview-1010--boosted.netlify.app/docs/5.1/components/dropdowns/#dark-dropdowns)

Closes #713 
Linked to #917 