### PR TITLE
Docs: Typography hide `display-5` and  `display-6`

### DIFF
--- a/site/content/docs/5.2/content/typography.md
+++ b/site/content/docs/5.2/content/typography.md
@@ -125,13 +125,12 @@ Traditional heading elements are designed to work best in the meat of your page 
 </table>
 <!-- End mod -->
 
+<!-- Boosted mod: no .display-5 and .display-6 since the font-sizes will be refactored -->
 {{< example >}}
 <h1 class="display-1">Display 1</h1>
 <h1 class="display-2">Display 2</h1>
 <h1 class="display-3">Display 3</h1>
 <h1 class="display-4">Display 4</h1>
-<h1 class="display-5">Display 5</h1>
-<h1 class="display-6">Display 6</h1>
 {{< /example >}}
 
 <!-- Boosted mod -->


### PR DESCRIPTION
Hide `.display-5` and `.display-6` from the documentation since they don't bring anything. Might be revert when we'll have the Specifications for font-size.