### PR TITLE
Error messages: Fix margin-top

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -944,7 +944,7 @@ $btn-social-networks: (
 // Forms
 
 // scss-docs-start form-text-variables
-$form-text-margin-top:                  .25rem !default;
+$form-text-margin-top:                  .375rem !default; // Boosted mod
 $form-text-font-size:                   null !default;
 $form-text-font-style:                  null !default;
 $form-text-font-weight:                 null !default;


### PR DESCRIPTION
Fix that works for `.form-text` too (IMO, it's better to change both at the same time).