### PR TITLE
chore(docs): reorder alphabetically list of components

### DIFF
--- a/site/content/docs/4.6/about/boosted-history.md
+++ b/site/content/docs/4.6/about/boosted-history.md
@@ -16,12 +16,12 @@ Boosted can be used for all responsive web projects for Orange group; other deve
 
 Orange Boosted ships with custom accessible components to suit specific needs:
 
-- [Orange navbar]({{< docsref "/components/navbar-orange" >}}),
-- [Orange Megamenu]({{< docsref "/components/orange-megamenu" >}}),
-- [Orange footer]({{< docsref "/components/orange-footer" >}}),
-- [Local navigation]({{< docsref "/components/local-navigation" >}}),
-- [Priority nav]({{< docsref "/components/priority-nav" >}}),
-- [Custom carousel]({{< docsref "/components/custom-carousel" >}}),
-- [Scroll up]({{< docsref "/components/scroll-up" >}}),
-- [Stepbar]({{< docsref "/components/stepbar" >}}),
-- [Orange switches]({{< docsref "/components/forms#orange-switches" >}}).
+- [Custom carousel]({{< docsref "/components/custom-carousel" >}})
+- [Local navigation]({{< docsref "/components/local-navigation" >}})
+- [Orange footer]({{< docsref "/components/orange-footer" >}})
+- [Orange megamenu]({{< docsref "/components/orange-megamenu" >}})
+- [Orange navbar]({{< docsref "/components/navbar-orange" >}})
+- [Orange switches]({{< docsref "/components/forms#orange-switches" >}})
+- [Priority nav]({{< docsref "/components/priority-nav" >}})
+- [Scroll up]({{< docsref "/components/scroll-up" >}})
+- [Stepbar]({{< docsref "/components/stepbar" >}})

--- a/site/content/docs/4.6/getting-started/introduction.md
+++ b/site/content/docs/4.6/getting-started/introduction.md
@@ -69,9 +69,9 @@ Curious which components explicitly require jQuery, our JavaScript, and Popper? 
 - Dropdowns for displaying and positioning (also requires [Popper](https://popper.js.org/))
 - Modals for displaying, positioning, and scroll behavior
 - Navbar for extending our Collapse plugin to implement responsive behavior
+- Scrollspy for scroll behavior and navigation updates
 - Toasts for displaying and dismissing
 - Tooltips and popovers for displaying and positioning (also requires [Popper](https://popper.js.org/))
-- Scrollspy for scroll behavior and navigation updates
 {{< /markdown >}}
 </details>
 


### PR DESCRIPTION
Backport of https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1188, this PR is a proposal to reorder alphabetically the list of components in the documentation.

I'm not sure this is the only place in the docs in v4 where we have a list of components.