### PR TITLE
Fix .mark padding (backport from v4.6)

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -772,7 +772,7 @@ $dt-font-weight:              $font-weight-bold !default;
 
 $list-inline-padding:         $spacer * .25 !default;
 
-$mark-padding:                0 .2em !default; // Boosted mod
+$mark-padding:                0 .1875em !default; // Boosted mod
 $mark-bg:                     $primary !default;
 // scss-docs-end type-variables
 // End mod

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -772,7 +772,7 @@ $dt-font-weight:              $font-weight-bold !default;
 
 $list-inline-padding:         $spacer * .25 !default;
 
-$mark-padding:                .1875em !default;
+$mark-padding:                0 .2em !default; // Boosted mod
 $mark-bg:                     $primary !default;
 // scss-docs-end type-variables
 // End mod


### PR DESCRIPTION
Backport form v4.6: Fix of `<mark>` vertical padding to avoid overlapping on the lines above and below.  See #1465.

ℹ️  `<mark>` is no more used in Docs>About>Brand>#master-artwork, but only in Docs/content/typography/#inline-text-elements and in Example/cheatsheet not visible at the moment. In these pages, depending on the usage of the context, the change might not show.