### PR TITLE
fix(forms): change the margin left value between the required symbol and the label

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -8,7 +8,7 @@ label {
   }
 }
 
-.is-required::after {
+.is-required:not(.form-group)::after {
   margin-left: $label-required-margin-left;
   font-weight: $font-weight-bold;
   color: $orange-2;

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -9,7 +9,7 @@ label {
 }
 
 .is-required::after {
-  margin-left: $label-margin-bottom;
+  margin-left: $label-required-margin-left;
   font-weight: $font-weight-bold;
   color: $orange-2;
   content: "*";

--- a/scss/_o-forms.scss
+++ b/scss/_o-forms.scss
@@ -82,7 +82,7 @@
   }
 
   &.is-required label::after {
-    margin-left: 6px;
+    margin-left: $label-required-margin-left;
     font-weight: $font-weight-bold;
     color: $orange-2;
     content: "*";

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -551,6 +551,7 @@ $btn-social-bg-size:        $spacer !default;
 // Forms
 
 $label-margin-bottom:                   .375rem !default;
+$label-required-margin-left:            .1875rem !default;
 
 $input-padding-y:                       $input-btn-padding-y !default;
 $input-padding-x:                       map-get($spacers, 2) !default; // Boosted mod input padding x is not the same as buttons padding-x!


### PR DESCRIPTION
Backport of https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1144 in v4.

[Live Preview](https://deploy-preview-1177--boosted.netlify.app/docs/4.6/components/forms/#custom-styles)