### PR TITLE
Remove back-to-top from small pages

### DIFF
--- a/site/assets/js/application.js
+++ b/site/assets/js/application.js
@@ -27,4 +27,24 @@
       sidenav.scrollTop = viewportTop - (sidenavHeight / 2) + (sidenavActiveLinkHeight / 2)
     }
   }
+
+  // Boosted mod: Remove back-to-top component from all pages when its not needed
+  ['load', 'resize'].forEach(event => {
+    window.addEventListener(event, () => {
+      const removeClass = 'd-none'
+      const html = document.querySelector('html')
+      const btt = document.querySelector('.back-to-top')
+
+      // 100(px) come from:
+      //   - 40px of back-to-top component
+      //   - 40px of navbar-minimized
+      //   - 20px of 'security'
+      if (html.offsetHeight < window.innerHeight + 100) {
+        btt.classList.add(removeClass)
+      } else {
+        btt.classList.remove(removeClass)
+      }
+    })
+  })
+  // End mod
 })()

--- a/site/assets/js/application.js
+++ b/site/assets/js/application.js
@@ -35,7 +35,7 @@
       const html = document.querySelector('html')
       const btt = document.querySelector('.back-to-top')
 
-      // 100(px) come from:
+      // 100(px) comes from:
       //   - 40px of back-to-top component
       //   - 40px of navbar-minimized
       //   - 20px of 'security'


### PR DESCRIPTION
Fixes #1231 

The threshold I put here is nearly the smallest one, but maybe we can remove it from pages that are at least 2 times the viewport height ?