### PR TITLE
Reintroduce `.right` class for checks radios as in v4

### DIFF
--- a/site/content/docs/5.1/forms/checks-radios.md
+++ b/site/content/docs/5.1/forms/checks-radios.md
@@ -123,6 +123,19 @@ A switch has the markup of a custom checkbox but uses the `.form-switch` class t
 </div>
 {{< /example >}}
 
+With our utilities, it is also possible to render a toggle switch with label text before.
+
+{{< example >}}
+<div class="form-check form-switch ps-0">
+  <input class="form-check-input float-end ms-1" type="checkbox" role="switch" id="flexSwitchCheckCheckedDisabled">
+  <label class="form-check-label d-block" for="flexSwitchCheckCheckedDisabled">Default switch with label before checkbox input</label>
+</div>
+<div class="form-check form-switch ps-0 w-50">
+  <input class="form-check-input float-end ms-1" type="checkbox" role="switch" id="flexSwitchCheckCheckedDisabled">
+  <label class="form-check-label d-block" for="flexSwitchCheckCheckedDisabled">Default switch with label before checkbox input</label>
+</div>
+{{< /example >}}
+
 ## Default (stacked)
 
 By default, any number of checkboxes and radios that are immediate sibling will be vertically stacked and appropriately spaced with `.form-check`.

--- a/site/content/docs/5.1/forms/checks-radios.md
+++ b/site/content/docs/5.1/forms/checks-radios.md
@@ -127,12 +127,12 @@ With our utilities, it is also possible to render a toggle switch with label tex
 
 {{< example >}}
 <div class="form-check form-switch ps-0">
-  <input class="form-check-input float-end ms-1" type="checkbox" role="switch" id="flexSwitchCheckCheckedDisabled">
-  <label class="form-check-label d-block" for="flexSwitchCheckCheckedDisabled">Default switch with label before checkbox input</label>
+  <input class="form-check-input float-end ms-1" type="checkbox" role="switch" id="flexRightSwitchCheckDefault">
+  <label class="form-check-label d-block" for="flexRightSwitchCheckDefault">Default switch with label before checkbox input</label>
 </div>
 <div class="form-check form-switch ps-0 w-50">
-  <input class="form-check-input float-end ms-1" type="checkbox" role="switch" id="flexSwitchCheckCheckedDisabled">
-  <label class="form-check-label d-block" for="flexSwitchCheckCheckedDisabled">Default switch with label before checkbox input</label>
+  <input class="form-check-input float-end ms-1" type="checkbox" role="switch" id="flexRightSwitchCheckDefault2">
+  <label class="form-check-label d-block" for="flexRightSwitchCheckDefault2">Default switch with label before checkbox input</label>
 </div>
 {{< /example >}}
 


### PR DESCRIPTION
Closes #1073 

### [Preview](https://deploy-preview-1086--boosted.netlify.app/docs/5.1/forms/checks-radios/#switches)