### PR TITLE
chore(workflows): temporarily enable BrowserStack for each push

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,11 +1,6 @@
 name: BrowserStack
 on:
   push:
-    paths:
-      - 'js/**'
-    branches:
-      - main
-      - v4-dev
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Temporarily enable BrowserStack builds for each push to help BrowserStack support having several failed builds to analyze.