### PR TITLE
Fix boosted logo on homepage

### DIFF
--- a/site/assets/scss/_boosted.scss
+++ b/site/assets/scss/_boosted.scss
@@ -22,8 +22,7 @@ body {
   height: 25em;
   font-size: 36%; // 1
   box-shadow: -2em 2em $gray-600, -4em 4em $gray-300;
-  transform: rotateX(50deg) rotateY(0deg) rotateZ(-45deg);
-  scale: .7;
+  transform: rotateX(50deg) rotateY(0deg) rotateZ(-45deg) scale(.7);
 
   @include media-breakpoint-up(sm) {
     font-size: xx-small;


### PR DESCRIPTION
Fixes #1353 

Use `scale()` instead of `scale:` due to [usability of scale](https://caniuse.com/mdn-css_properties_scale)