### PR TITLE
Fix Back to top container to allow clicking under the transparent surface

### DIFF
--- a/scss/_back-to-top.scss
+++ b/scss/_back-to-top.scss
@@ -36,6 +36,7 @@
   right: var(--#{$prefix}back-to-top-right);
   bottom: var(--#{$prefix}back-to-top-bottom);
   z-index: var(--#{$prefix}back-to-top-zindex);
+  pointer-events: none;
 }
 
 .back-to-top-link {


### PR DESCRIPTION
Fixes #1341

Please check all the weird edge cases you can think of and on different browsers/OS :)
Allowing actions under the transparent surface should be possible with this simple `pointer-events: none`.