### PR TITLE
fix(cookies): hide 'Cookies management panel' in the header

### DIFF
--- a/site/assets/scss/_tarteaucitron.scss
+++ b/site/assets/scss/_tarteaucitron.scss
@@ -198,3 +198,6 @@
   display: none;
 }
 
+.tac_visually-hidden { // stylelint-disable-line selector-class-pattern
+  @include visually-hidden();
+}


### PR DESCRIPTION
Fixes #1215 

This fix creates a `.tac_visually-hidden` rule from tarteaucitron.js by using `@include visually-hidden()` since we use the following configuration `useExternalCss: true`.

With `useExternalCss: false` we would have the content of `tarteaucitron.css` which contains a `.tac_visually-hidden` but this possibility hasn't been evaluated here.