### PR TITLE
chore(docs): small improvement to separate h1 and lead paragraph

### DIFF
--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -21,8 +21,8 @@
           </a>
           <h1 class="bd-title mb-0" id="content">{{ .Title | markdownify }}</h1>
         </div>
-        <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>
-        {{ partial "ads" . }}
+        <p class="bd-lead mt-2">{{ .Page.Params.Description | markdownify }}</p>
+        <!-- Boosted mod: No ads -->
       </div>
 
       {{ if (eq .Page.Params.toc true) }}

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -29,7 +29,7 @@
             </div>
             {{ end }}
           </div>
-          <!-- No ads -->
+          <!-- Boosted mod: No ads -->
         </div>
       </div>
     </div>

--- a/site/layouts/partials/ads.html
+++ b/site/layouts/partials/ads.html
@@ -1,1 +1,0 @@
-<!-- Boosted mod: no ads -->


### PR DESCRIPTION
New margin (that can be compared to [the current one](https://boosted.netlify.app/docs/5.2/getting-started/introduction/))
![Screenshot from 2022-07-06 16-05-05](https://user-images.githubusercontent.com/17381666/177569239-e3a5b3ab-bf26-406a-bad3-3092893a5d33.png)

