### PR TITLE
Docs(navs-tabs): add nested tabs

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "30.1 kB"
+      "maxSize": "30.2 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",
-      "maxSize": "28.0 kB"
+      "maxSize": "28.1 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.js",

--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -5,7 +5,7 @@
     "runners": [
       "axe"
     ],
-    "hideElements": ".bd-search, [id*='tarteaucitron'], #TableOfContents, .text-primary, .accordion-button:not(.collapsed), .active, [aria-current], select:disabled, [disabled] label, [disabled] + label, .modal, .bd-example nav, .badge.rounded-pill.bg-info.text-white, .exclude-from-pa11y-analysis, a.disabled, .form-check.form-switch",
+    "hideElements": ".bd-search, [id*='tarteaucitron'], #TableOfContents, .text-primary, .navbar-light .navbar-brand, .accordion-button:not(.collapsed), .active, [aria-current], select:disabled, [disabled] label, [disabled] + label, .modal, .bd-example nav, .badge.rounded-pill.bg-info.text-white, .exclude-from-pa11y-analysis, a.disabled, .form-check.form-switch, .nav-tabs .nav-item .nav-link.disabled",
     "ignore": [
       "heading-order",
       "scrollable-region-focusable"

--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -5,7 +5,7 @@
     "runners": [
       "axe"
     ],
-    "hideElements": ".bd-search, [id*='tarteaucitron'], #TableOfContents, .text-primary, .navbar-light .navbar-brand, .accordion-button:not(.collapsed), .active, [aria-current], select:disabled, [disabled] label, [disabled] + label, .modal, .bd-example nav, .badge.rounded-pill.bg-info.text-white, .exclude-from-pa11y-analysis, a.disabled, .form-check.form-switch, .nav-tabs .nav-item .nav-link.disabled",
+    "hideElements": ".bd-search, [id*='tarteaucitron'], #TableOfContents, .text-primary, .accordion-button:not(.collapsed), .active, [aria-current], select:disabled, [disabled] label, [disabled] + label, .modal, .bd-example nav, .badge.rounded-pill.bg-info.text-white, .exclude-from-pa11y-analysis, a.disabled, .form-check.form-switch, .nav-tabs .nav-item .nav-link.disabled",
     "ignore": [
       "heading-order",
       "scrollable-region-focusable"

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -98,7 +98,7 @@
 // Boosted mod
 .nav-tabs-light {
   --#{$variable-prefix}tabs-spacing: #{$nav-tabs-border-width * .5};
-  border-color: $gray-600;
+  border-color: $gray-500;
 
   .nav-link {
     // stylelint-disable-next-line function-disallowed-list
@@ -188,7 +188,28 @@
   > .tab-pane {
     display: none;
   }
+
+  > .tab-pane-with-nested-tab {
+    display: none;
+    margin: subtract(-$spacer, -$nav-tabs-border-width);
+  }
+
   > .active {
+    display: block;
+  }
+}
+
+.nested-tab-content {
+  // Boosted mod
+  padding: subtract($spacer, $nav-tabs-border-width);
+  border-top: 0;
+  // End mod
+
+  >.tab-pane {
+    display: none;
+  }
+
+  >.active {
     display: block;
   }
 }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -189,27 +189,14 @@
     display: none;
   }
 
+  // Boosted mod
   > .tab-pane-with-nested-tab {
     display: none;
     margin: subtract(-$spacer, -$nav-tabs-border-width);
   }
-
-  > .active {
-    display: block;
-  }
-}
-
-.nested-tab-content {
-  // Boosted mod
-  padding: subtract($spacer, $nav-tabs-border-width);
-  border-top: 0;
   // End mod
 
-  >.tab-pane {
-    display: none;
-  }
-
-  >.active {
+  > .active {
     display: block;
   }
 }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -52,7 +52,7 @@
   // End mod
 
   .nav-link {
-    padding: subtract(1rem, $nav-tabs-border-width) $nav-tabs-link-padding-x; // Boosted mod
+    padding: subtract(1rem, $nav-tabs-border-width) subtract($nav-tabs-link-padding-x, $nav-tabs-border-width); // Boosted mod
     // stylelint-disable-next-line function-disallowed-list
     margin-bottom: calc(var(--#{$variable-prefix}tabs-spacing) * -1);
     background: none;
@@ -182,27 +182,19 @@
 
 .tab-content {
   // Boosted mod
-  padding: $spacer $nav-tabs-link-padding-x;
+  padding: $spacer subtract($nav-tabs-link-padding-x, $nav-tabs-border-width);
   border: $nav-tabs-border-width solid;
   border-top: 0;
   // End mod
 
-  > .tab-pane .active{
-    display: block;
-
-  }
   > .tab-pane {
     display: none;
   }
 
-
   // Boosted mod
   > .tab-pane-with-nested-tab {
     display: none;
-    margin-top: -$spacer;
-    margin-right: -$nav-tabs-link-padding-x;
-    margin-bottom: -$spacer;
-    margin-left: -$nav-tabs-link-padding-x;
+    margin: $spacer * -1 subtract($nav-tabs-link-padding-x, $nav-tabs-border-width) * -1;
   }
   // End mod
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -52,7 +52,7 @@
   // End mod
 
   .nav-link {
-    padding: subtract(1rem, $nav-tabs-border-width) map-get($spacers, 4); // Boosted mod
+    padding: subtract(1rem, $nav-tabs-border-width) $nav-tabs-link-padding-x; // Boosted mod
     // stylelint-disable-next-line function-disallowed-list
     margin-bottom: calc(var(--#{$variable-prefix}tabs-spacing) * -1);
     background: none;
@@ -125,6 +125,8 @@
 
 .nav-pills {
   .nav-link {
+    padding-right: $nav-tabs-link-padding-x;
+    padding-left: $nav-tabs-link-padding-x;
     background: none;
     border: 0;
     @include border-radius($nav-pills-border-radius);
@@ -180,19 +182,27 @@
 
 .tab-content {
   // Boosted mod
-  padding: subtract($spacer, $nav-tabs-border-width);
+  padding: $spacer $nav-tabs-link-padding-x;
   border: $nav-tabs-border-width solid;
   border-top: 0;
   // End mod
 
+  > .tab-pane .active{
+    display: block;
+
+  }
   > .tab-pane {
     display: none;
   }
 
+
   // Boosted mod
   > .tab-pane-with-nested-tab {
     display: none;
-    margin: subtract(-$spacer, -$nav-tabs-border-width);
+    margin-top: -$spacer;
+    margin-right: -$nav-tabs-link-padding-x;
+    margin-bottom: -$spacer;
+    margin-left: -$nav-tabs-link-padding-x;
   }
   // End mod
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1199,6 +1199,7 @@ $nav-link-disabled-color:           $gray-500 !default;
 $nav-tabs-border-color:             $black !default;
 $nav-tabs-border-width:             $border-width !default;
 $nav-tabs-border-radius:            $border-radius !default;
+$nav-tabs-link-padding-x:           map-get($spacers, 4) !default;
 $nav-tabs-link-hover-border-color:  $nav-tabs-border-color !default;
 $nav-tabs-link-active-color:        $black !default;
 $nav-tabs-link-active-bg:           $body-bg !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1199,7 +1199,7 @@ $nav-link-disabled-color:           $gray-500 !default;
 $nav-tabs-border-color:             $black !default;
 $nav-tabs-border-width:             $border-width !default;
 $nav-tabs-border-radius:            $border-radius !default;
-$nav-tabs-link-padding-x:           1.8125rem !default;
+$nav-tabs-link-padding-x:           1.8125rem !default; // Boosted mod
 $nav-tabs-link-hover-border-color:  $nav-tabs-border-color !default;
 $nav-tabs-link-active-color:        $black !default;
 $nav-tabs-link-active-bg:           $body-bg !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1199,7 +1199,7 @@ $nav-link-disabled-color:           $gray-500 !default;
 $nav-tabs-border-color:             $black !default;
 $nav-tabs-border-width:             $border-width !default;
 $nav-tabs-border-radius:            $border-radius !default;
-$nav-tabs-link-padding-x:           map-get($spacers, 4) !default;
+$nav-tabs-link-padding-x:           1.8125rem !default;
 $nav-tabs-link-hover-border-color:  $nav-tabs-border-color !default;
 $nav-tabs-link-active-color:        $black !default;
 $nav-tabs-link-active-bg:           $body-bg !default;

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -178,20 +178,22 @@ Nav tabs light only differ visually, with a full width bottom border and a diffe
 Nav tabs light is nested in a tab for adding a level of depth in information organization.
 
 {{< example >}}
-<ul class="nav nav-tabs" id="nav-tab-with-nested-tabs" role="tablist">
-  <li class="nav-item">
-    <button class="nav-link active" aria-current="page" id="nav-tab1" data-bs-toggle="tab" data-bs-target="#tab1-content" type="button" role="tab" aria-controls="tab1-content" aria-selected="true">Tab 1</button>
-  </li>
-  <li class="nav-item">
-    <button class="nav-link" id="nav-tab2" data-bs-toggle="tab" data-bs-target="#tab2-content" type="button" role="tab" aria-controls="tab2-content" aria-selected="false">Tab 2</button>
-  </li>
-  <li class="nav-item">
-    <button class="nav-link" id="nav-tab3" data-bs-toggle="tab" data-bs-target="#tab3-content" type="button" role="tab" aria-controls="tab3-content" aria-selected="false">Tab 3</button>
-  </li>
-  <li class="nav-item">
-    <button class="nav-link disabled" id="nav-tab4" data-bs-toggle="tab" data-bs-target="#tab4-content" type="button" role="tab" aria-controls="tab4-content" aria-selected="false">Tab 4</button>
-  </li>
-</ul>
+<div role="tablist" aria-owns="nav-tab1 nav-tab2 nav-tab3 nav-tab4">
+  <ul class="nav nav-tabs" id="nav-tab-with-nested-tabs">
+    <li class="nav-item">
+      <button class="nav-link active" aria-current="page" id="nav-tab1" data-bs-toggle="tab" data-bs-target="#tab1-content" type="button" role="tab" aria-controls="tab1-content" aria-selected="true">Tab 1</button>
+    </li>
+    <li class="nav-item">
+      <button class="nav-link" id="nav-tab2" data-bs-toggle="tab" data-bs-target="#tab2-content" type="button" role="tab" aria-controls="tab2-content" aria-selected="false">Tab 2</button>
+    </li>
+    <li class="nav-item">
+      <button class="nav-link" id="nav-tab3" data-bs-toggle="tab" data-bs-target="#tab3-content" type="button" role="tab" aria-controls="tab3-content" aria-selected="false">Tab 3</button>
+    </li>
+    <li class="nav-item">
+      <button class="nav-link disabled" id="nav-tab4" data-bs-toggle="tab" data-bs-target="#tab4-content" type="button" role="tab" aria-controls="tab4-content" aria-selected="false">Tab 4</button>
+    </li>
+  </ul>
+</div>
 
 <!-- Tab panes -->
 <div class="tab-content" id="nav-tabs-content">

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -151,7 +151,6 @@ Takes the basic nav from above and adds the `.nav-tabs` class to generate a tabb
 <!-- Boosted mod -->
 ### Tabs light
 
-
 Nav tabs light only differ visually, with a full width bottom border and a different active state.
 
 {{< example >}}
@@ -170,10 +169,8 @@ Nav tabs light only differ visually, with a full width bottom border and a diffe
   </li>
 </ul>
 {{< /example >}}
-<!-- End mod -->
 
 ### Nested tabs
-
 
 Nav tabs light is nested in a tab for adding a level of depth in information organization.
 
@@ -181,39 +178,38 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
 <div role="tablist" aria-owns="nav-tab1 nav-tab2 nav-tab3 nav-tab4">
   <ul class="nav nav-tabs" id="nav-tab-with-nested-tabs">
     <li class="nav-item">
-      <button class="nav-link active" aria-current="page" id="nav-tab1" data-bs-toggle="tab" data-bs-target="#tab1-content" type="button" role="tab" aria-controls="tab1-content" aria-selected="true">Tab 1</button>
+      <a class="nav-link active" aria-current="page" id="nav-tab1" href="#tab1-content" data-bs-toggle="tab" data-bs-target="#tab1-content" type="button" role="tab" aria-controls="tab1-content" aria-selected="true">Tab 1</a>
     </li>
     <li class="nav-item">
-      <button class="nav-link" id="nav-tab2" data-bs-toggle="tab" data-bs-target="#tab2-content" type="button" role="tab" aria-controls="tab2-content" aria-selected="false">Tab 2</button>
+      <a class="nav-link" id="nav-tab2" data-bs-toggle="tab" href="#tab2-content" data-bs-target="#tab2-content" type="button" role="tab" aria-controls="tab2-content" aria-selected="false">Tab 2</a>
     </li>
     <li class="nav-item">
-      <button class="nav-link" id="nav-tab3" data-bs-toggle="tab" data-bs-target="#tab3-content" type="button" role="tab" aria-controls="tab3-content" aria-selected="false">Tab 3</button>
+      <a class="nav-link" id="nav-tab3" data-bs-toggle="tab" href="#tab3-content" data-bs-target="#tab3-content" type="button" role="tab" aria-controls="tab3-content" aria-selected="false">Tab 3</a>
     </li>
     <li class="nav-item">
-      <button class="nav-link disabled" id="nav-tab4" data-bs-toggle="tab" data-bs-target="#tab4-content" type="button" role="tab" aria-controls="tab4-content" aria-selected="false">Tab 4</button>
+      <a class="nav-link disabled" id="nav-tab4" type="button" role="tab" aria-selected="false">Tab 4</a>
     </li>
   </ul>
 </div>
 
-<!-- Tab panes -->
 <div class="tab-content" id="nav-tabs-content">
   <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tablist" aria-labelledby="nav-tab1">
     <ul class="nav nav-tabs nav-tabs-light mt-0">
       <li class="nav-item">
-        <button class="nav-link active" id="nav-linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page" >Link A</button>
+        <a class="nav-link active" id="nav-linkA" href="#linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page" >Link A</a>
       </li>
       <li class="nav-item">
-        <button class="nav-link" id="nav-linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tab">Link B</button>
+        <a class="nav-link" id="nav-linkB" href="#linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tab">Link B</a>
       </li>
       <li class="nav-item">
-        <button class="nav-link" id="nav-linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tab">Link C</button>
+        <a class="nav-link" id="nav-linkC" href="#linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tab">Link C</a>
       </li>
       <li class="nav-item">
-        <button class="nav-link disabled" id="nav-linkD" data-bs-toggle="tab" data-bs-target="#linkD" role="tab">Link D</button>
+        <a class="nav-link disabled" id="nav-linkD" role="tab">Link D</a>
       </li>
     </ul>
      <!-- Tab light panes -->
-    <div class="nested-tab-content ps-4" id="nav-tabs-light-content">
+    <div class="tab-content border-0 ps-4" id="nav-tabs-light-content">
       <div class="tab-pane fade show active" id="linkA" role="tabpanel" aria-labelledby="nav-linkA">Content of Link A</div>
       <div class="tab-pane" id="linkB" role="tabpanel" aria-labelledby="nav-linkB">Content of Link B</div>
       <div class="tab-pane" id="linkC" role="tabpanel" aria-labelledby="nav-linkC">Content of Link C</div>

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -172,6 +172,44 @@ Nav tabs light only differ visually, with a full width bottom border and a diffe
 {{< /example >}}
 <!-- End mod -->
 
+### Nested tabs
+
+
+Nav tabs light is nested in a tab for adding a level of depth in information organization.
+
+{{< example >}}
+<ul class="nav nav-tabs">
+  <li class="nav-item">
+    <a class="nav-link active" aria-current="page" href="#">Active</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link disabled">Disabled</a>
+  </li>
+</ul>
+<ul class="nav nav-tabs nav-tabs-light mt-0">
+  <li class="nav-item ps-1">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link active" href="#" aria-current="page">Active</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link disabled">Disabled</a>
+  </li>
+</ul>
+{{< /example >}}
+
+<!-- End mod -->
+
 ### Pills
 
 Take that same HTML, but use `.nav-pills` instead:

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -178,44 +178,44 @@ Nav tabs light only differ visually, with a full width bottom border and a diffe
 Nav tabs light is nested in a tab for adding a level of depth in information organization.
 
 {{< example >}}
-<ul class="nav nav-tabs" id="nav-tab" role="tablist">
+<ul class="nav nav-tabs" id="nav-tab-with-nested-tabs" role="tablist">
   <li class="nav-item">
-    <button class="nav-link active" aria-current="page" id="nav-tab1" data-bs-toggle="tab" data-bs-target="#tab1-content" type="button" role="tab" aria-controls="nested-tab" aria-selected="true">Tab 1</button>
+    <button class="nav-link active" aria-current="page" id="nav-tab1" data-bs-toggle="tab" data-bs-target="#tab1-content" type="button" role="tab" aria-controls="tab1-content" aria-selected="true">Tab 1</button>
   </li>
   <li class="nav-item">
-    <button class="nav-link" id="nav-tab2" data-bs-toggle="tab" data-bs-target="#tab2-content" type="button" role="tab" aria-controls="nav-link2" aria-selected="false">Tab 2</button>
+    <button class="nav-link" id="nav-tab2" data-bs-toggle="tab" data-bs-target="#tab2-content" type="button" role="tab" aria-controls="tab2-content" aria-selected="false">Tab 2</button>
   </li>
   <li class="nav-item">
-    <button class="nav-link" id="nav-tab3" data-bs-toggle="tab" data-bs-target="#tab3-content" type="button" role="tab" aria-controls="nav-link3" aria-selected="false">Tab 3</button>
+    <button class="nav-link" id="nav-tab3" data-bs-toggle="tab" data-bs-target="#tab3-content" type="button" role="tab" aria-controls="tab3-content" aria-selected="false">Tab 3</button>
   </li>
   <li class="nav-item">
-    <button class="nav-link disabled" id="nav-tab4" data-bs-toggle="tab" data-bs-target="#tab4-content" type="button" role="tab" aria-controls="nav-linkD-disabled" aria-selected="false">Tab 4</button>
+    <button class="nav-link disabled" id="nav-tab4" data-bs-toggle="tab" data-bs-target="#tab4-content" type="button" role="tab" aria-controls="tab4-content" aria-selected="false">Tab 4</button>
   </li>
 </ul>
 
 <!-- Tab panes -->
 <div class="tab-content" id="nav-tabContent">
-  <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tabpanel" aria-labelledby="tab1-content">
+  <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tab" aria-labelledby="tab1-content">
     <ul class="nav nav-tabs nav-tabs-light mt-0">
       <li class="nav-item">
-        <button class="nav-link active" id="nav-linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tabpanel" aria-current="page" aria-labelledby="nav-linkA-tab">Link A</button>
+        <button class="nav-link active" id="nav-linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page" aria-labelledby="nav-linkA-tab">Link A</button>
       </li>
       <li class="nav-item">
-        <button class="nav-link" id="nav-linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tabpanel" aria-labelledby="nav-linkB-tab">Link B</button>
+        <button class="nav-link" id="nav-linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tab" aria-labelledby="nav-linkB-tab">Link B</button>
       </li>
       <li class="nav-item">
-        <button class="nav-link" id="nav-linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tabpanel" aria-labelledby="nav-linkC-tab">Link C</button>
+        <button class="nav-link" id="nav-linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tab" aria-labelledby="nav-linkC-tab">Link C</button>
       </li>
       <li class="nav-item">
-        <button class="nav-link disabled" id="nav-linkD" data-bs-toggle="tab" data-bs-target="#linkD" role="tabpanel" aria-labelledby="nav-linkD-tab">Link D</button>
+        <button class="nav-link disabled" id="nav-linkD" data-bs-toggle="tab" data-bs-target="#linkD" role="tab" aria-labelledby="nav-linkD-tab">Link D</button>
       </li>
     </ul>
      <!-- Tab light panes -->
     <div class="nested-tab-content ps-4" id="nav-tabs-light-content">
-      <div class="tab-pane fade show active" id="linkA" role="tabpanel" aria-labelledby="linkA">Content of Link A</div>
-      <div class="tab-pane" id="linkB" role="tabpanel" aria-labelledby="linkB">Content of Link B</div>
-      <div class="tab-pane" id="linkC" role="tabpanel" aria-labelledby="linkC">Content of Link C</div>
-      <div class="tab-pane" id="linkD" role="tabpanel" aria-labelledby="linkD">Content of Link D</div>
+      <div class="tab-pane fade show active" id="linkA" role="tabpanel" aria-labelledby="nav-linkA">Content of Link A</div>
+      <div class="tab-pane" id="linkB" role="tabpanel" aria-labelledby="nav-linkB">Content of Link B</div>
+      <div class="tab-pane" id="linkC" role="tabpanel" aria-labelledby="nav-linkC">Content of Link C</div>
+      <div class="tab-pane" id="linkD" role="tabpanel" aria-labelledby="nav-linkD">Content of Link D</div>
     </div>
   </div>
   <div class="tab-pane" id="tab2-content" role="tabpanel" aria-labelledby="tab2-content">Content of Tab 2</div>

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -208,7 +208,6 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
         <a class="nav-link disabled" id="nav-linkD" role="tab">Link D</a>
       </li>
     </ul>
-     <!-- Tab light panes -->
     <div class="tab-content border-0" id="nav-tabs-light-content">
       <div class="tab-pane fade show active" id="linkA" role="tabpanel" aria-labelledby="nav-linkA">Content of Link A</div>
       <div class="tab-pane" id="linkB" role="tabpanel" aria-labelledby="nav-linkB">Content of Link B</div>

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -187,7 +187,7 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
       <a class="nav-link" id="nav-tab3" data-bs-toggle="tab" href="#tab3-content" data-bs-target="#tab3-content" role="tab" aria-controls="tab3-content" aria-selected="false">Tab 3</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link disabled" id="nav-tab4" type="button" role="tab" aria-selected="false">Tab 4</a>
+      <a class="nav-link disabled" id="nav-tab4" role="tab" aria-selected="false">Tab 4</a>
     </li>
   </ul>
 </div>

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -209,7 +209,7 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
       </li>
     </ul>
      <!-- Tab light panes -->
-    <div class="tab-content border-0 ps-4" id="nav-tabs-light-content">
+    <div class="tab-content border-0" id="nav-tabs-light-content">
       <div class="tab-pane fade show active" id="linkA" role="tabpanel" aria-labelledby="nav-linkA">Content of Link A</div>
       <div class="tab-pane" id="linkB" role="tabpanel" aria-labelledby="nav-linkB">Content of Link B</div>
       <div class="tab-pane" id="linkC" role="tabpanel" aria-labelledby="nav-linkC">Content of Link C</div>

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -201,10 +201,10 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
         <button class="nav-link active" id="nav-linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page" >Link A</button>
       </li>
       <li class="nav-item">
-        <button class="nav-link" id="nav-linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tab"">Link B</button>
+        <button class="nav-link" id="nav-linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tab">Link B</button>
       </li>
       <li class="nav-item">
-        <button class="nav-link" id="nav-linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tab"">Link C</button>
+        <button class="nav-link" id="nav-linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tab">Link C</button>
       </li>
       <li class="nav-item">
         <button class="nav-link disabled" id="nav-linkD" data-bs-toggle="tab" data-bs-target="#linkD" role="tab">Link D</button>

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -178,34 +178,50 @@ Nav tabs light only differ visually, with a full width bottom border and a diffe
 Nav tabs light is nested in a tab for adding a level of depth in information organization.
 
 {{< example >}}
-<ul class="nav nav-tabs">
+<ul class="nav nav-tabs" id="nav-tab" role="tablist">
   <li class="nav-item">
-    <a class="nav-link active" aria-current="page" href="#">Active</a>
+    <button class="nav-link active" aria-current="page" id="nav-tab1" data-bs-toggle="tab" data-bs-target="#tab1-content" type="button" role="tab" aria-controls="nested-tab" aria-selected="true">Tab 1</button>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="#">Link</a>
+    <button class="nav-link" id="nav-tab2" data-bs-toggle="tab" data-bs-target="#tab2-content" type="button" role="tab" aria-controls="nav-link2" aria-selected="false">Tab 2</button>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="#">Link</a>
+    <button class="nav-link" id="nav-tab3" data-bs-toggle="tab" data-bs-target="#tab3-content" type="button" role="tab" aria-controls="nav-link3" aria-selected="false">Tab 3</button>
   </li>
   <li class="nav-item">
-    <a class="nav-link disabled">Disabled</a>
+    <button class="nav-link disabled" id="nav-tab4" data-bs-toggle="tab" data-bs-target="#tab4-content" type="button" role="tab" aria-controls="nav-linkD-disabled" aria-selected="false">Tab 4</button>
   </li>
 </ul>
-<ul class="nav nav-tabs nav-tabs-light mt-0">
-  <li class="nav-item ps-1">
-    <a class="nav-link" href="#">Link</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link active" href="#" aria-current="page">Active</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" href="#">Link</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link disabled">Disabled</a>
-  </li>
-</ul>
+
+<!-- Tab panes -->
+<div class="tab-content" id="nav-tabContent">
+  <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tabpanel" aria-labelledby="tab1-content">
+    <ul class="nav nav-tabs nav-tabs-light mt-0">
+      <li class="nav-item">
+        <button class="nav-link active" id="nav-linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tabpanel" aria-current="page" aria-labelledby="nav-linkA-tab">Link A</button>
+      </li>
+      <li class="nav-item">
+        <button class="nav-link" id="nav-linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tabpanel" aria-labelledby="nav-linkB-tab">Link B</button>
+      </li>
+      <li class="nav-item">
+        <button class="nav-link" id="nav-linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tabpanel" aria-labelledby="nav-linkC-tab">Link C</button>
+      </li>
+      <li class="nav-item">
+        <button class="nav-link disabled" id="nav-linkD" data-bs-toggle="tab" data-bs-target="#linkD" role="tabpanel" aria-labelledby="nav-linkD-tab">Link D</button>
+      </li>
+    </ul>
+     <!-- Tab light panes -->
+    <div class="nested-tab-content ps-4" id="nav-tabs-light-content">
+      <div class="tab-pane fade show active" id="linkA" role="tabpanel" aria-labelledby="linkA">Content of Link A</div>
+      <div class="tab-pane" id="linkB" role="tabpanel" aria-labelledby="linkB">Content of Link B</div>
+      <div class="tab-pane" id="linkC" role="tabpanel" aria-labelledby="linkC">Content of Link C</div>
+      <div class="tab-pane" id="linkD" role="tabpanel" aria-labelledby="linkD">Content of Link D</div>
+    </div>
+  </div>
+  <div class="tab-pane" id="tab2-content" role="tabpanel" aria-labelledby="tab2-content">Content of Tab 2</div>
+  <div class="tab-pane" id="tab3-content" role="tabpanel" aria-labelledby="tab3-content">Content of Tab 3</div>
+  <div class="tab-pane" id="tab4-content" role="tabpanel" aria-labelledby="tab4-content">Content of Tab 4</div>
+</div>
 {{< /example >}}
 
 <!-- End mod -->

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -178,13 +178,13 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
 <div role="tablist" aria-owns="nav-tab1 nav-tab2 nav-tab3 nav-tab4">
   <ul class="nav nav-tabs" id="nav-tab-with-nested-tabs">
     <li class="nav-item">
-      <a class="nav-link active" aria-current="page" id="nav-tab1" href="#tab1-content" data-bs-toggle="tab" data-bs-target="#tab1-content" type="button" role="tab" aria-controls="tab1-content" aria-selected="true">Tab 1</a>
+      <a class="nav-link active" aria-current="page" id="nav-tab1" href="#tab1-content" data-bs-toggle="tab" data-bs-target="#tab1-content" role="tab" aria-controls="tab1-content" aria-selected="true">Tab 1</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" id="nav-tab2" data-bs-toggle="tab" href="#tab2-content" data-bs-target="#tab2-content" type="button" role="tab" aria-controls="tab2-content" aria-selected="false">Tab 2</a>
+      <a class="nav-link" id="nav-tab2" data-bs-toggle="tab" href="#tab2-content" data-bs-target="#tab2-content" role="tab" aria-controls="tab2-content" aria-selected="false">Tab 2</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" id="nav-tab3" data-bs-toggle="tab" href="#tab3-content" data-bs-target="#tab3-content" type="button" role="tab" aria-controls="tab3-content" aria-selected="false">Tab 3</a>
+      <a class="nav-link" id="nav-tab3" data-bs-toggle="tab" href="#tab3-content" data-bs-target="#tab3-content" role="tab" aria-controls="tab3-content" aria-selected="false">Tab 3</a>
     </li>
     <li class="nav-item">
       <a class="nav-link disabled" id="nav-tab4" type="button" role="tab" aria-selected="false">Tab 4</a>

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -194,20 +194,20 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
 </ul>
 
 <!-- Tab panes -->
-<div class="tab-content" id="nav-tabContent">
-  <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tablist">
+<div class="tab-content" id="nav-tabs-content">
+  <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tablist" aria-labelledby="nav-tab1">
     <ul class="nav nav-tabs nav-tabs-light mt-0">
       <li class="nav-item">
-        <button class="nav-link active" id="nav-linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page" aria-labelledby="nav-linkA-tab">Link A</button>
+        <button class="nav-link active" id="nav-linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page" >Link A</button>
       </li>
       <li class="nav-item">
-        <button class="nav-link" id="nav-linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tab" aria-labelledby="nav-linkB-tab">Link B</button>
+        <button class="nav-link" id="nav-linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tab"">Link B</button>
       </li>
       <li class="nav-item">
-        <button class="nav-link" id="nav-linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tab" aria-labelledby="nav-linkC-tab">Link C</button>
+        <button class="nav-link" id="nav-linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tab"">Link C</button>
       </li>
       <li class="nav-item">
-        <button class="nav-link disabled" id="nav-linkD" data-bs-toggle="tab" data-bs-target="#linkD" role="tab" aria-labelledby="nav-linkD-tab">Link D</button>
+        <button class="nav-link disabled" id="nav-linkD" data-bs-toggle="tab" data-bs-target="#linkD" role="tab">Link D</button>
       </li>
     </ul>
      <!-- Tab light panes -->
@@ -218,9 +218,9 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
       <div class="tab-pane" id="linkD" role="tabpanel" aria-labelledby="nav-linkD">Content of Link D</div>
     </div>
   </div>
-  <div class="tab-pane" id="tab2-content" role="tabpanel" aria-labelledby="tab2-content">Content of Tab 2</div>
-  <div class="tab-pane" id="tab3-content" role="tabpanel" aria-labelledby="tab3-content">Content of Tab 3</div>
-  <div class="tab-pane" id="tab4-content" role="tabpanel" aria-labelledby="tab4-content">Content of Tab 4</div>
+  <div class="tab-pane" id="tab2-content" role="tabpanel" aria-labelledby="nav-tab2">Content of Tab 2</div>
+  <div class="tab-pane" id="tab3-content" role="tabpanel" aria-labelledby="nav-tab3">Content of Tab 3</div>
+  <div class="tab-pane" id="tab4-content" role="tabpanel" aria-labelledby="nav-tab4">Content of Tab 4</div>
 </div>
 {{< /example >}}
 

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -195,7 +195,7 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
 
 <!-- Tab panes -->
 <div class="tab-content" id="nav-tabContent">
-  <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tab" aria-labelledby="tab1-content">
+  <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tablist">
     <ul class="nav nav-tabs nav-tabs-light mt-0">
       <li class="nav-item">
         <button class="nav-link active" id="nav-linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page" aria-labelledby="nav-linkA-tab">Link A</button>

--- a/site/content/docs/5.1/components/navs-tabs.md
+++ b/site/content/docs/5.1/components/navs-tabs.md
@@ -196,7 +196,7 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
   <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tablist" aria-labelledby="nav-tab1">
     <ul class="nav nav-tabs nav-tabs-light mt-0">
       <li class="nav-item">
-        <a class="nav-link active" id="nav-linkA" href="#linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page" >Link A</a>
+        <a class="nav-link active" id="nav-linkA" href="#linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page">Link A</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" id="nav-linkB" href="#linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tab">Link B</a>


### PR DESCRIPTION
Add in `Docs > Navs & tabs` the component `Tabs nested WEB-NAV-TAB-003` from https://system.design.orange.com/0c1af118d/p/44331c-navigation/b/9105e6/i/66611049![image](https://user-images.githubusercontent.com/89514509/148537270-0f01d0b7-b774-4049-97ae-2f572a2efb48.png)

Netlify link to look at what's done: 
https://deploy-preview-1017--boosted.netlify.app/docs/5.1/components/navs-tabs/#nested-tabs/