### PR TITLE
Stepped process: Fix arrow shape

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1983,8 +1983,8 @@ $step-item-next-bg:           $gray-400 !default;
 $step-item-shadow-size:       $border-width * 1.5 !default;
 $step-item-drop-shadow:       drop-shadow($step-item-shadow-size 0 0 $white) #{"/* rtl:"} drop-shadow(-$step-item-shadow-size 0 0 $white) #{"*/"} !default;
 
-$step-item-arrow-width:       1rem !default;
-$step-item-arrow-shape:       polygon(0% 0%, subtract(100%, $border-width) 50%, 0% 100%) #{"/* rtl:"} polygon(100% 0%, $border-width 50%, 100% 100%) #{"*/"} !default; // Used in clip-path
+$step-item-arrow-width:       .8125rem !default;
+$step-item-arrow-shape:       polygon(0% 0%, 1px 0%, subtract(100%, $border-width) 50%, 1px 100%, 0% 100%) #{"/* rtl:"} polygon(100% 0%, subtract(100%, 1px) 0%, $border-width 50%, subtract(100%, 1px) 100%, 100% 100%) #{"*/"} !default; // Used in clip-path
 
 $step-link-width:             1.25ch !default; // Matches width of a single number
 $step-link-color:             $white !default;


### PR DESCRIPTION
Fixes #1483.

Reshape the arrow shape in order not to have a triangle but an arrow (avoid some limit cases issues such as zoom in page).

### Checks

- [ ] Check that the [arrows](https://deploy-preview-1485--boosted.netlify.app/docs/5.2/components/stepped-process/) behave like they should on every breakpoint.
- [ ] Check that the [arrows](https://deploy-preview-1485--boosted.netlify.app/docs/5.2/components/stepped-process/) are well shaped compared to [design specs](https://system.design.orange.com/0c1af118d/p/283b6d-stepped-process/b/950d59/i/78830015).