### PR TITLE
fix(build): force swiper reinstall

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12039,6 +12039,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svelte": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
+      "integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -22230,6 +22240,13 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "svelte": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
+      "integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==",
+      "dev": true,
+      "peer": true
     },
     "svg-tags": {
       "version": "1.0.0",


### PR DESCRIPTION
Fix the error observed in `v4-dev` PR by running `npm i swiper@6.5.1` to fix `package-lock.json`:
```
Run npm ci
npm ERR! code EUSAGE
npm ERR! 
npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm ERR! 
npm ERR! Missing: svelte@3.48.0 from lock file
npm ERR! 
npm ERR! Clean install a project
npm ERR! 
npm ERR! Usage:
npm ERR! npm ci
npm ERR! 
npm ERR! Options:
npm ERR! [--no-audit] [--foreground-scripts] [--ignore-scripts]
npm ERR! [--script-shell <script-shell>]
npm ERR! 
npm ERR! aliases: clean-install, ic, install-clean, isntall-clean
npm ERR! 
npm ERR! Run "npm help ci" for more info
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-06-09T12_10_13_808Z-debug-0.log
Error: Process completed with exit code 1.
```