### PR TITLE
Dark accordions

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -115,3 +115,39 @@
     letter-spacing: $accordion-button-letter-spacing-lg;
   }
 }
+
+// Boosted mod
+.accordion-dark {
+  .accordion-button {
+    color: $accordion-dark-button-color;
+    background-color: $accordion-dark-button-bg;
+
+    &:not(.collapsed) {
+      color: $accordion-dark-button-active-color;
+      background-color: $accordion-dark-button-active-bg;
+    }
+
+    &:hover {
+      color: $accordion-dark-button-active-color;
+    }
+
+    &:focus {
+      color: $accordion-dark-button-active-color;
+    }
+  }
+
+  .accordion-header {
+    border: $accordion-border-width solid $accordion-dark-border-color;
+    border-width: $accordion-border-width 0 0;
+  }
+
+  .accordion-item {
+    color: color-contrast($accordion-dark-bg);
+    background-color: $accordion-dark-bg;
+
+    &:last-of-type {
+      border-bottom: $accordion-border-width solid $accordion-dark-border-color;
+    }
+  }
+}
+// End mod

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1387,7 +1387,7 @@ $card-footer-color:                 $gray-700 !default; // Boosted mod
 
 // scss-docs-start accordion-variables
 $accordion-padding-y:                     $spacer * .5 !default;
-$accordion-padding-x:                     $spacer * .5 !default;
+$accordion-padding-x:                     0 !default;
 $accordion-color:                         $body-color !default;
 $accordion-bg:                            $body-bg !default;
 $accordion-border-width:                  $border-width * .5 !default;
@@ -1405,6 +1405,14 @@ $accordion-button-bg:                     $accordion-bg !default;
 $accordion-transition:                    $btn-transition, border-radius .15s ease !default;
 $accordion-button-active-bg:              null !default;
 $accordion-button-active-color:           $accessible-orange !default;
+
+$accordion-dark-color:                    $white !default;
+$accordion-dark-bg:                       $black !default;
+$accordion-dark-border-color:             $gray-700 !default;
+$accordion-dark-button-color:             $accordion-dark-color !default;
+$accordion-dark-button-bg:                $accordion-dark-bg !default;
+$accordion-dark-button-active-bg:         null !default;
+$accordion-dark-button-active-color:      $brand-orange !default;
 
 // Boosted mod: no $accordion-button-focus-*
 

--- a/site/content/docs/5.1/components/accordion.md
+++ b/site/content/docs/5.1/components/accordion.md
@@ -198,6 +198,51 @@ Omit the `data-bs-parent` attribute on each `.accordion-collapse` to make accord
 </div>
 {{< /example >}}
 
+### Dark variant
+
+Accordions come with a dark variant: `.accordion-dark`.
+
+{{< example >}}
+<div class="accordion accordion-dark" id="accordionPanelsDarkExample">
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="panelsDark-headingOne">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsDark-collapseOne" aria-expanded="true" aria-controls="panelsDark-collapseOne">
+        Accordion Item #1
+      </button>
+    </h2>
+    <div id="panelsDark-collapseOne" class="accordion-collapse collapse show" aria-labelledby="panelsDark-headingOne" data-bs-parent="#accordionPanelsDarkExample">
+      <div class="accordion-body">
+        <strong>This is the first item's accordion body.</strong> It is shown by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
+      </div>
+    </div>
+  </div>
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="panelsDark-headingTwo">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#panelsDark-collapseTwo" aria-expanded="false" aria-controls="panelsDark-collapseTwo">
+        Accordion Item #2
+      </button>
+    </h2>
+    <div id="panelsDark-collapseTwo" class="accordion-collapse collapse" aria-labelledby="panelsDark-headingTwo" data-bs-parent="#accordionPanelsDarkExample">
+      <div class="accordion-body">
+        <strong>This is the second item's accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
+      </div>
+    </div>
+  </div>
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="panelsDark-headingThree">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#panelsDark-collapseThree" aria-expanded="false" aria-controls="panelsDark-collapseThree">
+        Accordion Item #3
+      </button>
+    </h2>
+    <div id="panelsDark-collapseThree" class="accordion-collapse collapse" aria-labelledby="panelsDark-headingThree" data-bs-parent="#accordionPanelsDarkExample">
+      <div class="accordion-body">
+        <strong>This is the third item's accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
+      </div>
+    </div>
+  </div>
+</div>
+{{< /example >}}
+
 ## Accessibility
 
 Please read the [collapse accessibility section]({{< docsref "/components/collapse#accessibility" >}}) for more information.


### PR DESCRIPTION
### Description

Adding a `.accordion-dark` for a dark variant of accordions.

### Motivation & Context

Need for orange footers

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Development

- [x] Should match specs (eg. either the Web UI Kit or any pattern from the WAI — or both…)
- [x] Docs added:
  - including the "Sass" part using `scss-docs` shortcode
  - in /about/overview/#custom-components if it is a new Orange custom component
  - in /getting-started/introduction/#components if it is a new Orange custom component that requires JavaScript (and Popper)
  - in /customize/overview#csps-and-embedded-svgs if it is a new Orange custom component that includes embedded SVGs in our CSS
  - in /forms/validation/?#supported-elements if it is a new Orange custom component that is a form control
  - in /forms/overview/ if it is a new Orange custom component that is a form control
- [x] Check (and fix) RTL version
- [x] Run linters
- [x] Run compilers
- [x] Tests added for JS-side
- [x] Run tests
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] Cross-browser test:
  - Firefox ESR
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Clean up the branch using `rebase -i`
- [ ] Commited with `feat(…): …` message
- [ ] Mention it in Migration Guide (if `back-from-v4`): renamed variables, changes in markup requirement,  etc.

### Reviews

- [ ] Code review
- [ ] A11y review
- [ ] Design review

### Related issues

No issue

### [Live preview](https://deploy-preview-{your pr number}--boosted.netlify.app/docs/5.1/components/accordion/#dark-variant)