### PR TITLE
fix(forms): hide input control text under valid icon

### DIFF
--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -46,6 +46,12 @@
           }
         }
       }
+
+      .form-control-color {
+        @include form-validation-state-selector($state) {
+          width: add($form-color-width, $input-height-inner);
+        }
+      }
     }
   } @else {
     .#{$state}-feedback {
@@ -129,6 +135,7 @@
 
     .form-check-input {
       @include form-validation-state-selector($state) {
+        filter: none; // Boosted mod: remove filter to avoid having a blue border (invert of red border)
         border-color: $color;
 
         &:checked,

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -25,8 +25,9 @@
     }
 
     @if $enable-validation-icons {
-      .form-control {
+      :not(.quantity-selector) > .form-control {
         @include form-validation-state-selector($state) {
+          padding-right: $input-height-inner;
           background-image: escape-svg($icon);
           background-repeat: no-repeat;
           background-position: right $input-height-inner-quarter top subtract($input-height-inner-quarter, 2px);

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -125,14 +125,6 @@
       }
     }
 
-    .form-control-color {
-      @include form-validation-state-selector($state) {
-        @if $enable-validation-icons {
-          width: add($form-color-width, $input-height-inner);
-        }
-      }
-    }
-
     .form-check-input {
       @include form-validation-state-selector($state) {
         filter: none; // Boosted mod: remove filter to avoid having a blue border (invert of red border)


### PR DESCRIPTION
Fixes #1305 

This PR is a proposal to fix #1305 by:
* adding the same `padding-right` rule than in Bootstrap
* avoiding to display the valid icon for Quantity Selector (not enough space)

Dear reviewer please check all possible cases in forms when inputs are valid.

### Live previews
* [Forms > Validation > Custom styles](https://deploy-preview-1306--boosted.netlify.app/docs/5.1/forms/validation/#custom-styles)
* [Forms > Validation > Supported elements](https://deploy-preview-1306--boosted.netlify.app/docs/5.1/forms/validation/#supported-elements)