### PR TITLE
chore(docs): reorder alphabetically list of components

### DIFF
--- a/site/content/docs/5.1/about/overview.md
+++ b/site/content/docs/5.1/about/overview.md
@@ -24,8 +24,8 @@ Boosted ships with custom accessible components to suit specific needs:
 
 - [Back to top]({{< docsref "/components/back-to-top" >}})
 - [Orange navbar]({{< docsref "/components/orange-navbar" >}})
-- [Star rating]({{< docsref "/forms/checks-radios#star-rating" >}})
 - [Quantity selector]({{< docsref "/forms/quantity-selector" >}})
+- [Star rating]({{< docsref "/forms/checks-radios#star-rating" >}})
 - [Stepped process]({{< docsref "/components/stepped-process" >}})
 - [Sticker]({{< docsref "/components/sticker" >}})
 

--- a/site/content/docs/5.1/customize/overview.md
+++ b/site/content/docs/5.1/customize/overview.md
@@ -42,15 +42,15 @@ Several Boosted components include embedded SVGs in our CSS to style components 
 - [Accordion]({{< docsref "/components/accordion" >}})
 - [Alerts]({{< docsref "/components/alerts" >}}) <!-- Boosted mod -->
 - [Breadcrumb]({{< docsref "/components/breadcrumb" >}}) <!-- Boosted mod -->
+- [Carousel controls]({{< docsref "/components/carousel#with-controls" >}})
 - [Close button]({{< docsref "/components/close-button" >}}) (used in alerts and modals)
 - [Form checkboxes and radio buttons]({{< docsref "/forms/checks-radios" >}})
 - [Form star rating]({{< docsref "/forms/checks-radios#star-rating" >}}) <!-- Boosted mod -->
 - [Form switches]({{< docsref "/forms/checks-radios#switches" >}})
 - [Form validation icons]({{< docsref "/forms/validation#server-side" >}})
-- [Select menus]({{< docsref "/forms/select" >}})
-- [Carousel controls]({{< docsref "/components/carousel#with-controls" >}})
 - [Navbar toggle buttons]({{< docsref "/components/navbar#responsive-behaviors" >}})
 - [Pagination]({{< docsref "/components/pagination" >}}) <!-- Boosted mod -->
 - [Quantity selector buttons]({{< docsref "/forms/quantity-selector" >}}) <!-- Boosted mod -->
+- [Select menus]({{< docsref "/forms/select" >}})
 
 Based on [community conversation](https://github.com/twbs/bootstrap/issues/25394), some options for addressing this in your own codebase include replacing the URLs with locally hosted assets, removing the images and using inline images (not possible in all components), and modifying your CSP. Our recommendation is to carefully review your own security policies and decide on the best path forward, if necessary.

--- a/site/content/docs/5.1/getting-started/introduction.md
+++ b/site/content/docs/5.1/getting-started/introduction.md
@@ -68,9 +68,9 @@ Curious which components explicitly require our JavaScript and Popper? Click the
 - Offcanvases for displaying, positioning, and scroll behavior
 - Orange navbar for minimizing the header
 - Quantity selector for incrementing/decrementing number value
+- Scrollspy for scroll behavior and navigation updates
 - Toasts for displaying and dismissing
 - Tooltips and popovers for displaying and positioning (also requires [Popper](https://popper.js.org/))
-- Scrollspy for scroll behavior and navigation updates
 {{< /markdown >}}
 </details>
 


### PR DESCRIPTION
This PR is a proposal to reorder alphabetically the list of components in the documentation. IMHO it is simpler to find the components in the list and more natural.

**After the merge**
- [ ] If we agree on that, I'll create a PR for Bootstrap as well
- [x] Check if it can be backported to v4