### PR TITLE
fix(a11y): change text color of positioned badges

### DIFF
--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -5,7 +5,7 @@
     "runners": [
       "axe"
     ],
-    "hideElements": ".bd-search, [id*='tarteaucitron'], #TableOfContents, .text-primary, .accordion-button:not(.collapsed), .active, [aria-current], select:disabled, [disabled] label, [disabled] + label, .modal, .bd-example nav, .badge.rounded-pill.bg-info.text-white, .exclude-from-pa11y-analysis, a.disabled, .form-check.form-switch, .nav-tabs .nav-item .nav-link.disabled",
+    "hideElements": ".bd-search, [id*='tarteaucitron'], #TableOfContents, .text-primary, .accordion-button:not(.collapsed), .active, [aria-current], select:disabled, [disabled] label, [disabled] + label, .modal, .bd-example nav, .exclude-from-pa11y-analysis, a.disabled, .form-check.form-switch, .nav-tabs .nav-item .nav-link.disabled",
     "ignore": [
       "heading-order",
       "scrollable-region-focusable"

--- a/site/content/docs/5.1/components/badge.md
+++ b/site/content/docs/5.1/components/badge.md
@@ -47,7 +47,7 @@ Use utilities to modify a `.badge` and position it in the corner of a link with 
     <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#buy"/>
   </svg>
   <span class="visually-hidden">Shopping basket</span>
-  <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-info text-white">
+  <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-info">
     99+
     <span class="visually-hidden">shopping basket items</span>
   </span>


### PR DESCRIPTION
This PR proposes to change the text color of positioned badges to have a good contrast.

[Rendering before](https://boosted.orange.com/docs/5.1/components/badge/#positioned) → [Live preview of this PR](https://deploy-preview-1175--boosted.netlify.app/docs/5.1/components/badge/#positioned)

Note: It was already spotted by pa11y and hidden back then waiting for a modification in the DSM. It is also a feedback from @Aniort in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1099#issuecomment-1078811343.

- [ ] Synchronize with @louismaximepiton and https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1099 to have the same modification for the headers
- [ ] @CyriaqueBillard @Franco-Riccitelli: Update the DSM to change the color if this PR suits you
- [ ] **After the merge**: Remove rule\#10 in [Wiki - Docs accessibility issues](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Docs-accessibility-issues)