### PR TITLE
feat(utilities): reintroduce `.text-uppercase`

### DIFF
--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -28,7 +28,7 @@
 // Transformation
 
 .text-lowercase  { text-transform: lowercase !important; }
-//.text-uppercase  { text-transform: uppercase !important; } // Boosted mod
+.text-uppercase  { text-transform: uppercase !important; }
 .text-capitalize { text-transform: capitalize !important; }
 
 // Boosted mod: Line length for accessibility

--- a/site/content/docs/4.6/utilities/text.md
+++ b/site/content/docs/4.6/utilities/text.md
@@ -76,11 +76,9 @@ Prevent long strings of text from breaking your components' layout by using `.te
 
 Transform text in components with text capitalization classes.
 
-<!-- Boosted mod -->
-Orange Brand — thus Boosted — does not allow uppercase text blocks.
-
 {{< example >}}
 <p class="text-lowercase">Lowercased text.</p>
+<p class="text-uppercase">Uppercased text.</p>
 <p class="text-capitalize">CapiTaliZed text.</p>
 {{< /example >}}
 


### PR DESCRIPTION
Backport in v4 of https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1216

### [Live preview](https://deploy-preview-1218--boosted.netlify.app/docs/4.6/utilities/text/#text-transform)