### PR TITLE
fix(social-btn): add white border on dark background

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -274,6 +274,7 @@
       &:active {
         color: $black;
         background-color: $white;
+        border-color: $white;
       }
     }
 

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -271,7 +271,8 @@
     &.btn-inverse {
       color: $white;
 
-      &:active {
+      &:active,
+      &.active {
         color: $black;
         background-color: $white;
         border-color: $white;


### PR DESCRIPTION
fix(social-btn): on dark background,need a white border so that the size of button doesn't decrease.
Closes #1121