### PR TITLE
Docs: Minor fixes for some misprint in Boosted

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -60,20 +60,22 @@
 }
 
 
+// Boosted mod: values changed + call to icons inside the mixin directly
 // scss-docs-start alert-modifiers
 // Generate contextual modifier classes for colorizing the alert.
 
 @each $state, $value in $alert-colors {
-  $alert-background: transparent; // Boosted mod
-  $alert-border: $alert-border-width solid $value; // Boosted mod
+  $alert-background: transparent;
+  $alert-border: $alert-border-width solid $value;
   // Boosted mod: no $alert-color change
 
   // Boosted mod: no contrast-ratio test
   .alert-#{$state} {
-    @include alert-variant($alert-background, $alert-border, $alert-color, map-get($alert-icons, $state)); // Boosted mod
+    @include alert-variant($alert-background, $alert-border, $alert-color, map-get($alert-icons, $state));
   }
 }
 // scss-docs-end alert-modifiers
+// End mod
 
 //
 // Boosted mod

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -187,6 +187,7 @@
 //
 // Add modifier classes to change text and background color on individual items.
 // Organizationally, this must come after the `:hover` states.
+
 @each $color, $value in $background-colors {
   @include list-group-item-variant($color, $value, color-contrast($value));
 }


### PR DESCRIPTION
Commits can be split of course, but here is what's taken into account:
- mixin changes for doc comprehension
- tables minor fixes. See #1499.
- navbar default `border-color` value. See #1498.
- spacing between nav and form in navbar offcanvas example. See #1498.
- third-level list. See #1497.
- hide `.display-5` and `.display-6`. See #1496.
- spacing for submit buttons in forms. See #1495.
- `Primary` for primary buttons. See #1494.
- image overlays in cards look like the v4 one. See #1493.
- add links to carousel captions. See #1491.
- Carousel doc reorder to get closer to Bootstrap. See #1491.
- Vertical center toasts' custom content. See #1490.
- Add different variant for close button (without `.btn-close`). See #1489.
- Change the responsive values in API doc. See #1488.