### PR TITLE
feat(stickers): Add CSS vars for $sticker-

### DIFF
--- a/scss/_sticker.scss
+++ b/scss/_sticker.scss
@@ -1,39 +1,43 @@
 .sticker {
+  // scss-docs-start sticker-css-vars
+  --#{$prefix}sticker-size: #{$sticker-size-md};
+  --#{$prefix}sticker-font-weight: #{$font-weight-bold};
+  --#{$prefix}sticker-background-color: #{$brand-orange};
+  --#{$prefix}sticker-content-max-width: #{$sticker-content-max-width-md};
+  // scss-docs-end sticker-css-vars
+
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: $sticker-size-md;
-  height: $sticker-size-md;
-  font-weight: $font-weight-bold;
+  width: var(--#{$prefix}sticker-size);
+  height: var(--#{$prefix}sticker-size);
+  font-weight: var(--#{$prefix}sticker-font-weight);
   text-align: center;
   word-wrap: break-word;
-  background-color: $brand-orange;
-  border-radius: $sticker-size-lg; // stylelint-disable-line property-disallowed-list
+  background-color: var(--#{$prefix}sticker-background-color);
+  // border-radius: $sticker-size-lg; // stylelint-disable-line property-disallowed-list
+  border-radius: var(#{$prefix}sticker-size=#{$sticker-size-lg}); // stylelint-disable-line property-disallowed-list
 
   > * {
-    max-width: $sticker-content-max-width-md;
+    max-width: var(--#{$prefix}sticker-content-max-width);
   }
 
   // Large sticker
 
   &.sticker-lg {
-    width: $sticker-size-lg;
-    height: $sticker-size-lg;
-
-    > * {
-      max-width: $sticker-content-max-width-lg;
-    }
+    // scss-docs-start sticker-lg-css-vars
+    --#{$prefix}sticker-size: #{$sticker-size-lg};
+    --#{$prefix}sticker-content-max-width: #{$sticker-content-max-width-lg};
+    // scss-docs-end sticker-lg-css-vars
   }
 
   // Small sticker
 
   &.sticker-sm {
-    width: $sticker-size-sm;
-    height: $sticker-size-sm;
-
-    > * {
-      max-width: $sticker-content-max-width-sm;
-    }
+    // scss-docs-start sticker-sm-css-vars
+    --#{$prefix}sticker-size: #{$sticker-size-sm};
+    --#{$prefix}sticker-content-max-width: #{$sticker-content-max-width-sm};
+    // scss-docs-end sticker-sm-css-vars
   }
 }

--- a/scss/_sticker.scss
+++ b/scss/_sticker.scss
@@ -16,8 +16,7 @@
   text-align: center;
   word-wrap: break-word;
   background-color: var(--#{$prefix}sticker-background-color);
-  // border-radius: $sticker-size-lg; // stylelint-disable-line property-disallowed-list
-  border-radius: var(#{$prefix}sticker-size=#{$sticker-size-lg}); // stylelint-disable-line property-disallowed-list
+  border-radius: var(--#{$prefix}sticker-size); // stylelint-disable-line property-disallowed-list
 
   > * {
     max-width: var(--#{$prefix}sticker-content-max-width);

--- a/site/content/docs/5.1/components/sticker.md
+++ b/site/content/docs/5.1/components/sticker.md
@@ -93,7 +93,7 @@ As part of Boosted's evolving CSS variables approach, stickers now use local CSS
 
 {{< scss-docs name="sticker-css-vars" file="scss/_sticker.scss" >}}
 
-`sm` and `lg` modifier classes are used to update the value of these CSS variables as needed for **small** and **large** stickers:
+Small and large sticker modifier classes are used to update the value of these CSS variables as needed.
 
 {{< scss-docs name="sticker-sm-css-vars" file="scss/_sticker.scss" >}}
 

--- a/site/content/docs/5.1/components/sticker.md
+++ b/site/content/docs/5.1/components/sticker.md
@@ -99,9 +99,6 @@ As part of Boosted's evolving CSS variables approach, stickers now use local CSS
 
 {{< scss-docs name="sticker-lg-css-vars" file="scss/_sticker.scss" >}}
 
-
-## Sass
-
-### Variables
+### Sass variables
 
 {{< scss-docs name="sticker" file="scss/_variables.scss" >}}

--- a/site/content/docs/5.1/components/sticker.md
+++ b/site/content/docs/5.1/components/sticker.md
@@ -68,7 +68,7 @@ Fancy larger or smaller stickers? Add `.sticker-lg` or `.sticker-sm` for additio
 Since stickers only provide a container, accessibility becomes specific to the sticker content:
 * [Showing and vocalizing prices](https://a11y-guidelines.orange.com/en/web/components-examples/price-vocalization) can help when stickers contain prices.
 * [Accessibility and SVGs](https://a11y-guidelines.orange.com/en/articles/accessible-svg) can help with the SVGs.
-* You must semantize the informative content in context with HTML elements, such as `<p>` (as shown in our examples), `<h1>` to `<h6>`, etc. 
+* You must semantize the informative content in context with HTML elements, such as `<p>` (as shown in our examples), `<h1>` to `<h6>`, etc.
 
 ### Focus on one use case
 
@@ -82,6 +82,23 @@ Since stickers only provide a container, accessibility becomes specific to the s
   </p>
 </div>
 {{< /example >}}
+
+## CSS
+
+### Variables
+
+{{< added-in "5.2.0" >}}
+
+As part of Boosted's evolving CSS variables approach, stickers now use local CSS variables on `.sticker` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+
+{{< scss-docs name="sticker-css-vars" file="scss/_sticker.scss" >}}
+
+`sm` and `lg` modifier classes are used to update the value of these CSS variables as needed for **small** and **large** stickers:
+
+{{< scss-docs name="sticker-sm-css-vars" file="scss/_sticker.scss" >}}
+
+{{< scss-docs name="sticker-lg-css-vars" file="scss/_sticker.scss" >}}
+
 
 ## Sass
 


### PR DESCRIPTION
Add CSS vars in Stickers component and Docs.

This is part of https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/1196.

Preview link: https://deploy-preview-1251--boosted.netlify.app/