### PR TITLE
feat(utilities): reintroduce `.text-uppercase`

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -511,7 +511,7 @@ $utilities: map-merge(
     "text-transform": (
       property: text-transform,
       class: text,
-      values: lowercase capitalize
+      values: lowercase uppercase capitalize
     ),
     "white-space": (
       property: white-space,

--- a/site/content/docs/5.1/utilities/text.md
+++ b/site/content/docs/5.1/utilities/text.md
@@ -61,6 +61,7 @@ Transform text in components with text capitalization classes.
 
 {{< example >}}
 <p class="text-lowercase">Lowercased text.</p>
+<p class="text-uppercase">Uppercased text.</p>
 <p class="text-capitalize">CapiTaliZed text.</p>
 {{< /example >}}
 


### PR DESCRIPTION
Even if ODS forbids uppercase texts this utility can still be useful for some automatic rendering or depending on the context. I need it for example in https://deploy-preview-1214--boosted.netlify.app/docs/5.1/components/accordion/#example where `.text-uppercase` will display "html" → "HTML".

### [Live preview](https://deploy-preview-1216--boosted.netlify.app/docs/5.1/utilities/text/#text-transform)