### PR TITLE
FIX: Restore line heights var values by fixing `calc(divide())` operations

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -276,10 +276,8 @@ $grid-row-columns:            6 !default;
 //
 // Define common padding and border radius sizes and more.
 
-// stylelint-disable function-disallowed-list
-$line-height-lg:              calc(divide(20, 18)) !default; // Boosted mod
-$line-height-sm:              calc(divide(16, 14)) !default; // Boosted mod
-// stylelint-enable function-disallowed-list
+$line-height-lg:              divide(20, 18) !default; // Boosted mod
+$line-height-sm:              divide(16, 14) !default; // Boosted mod
 
 // Boosted mod: Line length for accessibility
 $line-length-sm:              40ch !default;
@@ -357,6 +355,7 @@ $h3-font-size:                $font-size-base * 1.5 !default;     // 24px
 $h4-font-size:                $font-size-xlg !default;            // 20px
 $h5-font-size:                $font-size-lg !default;             // 18px
 $h6-font-size:                $font-size-base !default;           // 16px
+
 $h1-spacing:                  $letter-spacing-base * 10 !default; // -1px
 $h2-spacing:                  $letter-spacing-base * 8 !default;  // -0.8px
 $mid-spacing:                 $letter-spacing-base * 6 !default;  // -0.6px
@@ -364,14 +363,13 @@ $h3-spacing:                  $letter-spacing-base * 5 !default;  // -0.5px
 $h4-spacing:                  $letter-spacing-base * 4 !default;  // -0.4px
 $h5-spacing:                  $letter-spacing-base * 2 !default;  // -0.2px
 $h6-spacing:                  $letter-spacing-base !default;
-// stylelint-disable function-disallowed-list
+
 $h1-line-height:              1 !default;
-$h2-line-height:              calc(divide(32, 30)) !default;
-$h3-line-height:              calc(divide(26, 24)) !default;
-$h4-line-height:              calc(divide(22, 20)) !default;
-$h5-line-height:              calc(divide(20, 18)) !default;
+$h2-line-height:              divide(32, 30) !default;
+$h3-line-height:              divide(26, 24) !default;
+$h4-line-height:              divide(22, 20) !default;
+$h5-line-height:              divide(20, 18) !default;
 $h6-line-height:              $line-height-base !default;
-// stylelint-enable function-disallowed-list
 
 $headings-margin-bottom:      $spacer !default;
 $headings-font-family:        null !default;
@@ -399,8 +397,7 @@ $display-line-height:         1 !default;
 
 $lead-font-size:              $font-size-xlg !default; // Boosted mod
 $lead-font-weight:            400 !default; // Boosted mod
-// stylelint-disable-next-line function-disallowed-list
-$lead-line-height:            calc(divide(30, 20)) !default; // Boosted mod
+$lead-line-height:            divide(30, 20) !default; // Boosted mod
 $lead-letter-spacing:         $letter-spacing-base * 2.5 !default; // Boosted mod
 
 $small-font-size:             $font-size-sm !default; // Boosted mod → 14px
@@ -412,8 +409,7 @@ $text-muted-dark:             $gray-600 !default; // Boosted mod: ensure contras
 $blockquote-small-color:      $gray-700 !default;
 $blockquote-small-font-size:  $small-font-size !default;
 $blockquote-font-size:        $font-size-xlg !default; // Boosted mod
-// stylelint-disable-next-line function-disallowed-list
-$blockquote-line-height:      calc(divide(30, 20)) !default; // Boosted mod
+$blockquote-line-height:      divide(30, 20) !default; // Boosted mod
 $blockquote-letter-spacing:   -.015625rem !default; // Boosted mod
 
 $hr-border-color:             $gray-300 !default;


### PR DESCRIPTION
Closes #1066 

- [x] Check in all Sass files all `calc(divide(`
- [x] Check in all Sass files all `calc(` containing an operation; could be `divide`, `substract` etc.
- [x] Try to measure the impact in order to be able to explain it in the Release Note

## Impacted elements

### `$line-height-lg`

Impact `$input-btn-line-height-lg` and so:
- `$btn-line-height-lg`
  - `.btn-lg`: Large buttons — **Height has 2.5px in excess**
- `$input-line-height-lg` 
  - `.input-group-lg` > *: Large form inputs — Not really visible
  - `.col-form-label-lg`: Large form labels — Not really visible
  - `.form-control-lg`: Large form controls — Not really visible

### `$line-height-sm`

- `.blockquote-footer`: Quotes in cards — Minimal impact
- `$small-line-height`
  - `.alert-sm`: Small alerts — Minimal impact
  - `<small>` and `.small`: Depends on the use cases but should not be very visible
-  `$input-btn-line-height-sm`
  - `$btn-line-height-sm`
    - `.btn-sm`: **Small buttons  — Height has 1.5px in excess**
  - `$input-line-height-sm`
    - `.col-form-label-sm`: Small form labels — Minimal impact
    - `.form-control-sm`: Small form controls — Minimal impact
    - `.input-group-sm` > *: Small form inputs — Minimal impact
-  `$breadcrumb-line-height`
  - `.breadcrumb`: Breadcrumbs — Minimal impact

### `$h2-line-height`

- `.card-header` > `.btn-lg`: Card header large buttons — Minimal impact
- `.display-1`: Depends on the use cases but should not be very visible
- `media-breakpoint-up(lg)` > `h2, .h2`: Depends on the use cases but should not be very visible

### `$h3-line-height`

- `.card-header` > `button, a`: Card header buttons and links — Minimal impact
- `h1, .h1, .display-2, .display-3`: Depends on the use cases but should not be very visible
- `media-breakpoint-up(sm)` > `h2, .h2, .display-4`: Depends on the use cases but should not be very visible
- `media-breakpoint-up(lg)` > `h3, .h3`: Depends on the use cases but should not be very visible

### `$h4-line-height`

- `.mega-menu` > `.nav-heading`: Nav heading of the mega menu — Minimal impact
- `media-breakpoint-up(lg)` > `h4, .h4`: Depends on the use cases but should not be very visible

### `$h5-line-height`

- `.card-header` > `.btn-sm`: Card header small buttons — Minimal impact
- `h2, .h2, .display-4`: Depends on the use cases but should not be very visible
- `media-breakpoint-up(sm)` > `h3, .h3, h4, .h4, .lead`: Depends on the use cases but should not be very visible
- `media-breakpoint-up(lg)` > `h5, .h5`: Depends on the use cases but should not be very visible

### `$lead-line-height`

- `media-breakpoint-up(lg)` > `.lead`: Depends on the use cases but should not be very visible

### `$blockquote-line-height`

- `.blockquote`: Depends on the use cases but should not be very visible