### PR TITLE
fix(docs): move 'Dark variant' sections out of 'Example' for alerts and accordions

### DIFF
--- a/site/content/docs/5.2/components/accordion.md
+++ b/site/content/docs/5.2/components/accordion.md
@@ -198,7 +198,7 @@ Omit the `data-bs-parent` attribute on each `.accordion-collapse` to make accord
 </div>
 {{< /example >}}
 
-### Dark variant
+## Dark variant
 
 {{< added-in "5.2.0" >}}
 

--- a/site/content/docs/5.2/components/alerts.md
+++ b/site/content/docs/5.2/components/alerts.md
@@ -150,7 +150,7 @@ You can see this in action with a live demo:
 When an alert is dismissed, the element is completely removed from the page structure. If a keyboard user dismisses the alert using the close button, their focus will suddenly be lost and, depending on the browser, reset to the start of the page/document. For this reason, we recommend including additional JavaScript that listens for the `closed.bs.alert` event and programmatically sets `focus()` to the most appropriate location in the page. If you're planning to move focus to a non-interactive element that normally does not receive focus, make sure to add `tabindex="-1"` to the element.
 {{< /callout >}}
 
-### Dark variant
+## Dark variant
 
 {{< added-in "5.2.0" >}}
 


### PR DESCRIPTION
For consistency with Bootstrap docs architecture, I propose to move 'Dark variant' section out of the 'Example' section for alerts and accordions.

In Bootstrap:
- [Carousel > Dark variant](https://getbootstrap.com/docs/5.2/components/carousel/#dark-variant)
- [Close button > White variant](https://getbootstrap.com/docs/5.2/components/close-button/#white-variant)
- [Dropdowns > Dark dropdowns](https://getbootstrap.com/docs/5.2/components/dropdowns/#dark-dropdowns)

:pray: Please double-check if I haven't forgotten components in Boosted.