### PR TITLE
fix(forms): black outline for focused switches

### DIFF
--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -144,6 +144,7 @@
     background-position: $form-switch-bg-position, 0 0;
     background-size: $form-switch-bg-size, $form-switch-bg-square-size; // Get a 1px separation
     border-color: $white; // Boosted mod
+    outline-color: $white; // Boosted mod
     outline-offset: $spacer; // Boosted mod
     @include border-radius($form-switch-border-radius);
     @include transition($form-switch-transition);


### PR DESCRIPTION
Closes #1074 

[Live Preview - Forms > Switches](https://deploy-preview-1082--boosted.netlify.app/docs/5.1/forms/checks-radios/#switches)