### PR TITLE
fix(docs): make visible 'Design guidelines' menu item when the page is active

### DIFF
--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -20,7 +20,7 @@
           <a class="nav-link{{ if eq .Page.Title "Examples" }} active" aria-current="true{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/examples/" onclick="dataLayer.push({'event': 'clic', 'site_name':'accessibility-boosted', 'phase':'prod', 'track_category':'navbar', 'track_name':'examples'});">Examples</a>
         </li>
         <li class="nav-item col-6 col-md-auto">
-          <a class="nav-link{{ if eq .Page.Layout "guidelines" }} active" aria-current="true{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/guidelines/" onclick="dataLayer.push({'event': 'clic', 'site_name':'accessibility-boosted', 'phase':'prod', 'track_category':'navbar', 'track_name':'guidelines'});">Design guidelines</a>
+          <a class="nav-link{{ if eq .Page.Title "Orange Design System for web" }} active" aria-current="true{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/guidelines/" onclick="dataLayer.push({'event': 'clic', 'site_name':'accessibility-boosted', 'phase':'prod', 'track_category':'navbar', 'track_name':'guidelines'});">Design guidelines</a>
         </li>
       </ul>
 


### PR DESCRIPTION
Going onto [Orange Design System for web](https://deploy-preview-1083--boosted.netlify.app/docs/5.1/guidelines/) page make it active (and visible) in the menu bar.

![Screenshot from 2022-02-01 14-40-54](https://user-images.githubusercontent.com/17381666/151978915-e92b0d97-2f8e-4233-b2bc-084afd0c7c57.png)

If you do the same thing locally with the actual _main_ branch, the menu item won't be active.
