### PR TITLE
fix(forms): change the margin left value between the required symbol and the label

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -952,6 +952,7 @@ $form-label-font-style:                 null !default;
 $form-label-font-weight:                $font-weight-bold !default;
 $form-label-color:                      null !default;
 $form-label-disabled-color:             $gray-500 !default; // Boosted mod
+$form-label-required-margin-left:       .1875rem !default; // Boosted mod
 // scss-docs-end form-label-variables
 
 // scss-docs-start form-input-variables

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -125,7 +125,7 @@
   // Boosted mod: required symbol
   &:required {
     ~ .form-check-label::after {
-      margin-left: $form-label-margin-bottom;
+      margin-left: $form-label-required-margin-left;
       color: $accessible-orange;
       content: "*";
     }

--- a/scss/forms/_labels.scss
+++ b/scss/forms/_labels.scss
@@ -17,7 +17,7 @@
 }
 
 .is-required::after {
-  margin-left: $form-label-margin-bottom;
+  margin-left: $form-label-required-margin-left;
   color: $accessible-orange;
   content: "*";
 }


### PR DESCRIPTION
This PR is a proposal to modify the margin left value between the required symbol (the `*`)  and the corresponding label.

The current value in Boosted is 6px: https://boosted.orange.com/docs/5.1/forms/overview/#required-field.

![Screenshot from 2022-03-09 11-47-56](https://user-images.githubusercontent.com/17381666/157426865-103fa2f4-e684-4eeb-a6d1-cde43c5c1aec.png)

The value [defined in the DSM](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459/i/48901789) is 3px.

[**Preview of the modification**](https://deploy-preview-1144--boosted.netlify.app/docs/5.1/forms/overview/#required-field) (@CyriaqueBillard I let you check the rendering and tell us if it sounds good to you)

![Screenshot from 2022-03-09 11-52-58](https://user-images.githubusercontent.com/17381666/157427618-23fe1ac3-72ad-4f18-9609-47b7f01aeeeb.png)