### PR TITLE
chore(deps): revert tarteaucitronjs from 1.9.7 to 1.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "sirv-cli": "^2.0.2",
         "stylelint": "^14.9.1",
         "stylelint-config-twbs-bootstrap": "^4.0.0",
-        "tarteaucitronjs": "^1.9.7",
+        "tarteaucitronjs": "^1.8.4",
         "terser": "^5.14.1",
         "vnu-jar": "21.10.12"
       },
@@ -10725,9 +10725,9 @@
       }
     },
     "node_modules/tarteaucitronjs": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.9.7.tgz",
-      "integrity": "sha512-HDA+mEx/zKRWX6i3HO/x7XpO10uCrUSLtbkJ1Dc+AB/5yMu9yl4gsoPx25P8OqqZw8YPI3lRC85Sc86SzxMeVw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.8.4.tgz",
+      "integrity": "sha512-hwI8ycCQ3rQD1G7NoAAIWbRiSOa5nEcXXP8TR7QFYO0RCqxW6ANd+bLZwrAinFpJ0BxH0yWpjXogLH3lMlkvOQ==",
       "dev": true
     },
     "node_modules/terser": {
@@ -19378,9 +19378,9 @@
       }
     },
     "tarteaucitronjs": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.9.7.tgz",
-      "integrity": "sha512-HDA+mEx/zKRWX6i3HO/x7XpO10uCrUSLtbkJ1Dc+AB/5yMu9yl4gsoPx25P8OqqZw8YPI3lRC85Sc86SzxMeVw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.8.4.tgz",
+      "integrity": "sha512-hwI8ycCQ3rQD1G7NoAAIWbRiSOa5nEcXXP8TR7QFYO0RCqxW6ANd+bLZwrAinFpJ0BxH0yWpjXogLH3lMlkvOQ==",
       "dev": true
     },
     "terser": {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "sirv-cli": "^2.0.2",
     "stylelint": "^14.9.1",
     "stylelint-config-twbs-bootstrap": "^4.0.0",
-    "tarteaucitronjs": "^1.9.7",
+    "tarteaucitronjs": "^1.8.4",
     "terser": "^5.14.1",
     "vnu-jar": "21.10.12"
   },


### PR DESCRIPTION
Linked to #1382

With tac > 1.8.4 (from 1.9.1) we got this error on Netlify:

```
09:43:12.735 Uncaught TypeError: document.getElementById(...) is null
    color https://deploy-preview-1388--boosted.netlify.app/docs/5.2/assets/js/docs.min.js:6
    color https://deploy-preview-1388--boosted.netlify.app/docs/5.2/assets/js/docs.min.js:6
    addService https://deploy-preview-1388--boosted.netlify.app/docs/5.2/assets/js/docs.min.js:6
    load https://deploy-preview-1388--boosted.netlify.app/docs/5.2/assets/js/docs.min.js:6
    addScript https://deploy-preview-1388--boosted.netlify.app/docs/5.2/assets/js/docs.min.js:6
    addInternalScript https://deploy-preview-1388--boosted.netlify.app/docs/5.2/assets/js/docs.min.js:6
    load https://deploy-preview-1388--boosted.netlify.app/docs/5.2/assets/js/docs.min.js:6
    onload https://deploy-preview-1388--boosted.netlify.app/docs/5.2/assets/js/docs.min.js:6
docs.min.js:6:45074
```

Let's revert this change while we don't know where the issue comes from.