### PR TITLE
Delete .mark padding in Docs

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -191,6 +191,7 @@ small,
 
 mark,
 .mark {
+  padding: $mark-padding;
   background-color: $mark-bg;
 }
 

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -191,7 +191,6 @@ small,
 
 mark,
 .mark {
-  padding: $mark-padding;
   background-color: $mark-bg;
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -416,7 +416,7 @@ $blockquote-letter-spacing:   -.015625rem !default; // Boosted mod
 $hr-border-color:             $gray-300 !default;
 $hr-border-width:             $border-width * .5 !default;
 
-$mark-padding:                0 .2em !default;
+$mark-padding:                0 .2em !default; // Boosted mod
 
 $dt-font-weight:              $font-weight-bold !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -416,6 +416,8 @@ $blockquote-letter-spacing:   -.015625rem !default; // Boosted mod
 $hr-border-color:             $gray-300 !default;
 $hr-border-width:             $border-width * .5 !default;
 
+$mark-padding:                0 .2em !default;
+
 $dt-font-weight:              $font-weight-bold !default;
 
 $kbd-box-shadow:              null !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -416,8 +416,6 @@ $blockquote-letter-spacing:   -.015625rem !default; // Boosted mod
 $hr-border-color:             $gray-300 !default;
 $hr-border-width:             $border-width * .5 !default;
 
-$mark-padding:                .2em !default;
-
 $dt-font-weight:              $font-weight-bold !default;
 
 $kbd-box-shadow:              null !default;


### PR DESCRIPTION
The `.mark` padding of 0.2em used in Docs>About>Brand>#master-artwork and in Docs>Content>Typography>#inline-text-elements was vertically too much, occurring an overlapping on the text right above in a paragraph. To avoid that overlapping, the padding is removed on vertical axis in this PR.

**With the padding:**
![image](https://user-images.githubusercontent.com/89514509/185093242-21c7db10-ac2b-4810-bdd5-bdbb90ef542f.png)



**Without the paddding:**
![image](https://user-images.githubusercontent.com/89514509/185093412-dc24b895-c7ec-4753-8578-056794cbe416.png)

Signed-off-by: Isabelle Chanclou <isabelle.chanclou@orange.com>