### PR TITLE
fix(docs): replace '..' by '…' in the documentation title

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -54,7 +54,7 @@ module:
       target:                       static/docs/5.1/assets/js/lang
 
 params:
-  description:                      "Orange Boosted with Bootstrap is a Bootstrap based, Orange branded accessible and ergonomic components library.."
+  description:                      "Orange Boosted with Bootstrap is a Bootstrap based, Orange branded accessible and ergonomic components library…"
   authors:                          "Orange and Boosted contributors"
   social_image_path:                /docs/5.1/assets/brand/orange-social.png
   social_logo_path:                 /docs/5.1/assets/brand/orange-social-logo.png


### PR DESCRIPTION
Before this modification, screen reader said "and ergonomic components library dot dot".
With this modification, screen reader will say ""and ergonomic components library".

/CC @Aniort ;) Thanks again for your presentation about screen readers. I tried it with Orca on Ubuntu.