### PR TITLE
chore(meta): remove CODEOWNERS content

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-*.js    @julien-deramond
-*.css   @julien-deramond
-*.scss  @julien-deramond


### PR DESCRIPTION
Boosted Core Team prefers not have someone automatically set as reviewer. I chose to remove the content and not the file in order to remind us in the future the possibility to handle that differently.