### PR TITLE
Docs: image overlays as in v4

### DIFF
--- a/site/content/docs/5.2/components/card.md
+++ b/site/content/docs/5.2/components/card.md
@@ -376,8 +376,8 @@ Similar to headers and footers, cards can include top and bottom "image caps"—
 Turn an image into a card background and overlay your card's text. Depending on the image, you may or may not need additional styles or utilities.
 
 {{< example >}}
-<div class="card">
-  {{< placeholder width="100%" height="270" class="bd-placeholder-img-lg card-img" text="Card image" >}}
+<div class="card text-bg-dark">
+  {{< placeholder width="100%" height="270" class="bd-placeholder-img-lg card-img" text="Card image" background="#000" >}}
   <div class="card-img-overlay">
     <h5 class="card-title">Card title</h5>
     <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>


### PR DESCRIPTION
Make the image overlays look like in v4 to be more consistent.