### PR TITLE
fix(#1019): modify buttons icons padding

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -56,7 +56,7 @@
   }
 
   // Boosted mod: with icon
-  > svg {
+  &:not(.btn-icon) > svg {
     transform: translateY(1px);
   }
   // End mod
@@ -188,7 +188,8 @@
 
 // Boosted mod: icon button
 .btn-icon {
-  padding: var(--#{$boosted-variable-prefix}icon-spacing);
+  padding-right: var(--#{$boosted-variable-prefix}icon-spacing);
+  padding-left: var(--#{$boosted-variable-prefix}icon-spacing);
 }
 // End mod
 

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -188,8 +188,7 @@
 
 // Boosted mod: icon button
 .btn-icon {
-  padding-right: var(--#{$boosted-variable-prefix}icon-spacing);
-  padding-left: var(--#{$boosted-variable-prefix}icon-spacing);
+  padding: var(--#{$boosted-variable-prefix}icon-spacing);
 }
 // End mod
 


### PR DESCRIPTION
Closes #1019

### Prerequisites

- [X] I have [searched](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues?utf8=%E2%9C%93&q=is%3Aissue) for duplicate or closed issues
- [X] I have [validated](https://html5.validator.nu/) any HTML to avoid common problems
- [X] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

### Describe the issue

Icons in buttons icons should be 1px lower.
![chrome](https://user-images.githubusercontent.com/92363071/148204922-88e87109-63cc-4336-b29f-438390ac8306.png)
![firefox](https://user-images.githubusercontent.com/92363071/148204932-8c0fcba2-16df-4e6d-9a47-1e8c9250af97.png)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)