### PR TITLE
Back to top: remove not branded variant

### DIFF
--- a/scss/_back-to-top.scss
+++ b/scss/_back-to-top.scss
@@ -19,6 +19,7 @@
   --#{$prefix}back-to-top-link-height: #{$back-to-top-icon-height};
   --#{$prefix}back-to-top-title-offset-right: #{$back-to-top-title-offset-right};
   --#{$prefix}back-to-top-title-padding: #{$back-to-top-title-padding};
+  --#{$prefix}back-to-top-title-color: #{color-contrast($back-to-top-title-bg-color)};
   --#{$prefix}back-to-top-title-bg-color: #{$back-to-top-title-bg-color};
   --#{$prefix}back-to-top-title-active-decoration: #{$link-decoration};
   // scss-docs-end back-to-top-css-vars
@@ -59,7 +60,7 @@
       right: var(--#{$prefix}back-to-top-title-offset-right);
       z-index: -1; // To ensure focus indicator appears above
       padding: var(--#{$prefix}back-to-top-title-padding);
-      color: color-contrast($back-to-top-title-bg-color);
+      color: var(--#{$prefix}back-to-top-title-color);
       white-space: nowrap;
       content: attr(data-#{$prefix}label);
       background-color: var(--#{$prefix}back-to-top-title-bg-color);

--- a/site/content/docs/5.2/components/back-to-top.md
+++ b/site/content/docs/5.2/components/back-to-top.md
@@ -61,21 +61,6 @@ Add `.position-fixed` utility to your `.back-to-top-link` to make your back-to-t
 </nav>
 {{< /example >}}
 
-### Label inside
-
-Drop the `data-bs-label` attribute and the `<span class="visually-hidden">` and use [spacing utilities]({{< docsref "/utilities/spacing" >}}) to fine tune your button.
-
-<div class="bd-example">
-  <nav aria-label="Label inside back to top example" class="back-to-top position-static">
-    <a href="#top" class="back-to-top-link position-static btn btn-secondary px-3">Back to top</a>
-  </nav>
-</div>
-{{< example show_preview="false" >}}
-<nav aria-label="Back to top" class="back-to-top">
-  <a href="#top" class="back-to-top-link btn btn-secondary px-3">Back to top</a>
-</nav>
-{{< /example >}}
-
 ### Icon only
 
 Use a `title` attribute instead of `data-bs-label` to ensure a visible label is still provided on demand for sighted users.


### PR DESCRIPTION
Commits can be split if needed.

- Adding a missing CSS var on Back to top
- Removing the not branded variant.

Following the https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1428#issuecomment-1239036156.