### PR TITLE
Prepare migration guide v5.2.0 → v5.2.1

### DIFF
--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,10 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
+  * fix(forms): add validation icons for <select>s and fix its position for `<textarea>`
+    - Reset to Bootstrap default for feedback icon on select
+    - Setting the icon in the top right corner instead of center right
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1371
   * feat(css): add CSS vars to alerts
     - NEW CSS vars:
         - --#{$prefix}alert-line-height

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -17,13 +17,22 @@ toc: true
 
 <!--- * fix(back to top): remove 'Label inside' variant (#1520) -->
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
-
 <!---
   * fix(footers): change 'Terms & Conditions' to 'Terms and conditions'
     This information is important for the users in order to change the label they could have used
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1564
-  * fix(css): rename `$prefix` by `$func-prefix` in `get-color-from-rgba-string` function
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1567
+-->
+- <span class="badge bg-warning">Warning</span> All **Footers** examples have been modified to use the "Terms and conditions" wording instead of "Terms & Conditions". Please reflect this modification into your websites.
+
+
+<!--
+### Elements that should not appear in this migration guide because it has no impact for the developers
+
+* fix(css): rename `$prefix` by `$func-prefix` in `get-color-from-rgba-string` function
+    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1567
+
+### TODO
+  
   * feat(components): new Tags component
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/988
   * fix(icons): use the right close icon
@@ -45,19 +54,19 @@ toc: true
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1371
   * feat(css): add CSS vars to alerts
     - NEW CSS vars:
-        - --#{$prefix}alert-line-height
-        - --#{$prefix}alert-logo-size: #{$alert-logo-size};
-        - --#{$prefix}alert-icon-size: #{$alert-icon-size};
-        - --#{$prefix}alert-icon-margin-y: #{$alert-icon-margin-y};
-        - --#{$prefix}alert-link-font-weight: #{$alert-link-font-weight};
-        - --#{$prefix}alert-heading-font-weight: #{$alert-heading-font-weight};
-        - --#{$prefix}alert-dismissible-padding-right: #{$alert-dismissible-padding-r};
-        - --#{$prefix}alert-btn-close-offset: #{$alert-btn-close-offset};
+        - #{$prefix}alert-line-height
+        - #{$prefix}alert-logo-size: #{$alert-logo-size};
+        - #{$prefix}alert-icon-size: #{$alert-icon-size};
+        - #{$prefix}alert-icon-margin-y: #{$alert-icon-margin-y};
+        - #{$prefix}alert-link-font-weight: #{$alert-link-font-weight};
+        - #{$prefix}alert-heading-font-weight: #{$alert-heading-font-weight};
+        - #{$prefix}alert-dismissible-padding-right: #{$alert-dismissible-padding-r};
+        - #{$prefix}alert-btn-close-offset: #{$alert-btn-close-offset};
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1424
   * feat(css): add CSS vars to navbars
     - NEW `$navbar-font-weight` for SCSS vars.
-    - NEW `--#{$prefix}navbar-nav-font-size` and `--#{$prefix}navbar-nav-line-height` for .supra
-    - NEW `--#{$prefix}navbar-toggler-icon-filter` and `--#{$prefix}navbar-font-weight` for .navbar
+    - NEW `#{$prefix}navbar-nav-font-size` and `#{$prefix}navbar-nav-line-height` for .supra
+    - NEW `#{$prefix}navbar-toggler-icon-filter` and `#{$prefix}navbar-font-weight` for .navbar
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1422
   * feat(css): define `.btn-no-outline`, `.btn-link` and `.btn-social` with CSS vars
     - Reuse of buttons CSS variables to define `.btn-no-outline`, `.btn-link` and `.btn-social`
@@ -75,12 +84,12 @@ toc: true
     - Added a section Customize > CSS variables > Dark text rule in docs
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1293
   * feat(css): add CSS vars for Close button
-    - Several new `--#{$prefix}btn-close-*` CSS variables
+    - Several new `#{$prefix}btn-close-*` CSS variables
     - Several new `$btn-close-*` Sass variables
     - Creation of new `$btn-close-white-*` Sass variables
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1531
   * feat(css): add CSS vars to handle `.nav-tabs-light` and `.tab-content`
-    - New --#{$prefix}nav-tabs-link-hover-color, --#{$prefix}nav-tabs-link-hover-bg, --#{$prefix}nav-tabs-link-border-width CSS variables
+    - New #{$prefix}nav-tabs-link-hover-color, #{$prefix}nav-tabs-link-hover-bg, #{$prefix}nav-tabs-link-border-width CSS variables
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1427
   * fix(toast): adjust the layout of custom content (#1490)
     - Changed some utilities in the markup of "Toast > Custom content" example to adjust the layout
@@ -90,7 +99,7 @@ toc: true
         K/R: Remove since these are only example to show what is possible.
   * fix(navbar): minor fixes (#1498)
     - Add a .mb-3 to offcanvases navbar examples to add some space between the last link and the search bar in mobile viewport
-    - New $navbar-dark-border-color used in `--bs-navbar-border-color` for .navbar-dark
+    - New $navbar-dark-border-color used in `-bs-navbar-border-color` for .navbar-dark
     - Change the default value of $navbar-border-color now used only for light navbars
         Summary: Change the border-color management in navbar + small fix in example.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1498
@@ -519,13 +528,13 @@ toc: true
         Topics: Sass
         K/R: Remove
     - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
-  * feat(pagination): new `--#{$prefix}pagination-padding-end` CSS var [#1416](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1416)
-        Summary: new `--#{$prefix}pagination-padding-end` CSS var
+  * feat(pagination): new `#{$prefix}pagination-padding-end` CSS var [#1416](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1416)
+        Summary: new `#{$prefix}pagination-padding-end` CSS var
         Boosted: None
         Topics: Sass, Minor change, Pagination
         K/R: Keep
-  * fix(css): drop unused $list-group-hover-bg and `--#{$prefix}list-group-action-hover-bg` [#1417](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1417)
-        Summary: drop unused $list-group-hover-bg and `--#{$prefix}list-group-action-hover-bg`
+  * fix(css): drop unused $list-group-hover-bg and `#{$prefix}list-group-action-hover-bg` [#1417](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1417)
+        Summary: drop unused $list-group-hover-bg and `#{$prefix}list-group-action-hover-bg`
         Boosted: None
         Topics: Sass, Deprecated, List-group
         K/R: Keep

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,10 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!--
+  * fix(css):
+    - Changed the CSS rule to apply text style with a dark variant (was it already there in v5.2.0?)
+    - Added a section Customize > CSS variables > Dark text rule in docs
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1293
   * feat(css): add CSS vars for Close button
     - Several new `--#{$prefix}btn-close-*` CSS variables
     - Several new `$btn-close-*` Sass variables

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,9 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
+  * fix(footers): change 'Terms & Conditions' to 'Terms and conditions'
+    This information is important for the users in order to change the label they could have used
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1564
   * fix(css): rename `$prefix` by `$func-prefix` in `get-color-from-rgba-string` function
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1567
   * feat(components): new Tags component

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,8 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!--
+  * feat(css): add CSS vars to handle `.nav-tabs-light` and `.tab-content`
+    - New --#{$prefix}nav-tabs-link-hover-color, --#{$prefix}nav-tabs-link-hover-bg, --#{$prefix}nav-tabs-link-border-width CSS variables
   * fix(toast): adjust the layout of custom content (#1490)
     - Changed some utilities in the markup of "Toast > Custom content" example to adjust the layout
         Summary: Change custom toast example in the doc.

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,7 +19,12 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
-  * feat(css):  feat(css): define `.btn-no-outline`, `.btn-link` and `.btn-social` with CSS vars
+  * feat(css): add CSS vars to navbars
+    - NEW `$navbar-font-weight` for SCSS vars.
+    - NEW `--#{$prefix}navbar-nav-font-size` and `--#{$prefix}navbar-nav-line-height` for .supra
+    - NEW `--#{$prefix}navbar-toggler-icon-filter` and `--#{$prefix}navbar-font-weight` for .navbar
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1422
+  * feat(css): define `.btn-no-outline`, `.btn-link` and `.btn-social` with CSS vars
     - Reuse of buttons CSS variables to define `.btn-no-outline`, `.btn-link` and `.btn-social`
     - Probably not any impacts for the users
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1426

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,115 +19,527 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!--
+  * fix(toast): adjust the layout of custom content (#1490)
+    - Changed some utilities in the markup of "Toast > Custom content" example to adjust the layout
+        Summary: Change custom toast example in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1490
+        Topics: Docs, Markup, Toast
+        K/R: Remove since these are only example to show what is possible.
+  * fix(navbar): minor fixes (#1498)
+    - Add a .mb-3 to offcanvases navbar examples to add some space between the last link and the search bar in mobile viewport
+    - New $navbar-dark-border-color used in `--bs-navbar-border-color` for .navbar-dark
+    - Change the default value of $navbar-border-color now used only for light navbars
+        Summary: Change the border-color management in navbar + small fix in example.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1498
+        Topics: Docs, Sass, Add functionality, Breaking change, Navbar
+        K/R: Keep
   * <mark>/.mark: Improve rendering for accessibility (#1506)
+        Summary: Change the rendering for .mark.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1506
+        Topics: Sass, Add functionality, Reboot
+        K/R: Keep
   * chore(workflows): replace percy/snapshot-action by Percy CLI (#1530)
-  * chore: add a PR template (#1007) 
+        Summary: Remove percy/snapshot and add @percy/cli dependency.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1530
+        Topics: CI, Dependencies
+        K/R: Remove
+  * chore: add a PR template (#1007)
+        Summary: Add a PR template on Github.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1007
+        Topics: Git
+        K/R: Remove
   * feat(list group): add dark variant (#1525)
-  * fix(css): add workaround for postcss value parser error (#1524) 
+        Summary: Add a dark variant to list group.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1525
+        Topics: Docs, Sass, Add a functionality, List group
+        K/R: Keep
+  * fix(css): add workaround for postcss value parser error (#1524)
     - Note: linked to previous chore(merge) from Bootstrap. Just forgot to fix this one
+        Summary: Update Sass file for postcss parser.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1524
+        Topics: Sass, Fix, Navbar
+        K/R: Remove
   * chore(merge main patched commit) → 23fb7a7 (#1521)
-    - https://github.com/twbs/bootstrap/commit/97a9060a8fa643484fbe70d1e527267841670c9d
+    - https://github.com/twbs/bootstrap/commit/97a9060a8fa643484fbe70d1e527267841670c9d (same as the one following, should have been squashed)
     - https://github.com/twbs/bootstrap/commit/9b943880fc38ccde372973111fe5872b5960e75d
+        Summary: Remove the left margin when not necessary in first button group button.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1521/commits/8cc92657fca4a62966ad6185df2811a2e70c7f19
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1521/commits/fb182fcbc702c869437065b50422be2e1b6caaea
+        Topics: Sass, Fix, Button group
+        K/R: ?
     - https://github.com/twbs/bootstrap/commit/7a7469b8ab3e86dc522d3cf030b307364b1ada0b
+        Summary: Use the good Sass variable to initialize the CSS var in accordion.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1521/commits/efdf62a61304e0e4f63f6a9665245b6a3757ed4b
+        Topics: Sass, Add a functionality, Breaking changes, Accordion
+        K/R: Keep
     - https://github.com/twbs/bootstrap/commit/949456984aa21536afd35eddf7ea38b3648830a3
+        Summary: Manage the hover state on manual triggering in tooltip.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1521/commits/145b93615b461b598bc820397be5a88f7eff3e1d
+        Topics: Javascript, Fix, Tooltips
+        K/R: ?
     - https://github.com/twbs/bootstrap/commit/23fb7a79156d1ea4ce2ab5713debbbc251b4e22f
+        Summary: Fix the click on scrollbar inside modal.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1521/commits/896a692e9b27e828309b47ad69abe6b8bebea856
+        Topics: Javascript, Fix, Modal
+        K/R: ?
   * chore(merge main) patched commit → 2504b89 (#1513)
     - https://github.com/twbs/bootstrap/commit/a329575d82a65660ffa7b18cbd9f291e0ee7eef5
+        Summary: Put some doc inside a table.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/8eb7321b5fa2847a919ae8968f28395f5e1a5c44
+        Topics: Docs, List group, Navs tabs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/585146a6a7aa70faf25442d7d28636ce57e29588
+        Summary: Update eslint-config-xo dependency.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/7b69e857675288a38005be1f217e6f9098ed8040
+        Topics: Dependencies
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/75e09b1c0f5ae5f51078c7a25fe36d892c5cfcfe
+        Summary: Update rtlcss dependency.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/db7dfad165b642c689e88f95a4ab73d0a958b1ac
+        Topics: Dependencies
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/b8880e5eec6bb4f33578578ba2413f0d91424382
+        Summary: Workaround for postcss parser. (-1 * ...)
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/f5ceeb59dd270208acaa0ff63e9382a70ab12cb3
+        Topics: Sass
+        K/R: ?
     - https://github.com/twbs/bootstrap/commit/32c457db4b6ff389efbd35772b24746c7ffb0b6d
+        Summary: Change the focus management of buttons (use of :focus-visible instead of :focus).
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/f225846843ba8708980c1c4bf9c993845172acb0
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/a9bce73086fedf34cc3fdd50b0016754a50572a9
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/ee874a7fabbaa3da45a1595b68a196c6ea54cb2b
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/a3fa822704747ee61a895a8151ae88f789b19e2f
+        Topics: Sass, Breaking changes, Button
+        K/R: Keep
     - https://github.com/twbs/bootstrap/commit/2504b8995095d2bb41c9686afa175f9eaa91bec2
+        Summary: Remove gradient for .btn-link.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/d3d66c45bbd42f2c9a5471fcbfd147fc6c7d050e
+        Topics: Sass, Button
+        K/R: ?
     - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
-  * fix(docs): change responsive values in utility API examples (#1488) 
+  * fix(docs): change responsive values in utility API examples (#1488)
+        Summary: Change the responsive values in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1488
+        Topics: Docs, API
+        K/R: Remove
   * chore(merge main) patched commit → 337068f (#1510)
-    - https://github.com/twbs/bootstrap/commit/3ad8551f8b736be024a533aa281a89995258021f
+    - https://github.com/twbs/bootstrap/commit/b14190b5095195fbe803f81bf4ce56d09be5378d
+        Summary: Update popperjs dependency.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/363e4fee27febd22630716e8d88d716fe45b8cea
+        Topics: Dependencies
+        K/R: Keep
     - https://github.com/twbs/bootstrap/commit/77e17e3b8deb4d5467203f4e3cd903b7cd06bde4
+        Summary: Fix typo in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/9e31e675975fd0a135f571268bba4f26f6407be1
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/b5f2d5a31e24455447939c3a7487a4fe89a66ba6
+        Summary: Fix typo in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/349987f4f76e2fa66231abbb8300f640c6c3d2fa
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/4f97d8fabda142685e36391da2c37c7e09955ac6
+        Summary: Update Webpack guide doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/22ad93727a051a3f11b9459e300766e4a985f0b6
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/279363783759323c988d227145d5f6bc6c683efd
+        Summary: Fix 'precompiled' in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/0da15f756831a113c89a043ece5f094864d19849
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/8c380b2676eb5eb76716b94763ef21e98c86b9b7
+        Summary: Update the accordion Sass for accordion-flush.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/ab72fa70bb78d0bfc4ca6639070403c10bba82f0
+        Topics: Sass
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/54b4b2c66a6f0f403a8120a0c7720f29aaa71f7c
+        Summary: Explain a bit better vertical gutters.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/72d7d58f5feb514cc8c38ad219d29e9d763a5fb2
+        Topics: Docs, Gutters
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/337068f8b1044004f4b9abfffbb433694ae87993
+        Summary: Fix wrong dropdown menu opening when severals dropdowns in one element.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/7961a7acb10d49a0831711b983169641a3e30571
+        Topics: Javascript, Fix, Dropdown
+        K/R: ?
     - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
   * chore(merge main) patched commit → 3ad8551 (#1507)
     - ~~https://github.com/twbs/bootstrap/commit/af1bd974bba7f6e7f90c5ed3f42738bd101926cb~~ - Was already done via Dependabot
+        Summary: Update @rollup dependency.
+        Boosted: None
+        Topics: Dependencies
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/29332a954f86671d39f60007fb0c2ea633731e88
+        Summary: Doc update in tables.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/33c99bde00d0fe76202ffaf48f5634a5e388afd5
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/15318674fb086214e095c61af780a7d889f0f11e
+        Summary: Reorder offcanvas doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/125f0f1b83dfc334049a355724a72aa793e16dcb
+        Topics: Docs, Offcanvas
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/995df354f260ccf46672e4dc9e7b2c242bd4c02d
+        Summary: Change the cursor for search modal in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/a645786913577a1af25d743a50550a23578661f0
+        Topics: Sass
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/4cea8b1786ddbe365747cabebe9bee44d70a3b6d
+        Summary: Add a comment in Sass file.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/a645786913577a1af25d743a50550a23578661f0
+        Topics: Sass
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/a0238d126b385044bd7cb16bdc9118f3d44e016f
+        Summary: Add a CSS var to toast.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/405215a187e037eee4f1192d31681c4bf317e2c6
+        Topics: Sass, Add functionality, Toast
+        K/R: Keep
     - https://github.com/twbs/bootstrap/commit/465cc2da4f028c36f6b1dc7887776af0db4f9176
+        Summary: Change one example that wasn't correct in the card doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/64befa9347a80d4d13b2ee6f7839994547410110
+        Topics: Docs, Card
+        K/R: Remove since it only change the markup for one example.
     - https://github.com/twbs/bootstrap/commit/bc2ec7c7583bed6f51571501739c9e7d57e3ba2f
+        Summary: Initialize a CSS var for button.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/290a0e37a09c23a45df6193147eee9b3933e60b2
+        Topics: Sass
+        K/R: Remove but not sure
     - https://github.com/twbs/bootstrap/commit/a138bc3fb9ff3495a8d63d776e0ad21ed2aaa1ca
+        Summary: Change the way to display the dark variant doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/2936702a90fe147aa4808a9edbefeb0c77508e7b
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/9be3cdf265a800555b385e606c6f825859bd5476
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/df67fb2e976b70ab338a8da5623e2710aad41357
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/4e5130ecfe0d48f1d1e5ffefb48f36f787fff819
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/4330c7a1efb201e065e722ea828aedeee0bfeef8
+        Topics: Docs, Sass
+        K/R: Remove
     - ~~https://github.com/twbs/bootstrap/commit/ebbed79df7bb4735894f31bc558377a531c93710~~ Probably nothing to do. Linked to https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/1508
+        Summary: Solve a rounded issue for list group when there's only one.
+        Boosted: None
+        Topics: Sass
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/2f3aec819ae7bd04c00cc55fee977d12e11a46c6
+        Summary: Fix z-index issues on input group + support z-index for floating labels.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/da975b0442a063ed4530adea167ba30a89b02734
+        Topics: Sass, Add functionality, Input group
+        K/R: Keep to prevent issues with zindex
     - https://github.com/twbs/bootstrap/commit/87aaf9499620c9a7b592711a6e8d86e9a30467b6
+        Summary: Add a form select example.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/4f72cdaf526e3d2f7dba4a271095db1b4f5c0ce7
+        Topics: Example
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/cda901f2444d6b09cfa3261c84ef98288e3b9834
+        Summary: Change a bit the applied focus on `pre`.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/ea88a59023f311ad02be852b0617f72dba67a20d
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/97c768c9e2aff3469ca0667288d2dab045a1d5ef
+        Topics: Sass, Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/db3490788775ac88cc8dcc32f9b8bcd66f95859e
+        Summary: Update @babel/core, @popperjs/core, eslint, jquery, lockfile-lint, postcss, rollup, sass, stylelint and terser dependencies
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/3fbf956cb237236493a825e08f2c328fc06fad73
+        Topics: Dependencies
+        K/R: ?
     - https://github.com/twbs/bootstrap/commit/a12453a0ffe38af0e273e559ec4ced396d39feba
+        Summary: Change the starter template padding.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/abc0dc596e0379c9cc1e0ad4a88d9a40c7c5467f
+        Topics: Example
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/3ad8551f8b736be024a533aa281a89995258021f
+        Summary: Change the initialization of an accordion CSS var.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/840c96209c18aafe8d4cb31d92457d04fb123e37
+        Topics: Sass, Add functionality, Accordion
+        K/R: Remove
     - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
-  * fix(docs): reorder Carousel doc parts (#1491) 
-  * feat(breadcrumb): add dark variant (#1430) 
+  * fix(docs): reorder Carousel doc parts (#1491)
+        Summary: Reorder the carousel doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1491
+        Topics: Docs, Carousel
+        K/R: Remove
+  * feat(breadcrumb): add dark variant (#1430)
+        Summary: Add a dark variant and a CSS var for breadcrumb.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1430
+        Topics: Docs, Sass, Add functionality, Breadcrumb
+        K/R: Keep
   * feat(pagination): add dark variant (#1433)
+        Summary: Add a dark variant and a CSS var for pagination.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1433
+        Topics: Docs, Sass, Add functionality, Pagination
+        K/R: Keep
   * fix(dropdowns): add and trim CSS vars (#1423)
+        Summary: Add and remove some CSS var in dropdown.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1423
+        Topics: Sass, Add functionality, Breaking changes, Dropdowns
+        K/R: Keep
   * fix(docs): fix Orange Helvetica CSS file name in docs (#1487)
+        Summary: Fix documentation for Helvetica files.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1487
+        Topics: Docs
+        K/R: Keep (Don't know if this is mentioned anywhere)
   * chore(deps): update package-lock.json (#1503)
+        Summary: Update package-lock.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1503
+        Topics: Dependencies
+        K/R: Remove
   * feat(stepped process): add dark variant (#1434)
+        Summary: Add a dark variant for stepped process.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1434
+        Topics: Docs, Sass, Add functionality, Stepped process
+        K/R: Keep
   * fix(docs): move 'Dark variant' sections out of 'Example' for alerts and accordions (#1502)
-  * docs(search): enhance Algolia search results for a11y (#1432) 
+        Summary: Change the 'Dark variant' doc in Alerts and Accordions.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1502
+        Topics: Docs, Alerts, Accordions
+        K/R: Remove
+  * docs(search): enhance Algolia search results for a11y (#1432)
+        Summary: Changed the Algolia search modal look.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1432
+        Topics: Docs
+        K/R: Remove
   * chore(deps-dev): bump @rollup/plugin-commonjs from 22.0.1 to 22.0.2 (#1474)
-  * fix(cards): refine rendering of cards with image overlays (#1493) 
+        Summary: Update @rollup dependency.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1474
+        Topics: Dependencies
+        K/R: Remove
+  * fix(cards): refine rendering of cards with image overlays (#1493)
+        Summary: Backport of an example from v4.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1493
+        Topics: Docs, Card
+        K/R: Remove since it doesn't change the markup of each card
   * fix(docs): add missing points and Markdown formatting in some tables (#1499)
-  * docs(content): show a third-level list (#1497) 
+        Summary: Fix typo in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1499
+        Topics: Docs
+        K/R: Remove
+  * docs(content): show a third-level list (#1497)
+        Summary: Add a third-level list item in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1497
+        Topics: Docs, Reboot
+        K/R: Remove
   * fix(docs): replace 'Secondary' by 'Primary' label for some buttons when inconsistent (#1494)
+        Summary: Change typo in the doc
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1494
+        Topics: Docs, Buttons
+        K/R: Remove
   * fix(dropdown toggle split): same width for all `.dropdown-toggle-split`s orientations (#1451)
-  * fix(css): set .mark and <mark> y padding to 0 (#1484) 
+        Summary: Add `min-width` to `.dropdown-toggle-split`.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1451
+        Topics: Sass, Add functionality, Dropdown
+        K/R: Keep
+  * fix(css): set .mark and <mark> y padding to 0 (#1484)
+        Summary: Change the y padding- default value in `.mark`.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1484
+        Topics: Sass, Reboot
+        K/R: Remove
   * fix(stepped process): improve rendering of arrow shapes (#1485)
-  * fix(docs): update values in grids/breakpoints tables (#1440) 
-  * fix(modal): remove unused CSS variables (#1418) 
-  * fix(pagination): remove CSS variables (#1457) 
-  * fix(alerts): increase height when additional content (#1425) 
+        Summary: Changing the default values of the arrow in stepped-process.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1485
+        Topics: Sass, Stepped-process
+        K/R: Remove
+  * fix(docs): update values in grids/breakpoints tables (#1440)
+        Summary: Syncing the values in Sass and the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1440
+        Topics: Docs
+        K/R: Remove
+  * fix(modal): remove unused CSS variables (#1418)
+        Summary: Remove some CSS var in modal.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1418
+        Topics: Sass, Breaking changes, Modal
+        K/R: Keep
+  * fix(pagination): remove CSS variables (#1457)
+        Summary: Remove some CSS var in pagination.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1457
+        Topics: Sass, Breaking changes, Pagination
+        K/R: Keep
+  * fix(alerts): increase height when additional content (#1425)
+        Summary: Change the line-height inside alerts.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1425
+        Topics: Sass, Add functionality, Alerts
+        K/R: Keep
   * chore(deps): bump actions/cache from 3.0.5 to 3.0.8 (#1473)
+        Summary: Update actions/cache dependency.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1473
+        Topics: Dependencies
+        K/R: Remove
   * fix(docs): remove navbar box shadow version selector overlap [#1438](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1438)
+        Summary: remove navbar box shadow version selector overlap.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1438
+        Topics: Docs
+        K/R: Remove
   * chore(merge main) patched commit → c3c6591 [#1469](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469)
     - https://github.com/twbs/bootstrap/commit/dfae892801ffc194de6aec34d543d908db3dd8e1
+        Summary: Set title on element if needed when tooltip is closing.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/a769496787bbf22fb5532df78a733815520b7c53
+        Topics: Javascript, Add functionality, Tooltip
+        K/R: Keep
     - ~~https://github.com/twbs/bootstrap/commit/3feaf6ca0b0c6b6e134a8937ca132d43ed949a68~~ - Nothing to do in Boosted. We want to keep the search icon as it is contrary to what's done in Bootstrap
+        Summary: Changes the management of the Algolia search icon in the navbar.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/9eafd577523b55965066dbbf9ce825e0dbeced5e
+        Topics: Docs
+        K/R: Remove
     - ~~https://github.com/twbs/bootstrap/commit/90c50ab198a4ecffdda6a5ff10fe58cab2c816b2~~ - Nothing to do in Boosted since we don't have this modified section
+        Summary: Adding some missing `alt`.
+        Boosted: None
+        Topics: Docs, markup
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/db86607c088bd307aa21f4b4bd0258262262a4e4
+        Summary: Add a threshold option on Scrollspy.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/399ba677af1bf46098c797bf0419302e8b58dc03
+        Topics: Javascript, Add functionality, Scrollspy
+        K/R: Keep
     - ~~https://github.com/twbs/bootstrap/commit/17aa6732ab83653501e70dc88afcccead1dc0892~~ - Was already done in Boosted
+        Summary: Fix some typo error in the doc.
+        Boosted: None
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/85530309fabf6c7316e8511016d3daed1ab3aee4
+        Summary: Change the value of a Sass variable.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/71855c8c70070f805ec358bd303c150d74af255b
+        Topics: Sass
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/a4f81c04b5da87b9b05ceeeee87ae235f836d4e6
+        Summary: Update autoprefixer dependency.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/956586b6846c67e59fb021e20ec6e54ba8386ff8
+        Topics: Dependencies
+        K/R: Remove
     - ~~https://github.com/twbs/bootstrap/commit/c22dd50e1b3539685c609e0e0b37ba52bb2312cf~~ - `_floating-labels.scss` doesn't exist in Boosted
+        Summary: Align start for floating labels.
+        Boosted: None
+        Topics: Sass, Add functionality, Floating labels
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/7432f2a9224ed173d04930df3f02fd5a37e962c0
+        Summary: Fix typo error for a class in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/604f29949ce36209682377c634c94152a9df3286
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/6c221aa043e0bd14db31fb047c57c714e92605de
+        Summary: Fix border for floating labels inside input groups.
+        Boosted:https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/471d5f4d0a21dd7a4f60ed08c2048022be353315
+        Topics: Sass, Fix, Floating labels
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/4018fac20ebd0adeb65f6b01a13851098e94309a
+        Summary: Add doc for popover explanation.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/537b26f040347e40ccda2d061718f37e487eab48
+        Topics: Docs, Popover
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/8730ef0f8eec576a56b99ceb785da09f0c54b2ac
+        Summary: Adding no redundant selector to linter.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/7eea3cbe0ed6bead5b2d1385b0fe862224bf2769
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/7fa36229e80c84d3c531fdc44ca12667a70a4876
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/8bc1f66b1f5f57108391ae316e818a3bbcf2ab79
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/bcdcf5a9735874241fc441c7c1f5270ec74ca888
+        Topics: Sass, Lint
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/e57a94cd664aa7b819da9408053bfbdf414a78e4
+        Summary: Better explanation for grid row columns.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/e46024281f529fee43904942b4844a6092842cf4
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/9e57dfadac9cd924c35b7ff5b3d82981b59502de
+        Summary: Update features example.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/0b66371788d8b4031d9f720a5a99a0b8e2b63702
+        Topics: CSS, Example
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/aad77f32bd58175ab5c3577aed558adf8598b394
+        Summary: Update rollup dependency.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/938e1b33700f3bf61b3cb34619d19f0fd7ab47d6
+        Topics: Dependencies
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/a685b9648bf14c853b9a417c7c68f95d93e1aabc
+        Summary: Update eslint, @babel package and sass dependencies.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/02269b39e7c3f8cef2b2340d37906c06b413e699
+        Topics: Dependencies
+        K/R: ?
     - https://github.com/twbs/bootstrap/commit/c3c65911665ab64bdaa15d405db65ee81655dbf3
+        Summary: Change author of Sass function.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/71701ed4fed9d0f9fcaf0044933dfe49281c153c
+        Topics: Sass
+        K/R: Remove
     - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
-  * feat(pagination): new --#{$prefix}pagination-padding-end CSS var [#1416](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1416)
+  * feat(pagination): new `--#{$prefix}pagination-padding-end` CSS var [#1416](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1416)
+        Summary: new `--#{$prefix}pagination-padding-end` CSS var
+        Boosted: None
+        Topics: Sass, Minor change, Pagination
+        K/R: Keep
   * fix(css): drop unused $list-group-hover-bg and `--#{$prefix}list-group-action-hover-bg` [#1417](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1417)
+        Summary: drop unused $list-group-hover-bg and `--#{$prefix}list-group-action-hover-bg`
+        Boosted: None
+        Topics: Sass, Deprecated, List-group
+        K/R: Keep
   * chore(merge main) patched commit → 44c9c8d [#1421](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421)
     - https://github.com/twbs/bootstrap/commit/04b5d099b3643e08e6f92311a89a29861ff0191a
+        Summary: Remove unused parameter of a mixin.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/66694da38a7a1d12f1634968a409c11388783685
+        Topics: Sass
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/d12bcf7bc0f0cb55aa98db3a03f754c5a4d9001f
+        Summary: Change a deprecated link in doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/a98274d6c81e7e6e270de5d2ac735614b1bec78e
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/b6d27899fc03fe9c3be87a34e9d19696fb716f44
+        Summary: Change for a good wording in doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/eed7a8d12db58b5c1e27fc8878ecf2313d8a2103
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/7688c84b8a881f1fe131b204d16ba13246d25da5
+        Summary: Change the titles structure in a Bootstrap example.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/c52d795234fb5ee55f99d4b69ec981297a7595cc
+        Topics: Example
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/e547c9c2e90549ffec84b8c2c293770c5c213e39
+        Summary: Adding a missing parenthesis in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/965442d68ff83cc9c404ada83f084e1e4e1475a2
+        Topics: Docs
+        K/R: Remove
     - ~~https://github.com/twbs/bootstrap/commit/99cd8ca8a0f2cb0db8276316943fdd1a2199e791~~: already done in Boosted
+        Summary: Change the added-in short-code in doc.
+        Boosted: None
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/14e705d9ae700030242c9cc7191e6e6d376eda39
+        Summary: Change the link to create a new issue in Boosted.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/e78ee0cd3274acd0010e52202dfbfc824c027713
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/01bf7a9b86e6cffcf8f7436f8afa898a9453bd19
+        Summary: Add a missing added-in short-code in doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/050d91b7e548d74b42310362788628ef36502fa9
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/dc901d25fa663807886a9564765bae0f6fe47f8f
+        Summary: Add a missing added-in short-code in doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/a2792f5d41860b26e568e8b9a2bfc412b7128854
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/a153f360eea855f29947ac14be14e29380ddebeb
+        Summary: Remove useless calc in a Sass file.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/5b4e9c74631c97c67db9bf10b4500b84cac8cbf5
+        Topics: Sass
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/00aa1a5c6e04629955ee45780b86f6ce8fd48ebf
+        Summary: Remove Slack references in the doc.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/fd118dada5e46a25344f87636533ba6ff92811bc
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/501faa2c966632f31b919faf3fa78e9adbe6fe5b
+        Summary: Bring some new images to Webpack/Vite/Parcel and change the way they're managed.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/0bc25dd543d2962207663053c0261a265acd0297
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/5171f9985af857ffdd263a23d59f54b5d2bd1f46
+                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/1e44f5b8683fb613a748a0e7f6bbc3818ac1fd68
+        Topics: Docs
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/02f1c628f11122a4c2a40df6d2e1bc1fe6ec202a
+        Summary: Update lockfile-lint dependency.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/7a734d09b603c258d8c173dd8d4a9e4c3d3a2f64
+        Topics: Dependencies
+        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/44c9c8df8d8e5be84d5bea47f8ee110b64e86e62
-    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
+        Summary: Update Sass dependency.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/1d00904aec9702cf9c23525658b7752c935eb4a2
+        Topics: Dependency
+        K/R: ?
+    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide -> Done
 -->
 
 ## v5.2.0

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,12 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
+  * fix(forms): fix(forms): prevent that valid icon hides input content
+    - Valid icons don't hide anymore content in inputs when too long
+    - Quantity selector doesn't display valid icon anymore
+    - .form-control-color display the valid icon correctly and doesn't change its width when invalid
+    - .form-check-input -> switches are displayed correctly when invalid (no blue border)
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1306
   * fix(a11y): fix(a11y): add aria-hidden=true and focusable=false to SVGs in tooltips examples
     - SVGs in tooltips do not carry any specific information so they should not be readable by screen reader so we should add 'aria-hidden=true'
     - In addition, replaced the missing 'focusable=false' on the first svg

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -22,7 +22,7 @@ If you need more details about the changes, please refer to the [v5.2.1 release]
 - **Back to top**
   - <span class="badge bg-danger">Breaking</span> Back to top 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
-- **Breacrumb**
+- **Breadcrumb**
   - <span class="badge bg-success">New</span> Breadcrumb now has a dark variant.
 
 - **Footers**

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,8 +19,14 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!--
+  * feat(css): add CSS vars for Close button
+    - Several new `--#{$prefix}btn-close-*` CSS variables
+    - Several new `$btn-close-*` Sass variables
+    - Creation of new `$btn-close-white-*` Sass variables
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1531
   * feat(css): add CSS vars to handle `.nav-tabs-light` and `.tab-content`
     - New --#{$prefix}nav-tabs-link-hover-color, --#{$prefix}nav-tabs-link-hover-bg, --#{$prefix}nav-tabs-link-border-width CSS variables
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1427
   * fix(toast): adjust the layout of custom content (#1490)
     - Changed some utilities in the markup of "Toast > Custom content" example to adjust the layout
         Summary: Change custom toast example in the doc.

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -65,22 +65,15 @@ toc: true
   - `--bs-alert-logo-size`
   - `--bs-navbar-font-weight`
   - `--bs-navbar-toggler-icon-filter`
+- Dark text variants handling is now explained in [Customize > CSS variables > Dark text rule](https://boosted.orange.com/docs/5.2/customize/css-variables/#dark-text-rule).
 
 - <span class="badge bg-info align-text-top">New</span> Here is an exhaustive list of new Sass variables:
   - `$alert-heading-font-weight`
   - `$alert-icon-size-sm`
   - `$navbar-font-weight`
 
-
 <!--
 ### TODO
-  * doc(examples): remove Bootstrap examples unused in Boosted
-    - Mainly removed the files. No impact for the user. Only concerns the docs.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1542
-  * fix(css): reduce the scope of root dark text rule
-    - Changed the CSS rule to apply text style with a dark variant (was it already there in v5.2.0?)
-    - Added a section Customize > CSS variables > Dark text rule in docs
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1293
   * feat(css): add CSS vars for Close button
     - Several new `#{$prefix}btn-close-*` CSS variables
     - Several new `$btn-close-*` Sass variables
@@ -626,6 +619,10 @@ toc: true
     - Reset to Bootstrap default for feedback icon on select
     - Setting the icon in the top right corner instead of center right
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1371
+
+* doc(examples): remove Bootstrap examples unused in Boosted
+    - Mainly removed the files. No impact for the user. Only concerns the docs.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1542
 -->
 
 ## v5.2.0

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -15,37 +15,18 @@ toc: true
 
 ### Components
 
-<!-- * fix(back to top): remove 'Label inside' variant (#1520) -->
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
-<!--
-  * fix(footers): change 'Terms & Conditions' to 'Terms and conditions'
-    This information is important for the users in order to change the label they could have used
-    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1564
--->
 - <span class="badge bg-warning">Warning</span> All **Footers** examples have been modified to use the "Terms and conditions" wording instead of "Terms & Conditions". Please reflect this modification into your websites.
 
-<!--
-  * feat(components): new Tags component
-    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/988
--->
+- <span class="badge bg-warning">Warning</span> Changed the markup for **Toasts** with a custom content (toast message and close button). Please reflect this modification into your websites.
+
 - <span class="badge bg-info">New</span> **Tags** component.
 
 ### Icons and images
 
-<!--
-* fix(a11y): fix(a11y): add aria-hidden=true and focusable=false to SVGs in tooltips examples
-  - SVGs in tooltips do not carry any specific information so they should not be readable by screen reader so we should add 'aria-hidden=true'
-  - In addition, replaced the missing 'focusable=false' on the first svg
-    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1555
--->
 - <span class="badge bg-warning">Warning</span> **Tooltips** examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites.
 
-<!--
-* fix(icons): use the right close icon
-  - Change the SVG of the close icon used in modal, offcanvas and close buttons
-    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1566
--->
 - The close icon SVG has changed in modals, offcanvases and close buttons. Although is has no direct impact, you might want apply this same modification within your websites.
 
 ### Helpers
@@ -72,8 +53,16 @@ toc: true
   - `--bs-btn-close-disabled-color`
   - `--bs-btn-close-hover-color`
   - `--bs-btn-close-padding`
+  - `--bs-tab-content-border-width`
+  - `--bs-tab-content-padding-x`
+  - `--bs-tab-content-padding-y`
+  - `--bs-nav-tabs-link-border-width`
+  - `--bs-nav-tabs-link-hover-bg`
+  - `--bs-nav-tabs-link-hover-color`
+  - `--bs-nav-tabs-link-padding-x`
   - `--bs-navbar-font-weight`
   - `--bs-navbar-toggler-icon-filter`
+
 - <span class="badge bg-info">New</span> Here is an exhaustive list of new Sass variables:
   - `$alert-heading-font-weight`
   - `$alert-icon-size-sm`
@@ -91,19 +80,11 @@ toc: true
   - `$btn-close-white-disabled-color`
   - `$btn-close-white-hover-color`
   - `$navbar-font-weight`
+
 - Dark text variants handling is now explained in [Customize > CSS variables > Dark text rule](https://boosted.orange.com/docs/5.2/customize/css-variables/#dark-text-rule).
 
 <!--
 ### TODO
-  * feat(css): add CSS vars to handle `.nav-tabs-light` and `.tab-content`
-    - New #{$prefix}nav-tabs-link-hover-color, #{$prefix}nav-tabs-link-hover-bg, #{$prefix}nav-tabs-link-border-width CSS variables
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1427
-  * fix(toast): adjust the layout of custom content (#1490)
-    - Changed some utilities in the markup of "Toast > Custom content" example to adjust the layout
-        Summary: Change custom toast example in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1490
-        Topics: Docs, Markup, Toast
-        K/R: Remove since these are only example to show what is possible.
   * fix(navbar): minor fixes (#1498)
     - Add a .mb-3 to offcanvases navbar examples to add some space between the last link and the search bar in mobile viewport
     - New $navbar-dark-border-color used in `-bs-navbar-border-color` for .navbar-dark

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,10 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
+  * feat(css):  feat(css): define `.btn-no-outline`, `.btn-link` and `.btn-social` with CSS vars
+    - Reuse of buttons CSS variables to define `.btn-no-outline`, `.btn-link` and `.btn-social`
+    - Probably not any impacts for the users
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1426
   * feat(utilities): revamp `.img-thumbnail` and add desc in docs
     - Revamp rendering of `.img-thumbnail`
     - Add a new section in the Content > Images > Image thumbnails docs

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -132,26 +132,6 @@ toc: true
         Topics: Javascript, Fix, Modal
         K/R: ?
   * chore(merge main) patched commit → 2504b89 (#1513)
-    - https://github.com/twbs/bootstrap/commit/a329575d82a65660ffa7b18cbd9f291e0ee7eef5
-        Summary: Put some doc inside a table.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/8eb7321b5fa2847a919ae8968f28395f5e1a5c44
-        Topics: Docs, List group, Navs tabs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/585146a6a7aa70faf25442d7d28636ce57e29588
-        Summary: Update eslint-config-xo dependency.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/7b69e857675288a38005be1f217e6f9098ed8040
-        Topics: Dependencies
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/75e09b1c0f5ae5f51078c7a25fe36d892c5cfcfe
-        Summary: Update rtlcss dependency.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/db7dfad165b642c689e88f95a4ab73d0a958b1ac
-        Topics: Dependencies
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/b8880e5eec6bb4f33578578ba2413f0d91424382
-        Summary: Workaround for postcss parser. (-1 * ...)
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/f5ceeb59dd270208acaa0ff63e9382a70ab12cb3
-        Topics: Sass
-        K/R: ?
     - https://github.com/twbs/bootstrap/commit/32c457db4b6ff389efbd35772b24746c7ffb0b6d
         Summary: Change the focus management of buttons (use of :focus-visible instead of :focus).
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/f225846843ba8708980c1c4bf9c993845172acb0
@@ -160,104 +140,30 @@ toc: true
                  https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/a3fa822704747ee61a895a8151ae88f789b19e2f
         Topics: Sass, Breaking changes, Button
         K/R: Keep
-    - https://github.com/twbs/bootstrap/commit/2504b8995095d2bb41c9686afa175f9eaa91bec2
-        Summary: Remove gradient for .btn-link.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/d3d66c45bbd42f2c9a5471fcbfd147fc6c7d050e
-        Topics: Sass, Button
-        K/R: ?
     - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
+        - TODO
   * chore(merge main) patched commit → 337068f (#1510)
     - https://github.com/twbs/bootstrap/commit/b14190b5095195fbe803f81bf4ce56d09be5378d
         Summary: Update popperjs dependency.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/363e4fee27febd22630716e8d88d716fe45b8cea
         Topics: Dependencies
         K/R: Keep
-    - https://github.com/twbs/bootstrap/commit/337068f8b1044004f4b9abfffbb433694ae87993
-        Summary: Fix wrong dropdown menu opening when severals dropdowns in one element.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/7961a7acb10d49a0831711b983169641a3e30571
-        Topics: Javascript, Fix, Dropdown
-        K/R: ?
-    - https://github.com/twbs/bootstrap/commit/15318674fb086214e095c61af780a7d889f0f11e
-        Summary: Reorder offcanvas doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/125f0f1b83dfc334049a355724a72aa793e16dcb
-        Topics: Docs, Offcanvas
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/995df354f260ccf46672e4dc9e7b2c242bd4c02d
-        Summary: Change the cursor for search modal in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/a645786913577a1af25d743a50550a23578661f0
-        Topics: Sass
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/4cea8b1786ddbe365747cabebe9bee44d70a3b6d
-        Summary: Add a comment in Sass file.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/a645786913577a1af25d743a50550a23578661f0
-        Topics: Sass
-        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/a0238d126b385044bd7cb16bdc9118f3d44e016f
         Summary: Add a CSS var to toast.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/405215a187e037eee4f1192d31681c4bf317e2c6
         Topics: Sass, Add functionality, Toast
         K/R: Keep
-    - https://github.com/twbs/bootstrap/commit/465cc2da4f028c36f6b1dc7887776af0db4f9176
-        Summary: Change one example that wasn't correct in the card doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/64befa9347a80d4d13b2ee6f7839994547410110
-        Topics: Docs, Card
-        K/R: Remove since it only change the markup for one example.
     - https://github.com/twbs/bootstrap/commit/bc2ec7c7583bed6f51571501739c9e7d57e3ba2f
         Summary: Initialize a CSS var for button.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/290a0e37a09c23a45df6193147eee9b3933e60b2
         Topics: Sass
-        K/R: Remove but not sure
-    - https://github.com/twbs/bootstrap/commit/a138bc3fb9ff3495a8d63d776e0ad21ed2aaa1ca
-        Summary: Change the way to display the dark variant doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/2936702a90fe147aa4808a9edbefeb0c77508e7b
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/9be3cdf265a800555b385e606c6f825859bd5476
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/df67fb2e976b70ab338a8da5623e2710aad41357
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/4e5130ecfe0d48f1d1e5ffefb48f36f787fff819
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/4330c7a1efb201e065e722ea828aedeee0bfeef8
-        Topics: Docs, Sass
-        K/R: Remove
-    - ~~https://github.com/twbs/bootstrap/commit/ebbed79df7bb4735894f31bc558377a531c93710~~ Probably nothing to do. Linked to https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/1508
-        Summary: Solve a rounded issue for list group when there's only one.
-        Boosted: None
-        Topics: Sass
-        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/2f3aec819ae7bd04c00cc55fee977d12e11a46c6
         Summary: Fix z-index issues on input group + support z-index for floating labels.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/da975b0442a063ed4530adea167ba30a89b02734
         Topics: Sass, Add functionality, Input group
         K/R: Keep to prevent issues with zindex
-    - https://github.com/twbs/bootstrap/commit/87aaf9499620c9a7b592711a6e8d86e9a30467b6
-        Summary: Add a form select example.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/4f72cdaf526e3d2f7dba4a271095db1b4f5c0ce7
-        Topics: Example
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/cda901f2444d6b09cfa3261c84ef98288e3b9834
-        Summary: Change a bit the applied focus on `pre`.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/ea88a59023f311ad02be852b0617f72dba67a20d
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/97c768c9e2aff3469ca0667288d2dab045a1d5ef
-        Topics: Sass, Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/db3490788775ac88cc8dcc32f9b8bcd66f95859e
-        Summary: Update @babel/core, @popperjs/core, eslint, jquery, lockfile-lint, postcss, rollup, sass, stylelint and terser dependencies
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/3fbf956cb237236493a825e08f2c328fc06fad73
-        Topics: Dependencies
-        K/R: ?
-    - https://github.com/twbs/bootstrap/commit/a12453a0ffe38af0e273e559ec4ced396d39feba
-        Summary: Change the starter template padding.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/abc0dc596e0379c9cc1e0ad4a88d9a40c7c5467f
-        Topics: Example
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/3ad8551f8b736be024a533aa281a89995258021f
-        Summary: Change the initialization of an accordion CSS var.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/840c96209c18aafe8d4cb31d92457d04fb123e37
-        Topics: Sass, Add functionality, Accordion
-        K/R: Remove
     - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
-  * fix(docs): reorder Carousel doc parts (#1491)
-        Summary: Reorder the carousel doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1491
-        Topics: Docs, Carousel
-        K/R: Remove
+        - TODO
   * feat(breadcrumb): add dark variant (#1430)
         Summary: Add a dark variant and a CSS var for breadcrumb.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1430
@@ -278,71 +184,16 @@ toc: true
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1487
         Topics: Docs
         K/R: Keep (Don't know if this is mentioned anywhere)
-  * chore(deps): update package-lock.json (#1503)
-        Summary: Update package-lock.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1503
-        Topics: Dependencies
-        K/R: Remove
   * feat(stepped process): add dark variant (#1434)
         Summary: Add a dark variant for stepped process.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1434
         Topics: Docs, Sass, Add functionality, Stepped process
         K/R: Keep
-  * fix(docs): move 'Dark variant' sections out of 'Example' for alerts and accordions (#1502)
-        Summary: Change the 'Dark variant' doc in Alerts and Accordions.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1502
-        Topics: Docs, Alerts, Accordions
-        K/R: Remove
-  * docs(search): enhance Algolia search results for a11y (#1432)
-        Summary: Changed the Algolia search modal look.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1432
-        Topics: Docs
-        K/R: Remove
-  * chore(deps-dev): bump @rollup/plugin-commonjs from 22.0.1 to 22.0.2 (#1474)
-        Summary: Update @rollup dependency.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1474
-        Topics: Dependencies
-        K/R: Remove
-  * fix(cards): refine rendering of cards with image overlays (#1493)
-        Summary: Backport of an example from v4.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1493
-        Topics: Docs, Card
-        K/R: Remove since it doesn't change the markup of each card
-  * fix(docs): add missing points and Markdown formatting in some tables (#1499)
-        Summary: Fix typo in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1499
-        Topics: Docs
-        K/R: Remove
-  * docs(content): show a third-level list (#1497)
-        Summary: Add a third-level list item in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1497
-        Topics: Docs, Reboot
-        K/R: Remove
-  * fix(docs): replace 'Secondary' by 'Primary' label for some buttons when inconsistent (#1494)
-        Summary: Change typo in the doc
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1494
-        Topics: Docs, Buttons
-        K/R: Remove
   * fix(dropdown toggle split): same width for all `.dropdown-toggle-split`s orientations (#1451)
         Summary: Add `min-width` to `.dropdown-toggle-split`.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1451
         Topics: Sass, Add functionality, Dropdown
         K/R: Keep
-  * fix(css): set .mark and <mark> y padding to 0 (#1484)
-        Summary: Change the y padding- default value in `.mark`.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1484
-        Topics: Sass, Reboot
-        K/R: Remove
-  * fix(stepped process): improve rendering of arrow shapes (#1485)
-        Summary: Changing the default values of the arrow in stepped-process.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1485
-        Topics: Sass, Stepped-process
-        K/R: Remove
-  * fix(docs): update values in grids/breakpoints tables (#1440)
-        Summary: Syncing the values in Sass and the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1440
-        Topics: Docs
-        K/R: Remove
   * fix(modal): remove unused CSS variables (#1418)
         Summary: Remove some CSS var in modal.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1418
@@ -358,106 +209,12 @@ toc: true
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1425
         Topics: Sass, Add functionality, Alerts
         K/R: Keep
-  * chore(deps): bump actions/cache from 3.0.5 to 3.0.8 (#1473)
-        Summary: Update actions/cache dependency.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1473
-        Topics: Dependencies
-        K/R: Remove
-  * fix(docs): remove navbar box shadow version selector overlap [#1438](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1438)
-        Summary: remove navbar box shadow version selector overlap.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1438
-        Topics: Docs
-        K/R: Remove
   * chore(merge main) patched commit → c3c6591 [#1469](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469)
-    - https://github.com/twbs/bootstrap/commit/dfae892801ffc194de6aec34d543d908db3dd8e1
-        Summary: Set title on element if needed when tooltip is closing.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/a769496787bbf22fb5532df78a733815520b7c53
-        Topics: Javascript, Add functionality, Tooltip
-        K/R: Keep
-    - ~~https://github.com/twbs/bootstrap/commit/3feaf6ca0b0c6b6e134a8937ca132d43ed949a68~~ - Nothing to do in Boosted. We want to keep the search icon as it is contrary to what's done in Bootstrap
-        Summary: Changes the management of the Algolia search icon in the navbar.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/9eafd577523b55965066dbbf9ce825e0dbeced5e
-        Topics: Docs
-        K/R: Remove
-    - ~~https://github.com/twbs/bootstrap/commit/90c50ab198a4ecffdda6a5ff10fe58cab2c816b2~~ - Nothing to do in Boosted since we don't have this modified section
-        Summary: Adding some missing `alt`.
-        Boosted: None
-        Topics: Docs, markup
-        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/db86607c088bd307aa21f4b4bd0258262262a4e4
         Summary: Add a threshold option on Scrollspy.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/399ba677af1bf46098c797bf0419302e8b58dc03
         Topics: Javascript, Add functionality, Scrollspy
         K/R: Keep
-    - ~~https://github.com/twbs/bootstrap/commit/17aa6732ab83653501e70dc88afcccead1dc0892~~ - Was already done in Boosted
-        Summary: Fix some typo error in the doc.
-        Boosted: None
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/85530309fabf6c7316e8511016d3daed1ab3aee4
-        Summary: Change the value of a Sass variable.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/71855c8c70070f805ec358bd303c150d74af255b
-        Topics: Sass
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/a4f81c04b5da87b9b05ceeeee87ae235f836d4e6
-        Summary: Update autoprefixer dependency.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/956586b6846c67e59fb021e20ec6e54ba8386ff8
-        Topics: Dependencies
-        K/R: Remove
-    - ~~https://github.com/twbs/bootstrap/commit/c22dd50e1b3539685c609e0e0b37ba52bb2312cf~~ - `_floating-labels.scss` doesn't exist in Boosted
-        Summary: Align start for floating labels.
-        Boosted: None
-        Topics: Sass, Add functionality, Floating labels
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/7432f2a9224ed173d04930df3f02fd5a37e962c0
-        Summary: Fix typo error for a class in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/604f29949ce36209682377c634c94152a9df3286
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/6c221aa043e0bd14db31fb047c57c714e92605de
-        Summary: Fix border for floating labels inside input groups.
-        Boosted:https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/471d5f4d0a21dd7a4f60ed08c2048022be353315
-        Topics: Sass, Fix, Floating labels
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/4018fac20ebd0adeb65f6b01a13851098e94309a
-        Summary: Add doc for popover explanation.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/537b26f040347e40ccda2d061718f37e487eab48
-        Topics: Docs, Popover
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/8730ef0f8eec576a56b99ceb785da09f0c54b2ac
-        Summary: Adding no redundant selector to linter.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/7eea3cbe0ed6bead5b2d1385b0fe862224bf2769
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/7fa36229e80c84d3c531fdc44ca12667a70a4876
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/8bc1f66b1f5f57108391ae316e818a3bbcf2ab79
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/bcdcf5a9735874241fc441c7c1f5270ec74ca888
-        Topics: Sass, Lint
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/e57a94cd664aa7b819da9408053bfbdf414a78e4
-        Summary: Better explanation for grid row columns.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/e46024281f529fee43904942b4844a6092842cf4
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/9e57dfadac9cd924c35b7ff5b3d82981b59502de
-        Summary: Update features example.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/0b66371788d8b4031d9f720a5a99a0b8e2b63702
-        Topics: CSS, Example
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/aad77f32bd58175ab5c3577aed558adf8598b394
-        Summary: Update rollup dependency.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/938e1b33700f3bf61b3cb34619d19f0fd7ab47d6
-        Topics: Dependencies
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/a685b9648bf14c853b9a417c7c68f95d93e1aabc
-        Summary: Update eslint, @babel package and sass dependencies.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/02269b39e7c3f8cef2b2340d37906c06b413e699
-        Topics: Dependencies
-        K/R: ?
-    - https://github.com/twbs/bootstrap/commit/c3c65911665ab64bdaa15d405db65ee81655dbf3
-        Summary: Change author of Sass function.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/71701ed4fed9d0f9fcaf0044933dfe49281c153c
-        Topics: Sass
-        K/R: Remove
-    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
   * feat(pagination): new `#{$prefix}pagination-padding-end` CSS var [#1416](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1416)
         Summary: new `#{$prefix}pagination-padding-end` CSS var
         Boosted: None
@@ -468,100 +225,6 @@ toc: true
         Boosted: None
         Topics: Sass, Deprecated, List-group
         K/R: Keep
-  * chore(merge main) patched commit → 44c9c8d [#1421](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421)
-    - https://github.com/twbs/bootstrap/commit/04b5d099b3643e08e6f92311a89a29861ff0191a
-        Summary: Remove unused parameter of a mixin.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/66694da38a7a1d12f1634968a409c11388783685
-        Topics: Sass
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/d12bcf7bc0f0cb55aa98db3a03f754c5a4d9001f
-        Summary: Change a deprecated link in doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/a98274d6c81e7e6e270de5d2ac735614b1bec78e
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/b6d27899fc03fe9c3be87a34e9d19696fb716f44
-        Summary: Change for a good wording in doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/eed7a8d12db58b5c1e27fc8878ecf2313d8a2103
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/7688c84b8a881f1fe131b204d16ba13246d25da5
-        Summary: Change the titles structure in a Bootstrap example.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/c52d795234fb5ee55f99d4b69ec981297a7595cc
-        Topics: Example
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/e547c9c2e90549ffec84b8c2c293770c5c213e39
-        Summary: Adding a missing parenthesis in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/965442d68ff83cc9c404ada83f084e1e4e1475a2
-        Topics: Docs
-        K/R: Remove
-    - ~~https://github.com/twbs/bootstrap/commit/99cd8ca8a0f2cb0db8276316943fdd1a2199e791~~: already done in Boosted
-        Summary: Change the added-in short-code in doc.
-        Boosted: None
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/14e705d9ae700030242c9cc7191e6e6d376eda39
-        Summary: Change the link to create a new issue in Boosted.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/e78ee0cd3274acd0010e52202dfbfc824c027713
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/01bf7a9b86e6cffcf8f7436f8afa898a9453bd19
-        Summary: Add a missing added-in short-code in doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/050d91b7e548d74b42310362788628ef36502fa9
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/dc901d25fa663807886a9564765bae0f6fe47f8f
-        Summary: Add a missing added-in short-code in doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/a2792f5d41860b26e568e8b9a2bfc412b7128854
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/a153f360eea855f29947ac14be14e29380ddebeb
-        Summary: Remove useless calc in a Sass file.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/5b4e9c74631c97c67db9bf10b4500b84cac8cbf5
-        Topics: Sass
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/00aa1a5c6e04629955ee45780b86f6ce8fd48ebf
-        Summary: Remove Slack references in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/fd118dada5e46a25344f87636533ba6ff92811bc
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/501faa2c966632f31b919faf3fa78e9adbe6fe5b
-        Summary: Bring some new images to Webpack/Vite/Parcel and change the way they're managed.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/0bc25dd543d2962207663053c0261a265acd0297
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/5171f9985af857ffdd263a23d59f54b5d2bd1f46
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/1e44f5b8683fb613a748a0e7f6bbc3818ac1fd68
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/02f1c628f11122a4c2a40df6d2e1bc1fe6ec202a
-        Summary: Update lockfile-lint dependency.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/7a734d09b603c258d8c173dd8d4a9e4c3d3a2f64
-        Topics: Dependencies
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/44c9c8df8d8e5be84d5bea47f8ee110b64e86e62
-        Summary: Update Sass dependency.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/1d00904aec9702cf9c23525658b7752c935eb4a2
-        Topics: Dependency
-        K/R: ?
-    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide >> Done
-
-
-### Elements that should not appear in this migration guide because it has no impact for the developers
-
-* fix(css): rename `$prefix` by `$func-prefix` in `get-color-from-rgba-string` function
-    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1567
-* fix(forms): prevent that valid icon hides input content
-    - Valid icons don't hide anymore content in inputs when too long
-    - Quantity selector doesn't display valid icon anymore
-    - .form-control-color display the valid icon correctly and doesn't change its width when invalid
-    - .form-check-input -> switches are displayed correctly when invalid (no blue border)
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1306
-* fix(forms): add validation icons for <select>s and fix its position for `<textarea>`
-    - Reset to Bootstrap default for feedback icon on select
-    - Setting the icon in the top right corner instead of center right
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1371
-
-* doc(examples): remove Bootstrap examples unused in Boosted
-    - Mainly removed the files. No impact for the user. Only concerns the docs.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1542
 -->
 
 ## v5.2.0

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -9,6 +9,127 @@ aliases:
 toc: true
 ---
 
+## v5.2.1
+
+<hr class="mb-4">
+
+### Components
+
+<!--* fix(back to top): remove 'Label inside' variant (#1520) -->
+- <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
+
+<!--
+  * <mark>/.mark: Improve rendering for accessibility (#1506)
+  * chore(workflows): replace percy/snapshot-action by Percy CLI (#1530)
+  * chore: add a PR template (#1007) 
+  * feat(list group): add dark variant (#1525)
+  * fix(css): add workaround for postcss value parser error (#1524) 
+    - Note: linked to previous chore(merge) from Bootstrap. Just forgot to fix this one
+  * chore(merge main patched commit) → 23fb7a7 (#1521)
+    - https://github.com/twbs/bootstrap/commit/97a9060a8fa643484fbe70d1e527267841670c9d
+    - https://github.com/twbs/bootstrap/commit/9b943880fc38ccde372973111fe5872b5960e75d
+    - https://github.com/twbs/bootstrap/commit/7a7469b8ab3e86dc522d3cf030b307364b1ada0b
+    - https://github.com/twbs/bootstrap/commit/949456984aa21536afd35eddf7ea38b3648830a3
+    - https://github.com/twbs/bootstrap/commit/23fb7a79156d1ea4ce2ab5713debbbc251b4e22f
+  * chore(merge main) patched commit → 2504b89 (#1513)
+    - https://github.com/twbs/bootstrap/commit/a329575d82a65660ffa7b18cbd9f291e0ee7eef5
+    - https://github.com/twbs/bootstrap/commit/585146a6a7aa70faf25442d7d28636ce57e29588
+    - https://github.com/twbs/bootstrap/commit/75e09b1c0f5ae5f51078c7a25fe36d892c5cfcfe
+    - https://github.com/twbs/bootstrap/commit/b8880e5eec6bb4f33578578ba2413f0d91424382
+    - https://github.com/twbs/bootstrap/commit/32c457db4b6ff389efbd35772b24746c7ffb0b6d
+    - https://github.com/twbs/bootstrap/commit/2504b8995095d2bb41c9686afa175f9eaa91bec2
+    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
+  * fix(docs): change responsive values in utility API examples (#1488) 
+  * chore(merge main) patched commit → 337068f (#1510)
+    - https://github.com/twbs/bootstrap/commit/3ad8551f8b736be024a533aa281a89995258021f
+    - https://github.com/twbs/bootstrap/commit/77e17e3b8deb4d5467203f4e3cd903b7cd06bde4
+    - https://github.com/twbs/bootstrap/commit/b5f2d5a31e24455447939c3a7487a4fe89a66ba6
+    - https://github.com/twbs/bootstrap/commit/4f97d8fabda142685e36391da2c37c7e09955ac6
+    - https://github.com/twbs/bootstrap/commit/279363783759323c988d227145d5f6bc6c683efd
+    - https://github.com/twbs/bootstrap/commit/8c380b2676eb5eb76716b94763ef21e98c86b9b7
+    - https://github.com/twbs/bootstrap/commit/54b4b2c66a6f0f403a8120a0c7720f29aaa71f7c
+    - https://github.com/twbs/bootstrap/commit/337068f8b1044004f4b9abfffbb433694ae87993
+    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
+  * chore(merge main) patched commit → 3ad8551 (#1507)
+    - ~~https://github.com/twbs/bootstrap/commit/af1bd974bba7f6e7f90c5ed3f42738bd101926cb~~ - Was already done via Dependabot
+    - https://github.com/twbs/bootstrap/commit/29332a954f86671d39f60007fb0c2ea633731e88
+    - https://github.com/twbs/bootstrap/commit/15318674fb086214e095c61af780a7d889f0f11e
+    - https://github.com/twbs/bootstrap/commit/995df354f260ccf46672e4dc9e7b2c242bd4c02d
+    - https://github.com/twbs/bootstrap/commit/4cea8b1786ddbe365747cabebe9bee44d70a3b6d
+    - https://github.com/twbs/bootstrap/commit/a0238d126b385044bd7cb16bdc9118f3d44e016f
+    - https://github.com/twbs/bootstrap/commit/465cc2da4f028c36f6b1dc7887776af0db4f9176
+    - https://github.com/twbs/bootstrap/commit/bc2ec7c7583bed6f51571501739c9e7d57e3ba2f
+    - https://github.com/twbs/bootstrap/commit/a138bc3fb9ff3495a8d63d776e0ad21ed2aaa1ca
+    - ~~https://github.com/twbs/bootstrap/commit/ebbed79df7bb4735894f31bc558377a531c93710~~ Probably nothing to do. Linked to https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/1508
+    - https://github.com/twbs/bootstrap/commit/2f3aec819ae7bd04c00cc55fee977d12e11a46c6
+    - https://github.com/twbs/bootstrap/commit/87aaf9499620c9a7b592711a6e8d86e9a30467b6
+    - https://github.com/twbs/bootstrap/commit/cda901f2444d6b09cfa3261c84ef98288e3b9834
+    - https://github.com/twbs/bootstrap/commit/db3490788775ac88cc8dcc32f9b8bcd66f95859e
+    - https://github.com/twbs/bootstrap/commit/a12453a0ffe38af0e273e559ec4ced396d39feba
+    - https://github.com/twbs/bootstrap/commit/3ad8551f8b736be024a533aa281a89995258021f
+    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
+  * fix(docs): reorder Carousel doc parts (#1491) 
+  * feat(breadcrumb): add dark variant (#1430) 
+  * feat(pagination): add dark variant (#1433)
+  * fix(dropdowns): add and trim CSS vars (#1423)
+  * fix(docs): fix Orange Helvetica CSS file name in docs (#1487)
+  * chore(deps): update package-lock.json (#1503)
+  * feat(stepped process): add dark variant (#1434)
+  * fix(docs): move 'Dark variant' sections out of 'Example' for alerts and accordions (#1502)
+  * docs(search): enhance Algolia search results for a11y (#1432) 
+  * chore(deps-dev): bump @rollup/plugin-commonjs from 22.0.1 to 22.0.2 (#1474)
+  * fix(cards): refine rendering of cards with image overlays (#1493) 
+  * fix(docs): add missing points and Markdown formatting in some tables (#1499)
+  * docs(content): show a third-level list (#1497) 
+  * fix(docs): replace 'Secondary' by 'Primary' label for some buttons when inconsistent (#1494)
+  * fix(dropdown toggle split): same width for all `.dropdown-toggle-split`s orientations (#1451)
+  * fix(css): set .mark and <mark> y padding to 0 (#1484) 
+  * fix(stepped process): improve rendering of arrow shapes (#1485)
+  * fix(docs): update values in grids/breakpoints tables (#1440) 
+  * fix(modal): remove unused CSS variables (#1418) 
+  * fix(pagination): remove CSS variables (#1457) 
+  * fix(alerts): increase height when additional content (#1425) 
+  * chore(deps): bump actions/cache from 3.0.5 to 3.0.8 (#1473)
+  * fix(docs): remove navbar box shadow version selector overlap [#1438](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1438)
+  * chore(merge main) patched commit → c3c6591 [#1469](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469)
+    - https://github.com/twbs/bootstrap/commit/dfae892801ffc194de6aec34d543d908db3dd8e1
+    - ~~https://github.com/twbs/bootstrap/commit/3feaf6ca0b0c6b6e134a8937ca132d43ed949a68~~ - Nothing to do in Boosted. We want to keep the search icon as it is contrary to what's done in Bootstrap
+    - ~~https://github.com/twbs/bootstrap/commit/90c50ab198a4ecffdda6a5ff10fe58cab2c816b2~~ - Nothing to do in Boosted since we don't have this modified section
+    - https://github.com/twbs/bootstrap/commit/db86607c088bd307aa21f4b4bd0258262262a4e4
+    - ~~https://github.com/twbs/bootstrap/commit/17aa6732ab83653501e70dc88afcccead1dc0892~~ - Was already done in Boosted
+    - https://github.com/twbs/bootstrap/commit/85530309fabf6c7316e8511016d3daed1ab3aee4
+    - https://github.com/twbs/bootstrap/commit/a4f81c04b5da87b9b05ceeeee87ae235f836d4e6
+    - ~~https://github.com/twbs/bootstrap/commit/c22dd50e1b3539685c609e0e0b37ba52bb2312cf~~ - `_floating-labels.scss` doesn't exist in Boosted
+    - https://github.com/twbs/bootstrap/commit/7432f2a9224ed173d04930df3f02fd5a37e962c0
+    - https://github.com/twbs/bootstrap/commit/6c221aa043e0bd14db31fb047c57c714e92605de
+    - https://github.com/twbs/bootstrap/commit/4018fac20ebd0adeb65f6b01a13851098e94309a
+    - https://github.com/twbs/bootstrap/commit/8730ef0f8eec576a56b99ceb785da09f0c54b2ac
+    - https://github.com/twbs/bootstrap/commit/e57a94cd664aa7b819da9408053bfbdf414a78e4
+    - https://github.com/twbs/bootstrap/commit/9e57dfadac9cd924c35b7ff5b3d82981b59502de
+    - https://github.com/twbs/bootstrap/commit/aad77f32bd58175ab5c3577aed558adf8598b394
+    - https://github.com/twbs/bootstrap/commit/a685b9648bf14c853b9a417c7c68f95d93e1aabc
+    - https://github.com/twbs/bootstrap/commit/c3c65911665ab64bdaa15d405db65ee81655dbf3
+    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
+  * feat(pagination): new --#{$prefix}pagination-padding-end CSS var [#1416](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1416)
+  * fix(css): drop unused $list-group-hover-bg and `--#{$prefix}list-group-action-hover-bg` [#1417](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1417)
+  * chore(merge main) patched commit → 44c9c8d [#1421](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421)
+    - https://github.com/twbs/bootstrap/commit/04b5d099b3643e08e6f92311a89a29861ff0191a
+    - https://github.com/twbs/bootstrap/commit/d12bcf7bc0f0cb55aa98db3a03f754c5a4d9001f
+    - https://github.com/twbs/bootstrap/commit/b6d27899fc03fe9c3be87a34e9d19696fb716f44
+    - https://github.com/twbs/bootstrap/commit/7688c84b8a881f1fe131b204d16ba13246d25da5
+    - https://github.com/twbs/bootstrap/commit/e547c9c2e90549ffec84b8c2c293770c5c213e39
+    - ~~https://github.com/twbs/bootstrap/commit/99cd8ca8a0f2cb0db8276316943fdd1a2199e791~~: already done in Boosted
+    - https://github.com/twbs/bootstrap/commit/14e705d9ae700030242c9cc7191e6e6d376eda39
+    - https://github.com/twbs/bootstrap/commit/01bf7a9b86e6cffcf8f7436f8afa898a9453bd19
+    - https://github.com/twbs/bootstrap/commit/dc901d25fa663807886a9564765bae0f6fe47f8f
+    - https://github.com/twbs/bootstrap/commit/a153f360eea855f29947ac14be14e29380ddebeb
+    - https://github.com/twbs/bootstrap/commit/00aa1a5c6e04629955ee45780b86f6ce8fd48ebf
+    - https://github.com/twbs/bootstrap/commit/501faa2c966632f31b919faf3fa78e9adbe6fe5b
+    - https://github.com/twbs/bootstrap/commit/02f1c628f11122a4c2a40df6d2e1bc1fe6ec202a
+    - https://github.com/twbs/bootstrap/commit/44c9c8df8d8e5be84d5bea47f8ee110b64e86e62
+    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
+-->
+
 ## v5.2.0
 
 <hr class="mb-4">

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -67,7 +67,7 @@ If you need more details about the changes, please refer to the [v5.2.1 release]
 
 - <span class="badge bg-warning">Warning</span> Changed the rendering of `<mark>` (and so `.mark`). Depending on your usage it may worth checking the impact in your websites.
 
-- <span class="badge bg-warning">Warning</span> Tooltips examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites.
+- <span class="badge bg-warning">Warning</span> Tooltips examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites. By the way please check all the SVGs in your websites in order to apply this same modification if needed.
   <details class="mb-3">
     <summary>More info</summary>
     {{< markdown >}}
@@ -82,7 +82,6 @@ If you need more details about the changes, please refer to the [v5.2.1 release]
 ```
     {{< /markdown >}}
   </details>
-  By the way check all the SVGs in your websites in order to apply this same modification if needed.
 
 - The close icon SVG rendering has changed in modals, offcanvases and close buttons. Although is has no direct impact, you might want apply this same modification within your websites.
 

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -48,106 +48,114 @@ toc: true
 
 ### CSS and Sass variables
 
-- <span class="badge bg-info">New</span> Here is an exhaustive list of new CSS variables:
-  - `--bs-alert-btn-close-offset`
-  - `--bs-alert-dismissible-padding-right`
-  - `--bs-alert-heading-font-weight`
-  - `--bs-alert-icon-margin-y`
-  - `--bs-alert-icon-size`
-  - `--bs-alert-line-height`
-  - `--bs-alert-link-font-weight`
-  - `--bs-alert-logo-size`
-  - `--bs-breadcrumb-color`
-  - `--bs-btn-close-active-border-color`
-  - `--bs-btn-close-active-color`
-  - `--bs-btn-close-bg`
-  - `--bs-btn-close-border-color`
-  - `--bs-btn-close-border-width`
-  - `--bs-btn-close-color`
-  - `--bs-btn-close-disabled-color`
-  - `--bs-btn-close-hover-color`
-  - `--bs-btn-close-padding`
-  - `--bs-btn-hover-border-color`
-  - `--bs-dropdown-zindex`
-  - `--bs-highlight-color`
-  - `--bs-pagination-active-item-color`
-  - `--bs-pagination-padding-end`
-  - `--bs-tab-content-border-width`
-  - `--bs-tab-content-padding-x`
-  - `--bs-tab-content-padding-y`
-  - `--bs-nav-tabs-link-border-width`
-  - `--bs-nav-tabs-link-hover-bg`
-  - `--bs-nav-tabs-link-hover-color`
-  - `--bs-nav-tabs-link-padding-x`
-  - `--bs-navbar-font-weight`
-  - `--bs-navbar-toggler-icon-filter`
-  - `--bs-stepped-process-link-next-color`
-  - `--bs-toast-zindex`
+- <details>
+    <summary><span class="badge bg-info">New</span> CSS variables:</summary>
+    <ul>
+      <li><code>--bs-alert-btn-close-offset</code></li>
+      <li><code>--bs-alert-dismissible-padding-right</code></li>
+      <li><code>--bs-alert-heading-font-weight</code></li>
+      <li><code>--bs-alert-icon-margin-y</code></li>
+      <li><code>--bs-alert-icon-size</code></li>
+      <li><code>--bs-alert-line-height</code></li>
+      <li><code>--bs-alert-link-font-weight</code></li>
+      <li><code>--bs-alert-logo-size</code></li>
+      <li><code>--bs-breadcrumb-color</code></li>
+      <li><code>--bs-btn-close-active-border-color</code></li>
+      <li><code>--bs-btn-close-active-color</code></li>
+      <li><code>--bs-btn-close-bg</code></li>
+      <li><code>--bs-btn-close-border-color</code></li>
+      <li><code>--bs-btn-close-border-width</code></li>
+      <li><code>--bs-btn-close-color</code></li>
+      <li><code>--bs-btn-close-disabled-color</code></li>
+      <li><code>--bs-btn-close-hover-color</code></li>
+      <li><code>--bs-btn-close-padding</code></li>
+      <li><code>--bs-btn-hover-border-color</code></li>
+      <li><code>--bs-dropdown-zindex</code></li>
+      <li><code>--bs-highlight-color</code></li>
+      <li><code>--bs-pagination-active-item-color</code></li>
+      <li><code>--bs-pagination-padding-end</code></li>
+      <li><code>--bs-tab-content-border-width</code></li>
+      <li><code>--bs-tab-content-padding-x</code></li>
+      <li><code>--bs-tab-content-padding-y</code></li>
+      <li><code>--bs-nav-tabs-link-border-width</code></li>
+      <li><code>--bs-nav-tabs-link-hover-bg</code></li>
+      <li><code>--bs-nav-tabs-link-hover-color</code></li>
+      <li><code>--bs-nav-tabs-link-padding-x</code></li>
+      <li><code>--bs-navbar-font-weight</code></li>
+      <li><code>--bs-navbar-toggler-icon-filter</code></li>
+      <li><code>--bs-stepped-process-link-next-color</code></li>
+      <li><code>--bs-toast-zindex</code></li>
+    </ul>
+  </details>
 
-- <span class="badge bg-info">New</span> Here is an exhaustive list of new Sass variables:
-  - `$alert-heading-font-weight`
-  - `$alert-icon-size-sm`
-  - `$breadcrumb-color`
-  - `$breadcrumb-dark-active-color`
-  - `$breadcrumb-dark-bg`
-  - `$breadcrumb-dark-color`
-  - `$breadcrumb-dark-divider-color`
-  - `$btn-close-active-border-color`
-  - `$btn-close-active-color`
-  - `$btn-close-border-color`
-  - `$btn-close-border-width`
-  - `$btn-close-disabled-color`
-  - `$btn-close-hover-color`
-  - `$btn-close-white-active-border-color`
-  - `$btn-close-white-active-color`
-  - `$btn-close-white-bg`
-  - `$btn-close-white-border-color`
-  - `$btn-close-white-color`
-  - `$btn-close-white-disabled-color`
-  - `$btn-close-white-hover-color`
-  - `$list-group-dark-action-active-bg`
-  - `$list-group-dark-action-active-color`
-  - `$list-group-dark-action-color`
-  - `$list-group-dark-action-hover-color`
-  - `$list-group-dark-active-bg`
-  - `$list-group-dark-active-border-color`
-  - `$list-group-dark-active-color`
-  - `$list-group-dark-bg`
-  - `$list-group-dark-border-color`
-  - `$list-group-dark-color`
-  - `$list-group-dark-disabled-bg`
-  - `$list-group-dark-disabled-color`
-  - `$mark-bg-dark`
-  - `$mark-color`
-  - `$mark-color-dark`
-  - `$navbar-dark-border-color`
-  - `$navbar-font-weight`
-  - `$pagination-active-item-color`
-  - `$pagination-dark-active-bg`
-  - `$pagination-dark-active-border-color`
-  - `$pagination-dark-active-color`
-  - `$pagination-dark-active-item-bg`
-  - `$pagination-dark-active-item-border-color`
-  - `$pagination-dark-active-item-color`
-  - `$pagination-dark-bg`
-  - `$pagination-dark-border-color`
-  - `$pagination-dark-color`
-  - `$pagination-dark-disabled-bg`
-  - `$pagination-dark-disabled-border-color`
-  - `$pagination-dark-disabled-color`
-  - `$pagination-dark-focus-bg`
-  - `$pagination-dark-focus-color`
-  - `$pagination-dark-hover-bg`
-  - `$pagination-dark-hover-border-color`
-  - `$pagination-dark-hover-color`
-  - `$step-item-dark-active-bg`
-  - `$step-item-dark-bg`
-  - `$step-item-dark-drop-shadow`
-  - `$step-item-dark-next-bg`
-  - `$step-link-dark-active-color`
-  - `$step-link-dark-color`
-  - `$step-link-dark-next-color`
-  - `$step-link-next-color`
+- <details>
+    <summary><span class="badge bg-info">New</span> Sass variables:</summary>
+    <ul>
+      <li><code>$alert-heading-font-weight</code></li>
+      <li><code>$alert-icon-size-sm</code></li>
+      <li><code>$breadcrumb-color</code></li>
+      <li><code>$breadcrumb-dark-active-color</code></li>
+      <li><code>$breadcrumb-dark-bg</code></li>
+      <li><code>$breadcrumb-dark-color</code></li>
+      <li><code>$breadcrumb-dark-divider-color</code></li>
+      <li><code>$btn-close-active-border-color</code></li>
+      <li><code>$btn-close-active-color</code></li>
+      <li><code>$btn-close-border-color</code></li>
+      <li><code>$btn-close-border-width</code></li>
+      <li><code>$btn-close-disabled-color</code></li>
+      <li><code>$btn-close-hover-color</code></li>
+      <li><code>$btn-close-white-active-border-color</code></li>
+      <li><code>$btn-close-white-active-color</code></li>
+      <li><code>$btn-close-white-bg</code></li>
+      <li><code>$btn-close-white-border-color</code></li>
+      <li><code>$btn-close-white-color</code></li>
+      <li><code>$btn-close-white-disabled-color</code></li>
+      <li><code>$btn-close-white-hover-color</code></li>
+      <li><code>$list-group-dark-action-active-bg</code></li>
+      <li><code>$list-group-dark-action-active-color</code></li>
+      <li><code>$list-group-dark-action-color</code></li>
+      <li><code>$list-group-dark-action-hover-color</code></li>
+      <li><code>$list-group-dark-active-bg</code></li>
+      <li><code>$list-group-dark-active-border-color</code></li>
+      <li><code>$list-group-dark-active-color</code></li>
+      <li><code>$list-group-dark-bg</code></li>
+      <li><code>$list-group-dark-border-color</code></li>
+      <li><code>$list-group-dark-color</code></li>
+      <li><code>$list-group-dark-disabled-bg</code></li>
+      <li><code>$list-group-dark-disabled-color</code></li>
+      <li><code>$mark-bg-dark</code></li>
+      <li><code>$mark-color</code></li>
+      <li><code>$mark-color-dark</code></li>
+      <li><code>$navbar-dark-border-color</code></li>
+      <li><code>$navbar-font-weight</code></li>
+      <li><code>$pagination-active-item-color</code></li>
+      <li><code>$pagination-dark-active-bg</code></li>
+      <li><code>$pagination-dark-active-border-color</code></li>
+      <li><code>$pagination-dark-active-color</code></li>
+      <li><code>$pagination-dark-active-item-bg</code></li>
+      <li><code>$pagination-dark-active-item-border-color</code></li>
+      <li><code>$pagination-dark-active-item-color</code></li>
+      <li><code>$pagination-dark-bg</code></li>
+      <li><code>$pagination-dark-border-color</code></li>
+      <li><code>$pagination-dark-color</code></li>
+      <li><code>$pagination-dark-disabled-bg</code></li>
+      <li><code>$pagination-dark-disabled-border-color</code></li>
+      <li><code>$pagination-dark-disabled-color</code></li>
+      <li><code>$pagination-dark-focus-bg</code></li>
+      <li><code>$pagination-dark-focus-color</code></li>
+      <li><code>$pagination-dark-hover-bg</code></li>
+      <li><code>$pagination-dark-hover-border-color</code></li>
+      <li><code>$pagination-dark-hover-color</code></li>
+      <li><code>$step-item-dark-active-bg</code></li>
+      <li><code>$step-item-dark-bg</code></li>
+      <li><code>$step-item-dark-drop-shadow</code></li>
+      <li><code>$step-item-dark-next-bg</code></li>
+      <li><code>$step-link-dark-active-color</code></li>
+      <li><code>$step-link-dark-color</code></li>
+      <li><code>$step-link-dark-next-color</code></li>
+      <li><code>$step-link-next-color</code></li>
+    </ul>
+  </details>
 
 - <span class="badge bg-danger">Breaking</span> `--bs-pagination-margin-start` and `--bs-pagination-focus-outline` are now deprecated.
 

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,10 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
+  * feat(utilities): revamp `.img-thumbnail` and add desc in docs
+    - Revamp rendering of `.img-thumbnail`
+    - Add a new section in the Content > Images > Image thumbnails docs
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1441
   * doc(examples): remove Bootstrap examples unused in Boosted
     - Mainly removed the files. No impact for the user. Only concerns the docs.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1542

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,7 +19,10 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
-  * fix(forms): fix(forms): prevent that valid icon hides input content
+  * fix(icons): use the right close icon
+    - Change the SVG of the close icon used in modal, offcanvas and close buttons
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1566
+  * fix(forms): prevent that valid icon hides input content
     - Valid icons don't hide anymore content in inputs when too long
     - Quantity selector doesn't display valid icon anymore
     - .form-control-color display the valid icon correctly and doesn't change its width when invalid

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -80,7 +80,7 @@ If you need more details about the changes, please refer to the [v5.2.1 release]
       {{< /markdown >}}
     </details>
 
-### Content
+### Contents
 
 - <span class="badge bg-warning">Warning</span> Changed the rendering of `<mark>` (and so `.mark`). Depending on your usage it may worth checking the impact in your websites.
 

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -16,20 +16,20 @@ toc: true
 ### Components
 
 <!-- * fix(back to top): remove 'Label inside' variant (#1520) -->
-- <span class="badge bg-danger align-text-top">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
+- <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!--
   * fix(footers): change 'Terms & Conditions' to 'Terms and conditions'
     This information is important for the users in order to change the label they could have used
     Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1564
 -->
-- <span class="badge bg-warning align-text-top">Warning</span> All **Footers** examples have been modified to use the "Terms and conditions" wording instead of "Terms & Conditions". Please reflect this modification into your websites.
+- <span class="badge bg-warning">Warning</span> All **Footers** examples have been modified to use the "Terms and conditions" wording instead of "Terms & Conditions". Please reflect this modification into your websites.
 
 <!--
   * feat(components): new Tags component
     Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/988
 -->
-- <span class="badge bg-info align-text-top">New</span> **Tags** component.
+- <span class="badge bg-info">New</span> **Tags** component.
 
 ### Icons and images
 
@@ -39,7 +39,7 @@ toc: true
   - In addition, replaced the missing 'focusable=false' on the first svg
     Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1555
 -->
-- <span class="badge bg-warning align-text-top">Warning</span> **Tooltips** examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites.
+- <span class="badge bg-warning">Warning</span> **Tooltips** examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites.
 
 <!--
 * fix(icons): use the right close icon
@@ -50,11 +50,11 @@ toc: true
 
 ### Helpers
 
-- <span class="badge bg-info align-text-top">New</span> `.img-thumbnail` officially supported.
+- <span class="badge bg-info">New</span> `.img-thumbnail` officially supported.
 
 ### CSS and Sass variables
 
-- <span class="badge bg-info align-text-top">New</span> Here is an exhaustive list of new CSS variables:
+- <span class="badge bg-info">New</span> Here is an exhaustive list of new CSS variables:
   - `--bs-alert-btn-close-offset`
   - `--bs-alert-dismissible-padding-right`
   - `--bs-alert-heading-font-weight`
@@ -63,22 +63,38 @@ toc: true
   - `--bs-alert-line-height`
   - `--bs-alert-link-font-weight`
   - `--bs-alert-logo-size`
+  - `--bs-btn-close-active-border-color`
+  - `--bs-btn-close-active-color`
+  - `--bs-btn-close-bg`
+  - `--bs-btn-close-border-color`
+  - `--bs-btn-close-border-width`
+  - `--bs-btn-close-color`
+  - `--bs-btn-close-disabled-color`
+  - `--bs-btn-close-hover-color`
+  - `--bs-btn-close-padding`
   - `--bs-navbar-font-weight`
   - `--bs-navbar-toggler-icon-filter`
-- Dark text variants handling is now explained in [Customize > CSS variables > Dark text rule](https://boosted.orange.com/docs/5.2/customize/css-variables/#dark-text-rule).
-
-- <span class="badge bg-info align-text-top">New</span> Here is an exhaustive list of new Sass variables:
+- <span class="badge bg-info">New</span> Here is an exhaustive list of new Sass variables:
   - `$alert-heading-font-weight`
   - `$alert-icon-size-sm`
+  - `$btn-close-active-border-color`
+  - `$btn-close-active-color`
+  - `$btn-close-border-color`
+  - `$btn-close-border-width`
+  - `$btn-close-disabled-color`
+  - `$btn-close-hover-color`
+  - `$btn-close-white-active-border-color`
+  - `$btn-close-white-active-color`
+  - `$btn-close-white-bg`
+  - `$btn-close-white-border-color`
+  - `$btn-close-white-color`
+  - `$btn-close-white-disabled-color`
+  - `$btn-close-white-hover-color`
   - `$navbar-font-weight`
+- Dark text variants handling is now explained in [Customize > CSS variables > Dark text rule](https://boosted.orange.com/docs/5.2/customize/css-variables/#dark-text-rule).
 
 <!--
 ### TODO
-  * feat(css): add CSS vars for Close button
-    - Several new `#{$prefix}btn-close-*` CSS variables
-    - Several new `$btn-close-*` Sass variables
-    - Creation of new `$btn-close-white-*` Sass variables
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1531
   * feat(css): add CSS vars to handle `.nav-tabs-light` and `.tab-content`
     - New #{$prefix}nav-tabs-link-hover-color, #{$prefix}nav-tabs-link-hover-bg, #{$prefix}nav-tabs-link-border-width CSS variables
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1427
@@ -708,7 +724,7 @@ Your custom Boosted CSS builds should now look something like this with a separa
 
 - Added [striped columns]({{< docsref "/content/tables#striped-columns" >}}) support to tables via the new `.table-striped-columns` class.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Changed `data-o-label` to `data-bs-label` in Back to top component.
+- <span class="badge bg-danger">Breaking</span> Changed `data-o-label` to `data-bs-label` in Back to top component.
 
 For a complete list of changes, [see the v5.2.0 project on GitHub](https://github.com/twbs/bootstrap/projects/32).
 
@@ -776,27 +792,27 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - We've ditched the default Sass map merges to make it easier to remove redundant values. Keep in mind you now have to define all values in the Sass maps like `$theme-colors`. Check out how to deal with [Sass maps]({{< docsref "/customize/sass#maps-and-loops" >}}).
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `color-yiq()` function and related variables to `color-contrast()` as it's no longer related to YIQ color space. [See #30168.](https://github.com/twbs/bootstrap/pull/30168/)
+- <span class="badge bg-danger">Breaking</span> Renamed `color-yiq()` function and related variables to `color-contrast()` as it's no longer related to YIQ color space. [See #30168.](https://github.com/twbs/bootstrap/pull/30168/)
   - `$yiq-contrasted-threshold` is renamed to `$min-contrast-ratio`.
   - `$yiq-text-dark` and `$yiq-text-light` are respectively renamed to `$color-contrast-dark` and `$color-contrast-light`.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Media query mixins parameters have changed for a more logical approach.
+- <span class="badge bg-danger">Breaking</span> Media query mixins parameters have changed for a more logical approach.
   - `media-breakpoint-down()` uses the breakpoint itself instead of the next breakpoint (e.g., `media-breakpoint-down(lg)` instead of `media-breakpoint-down(md)` targets viewports smaller than `lg`).
   - Similarly, the second parameter in `media-breakpoint-between()` also uses the breakpoint itself instead of the next breakpoint (e.g., `media-between(sm, lg)` instead of `media-breakpoint-between(sm, md)` targets viewports between `sm` and `lg`).
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Removed print styles and `$enable-print-styles` variable. Print display classes are still around. [See #28339](https://github.com/twbs/bootstrap/pull/28339).
+- <span class="badge bg-danger">Breaking</span> Removed print styles and `$enable-print-styles` variable. Print display classes are still around. [See #28339](https://github.com/twbs/bootstrap/pull/28339).
 
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `color()`, `theme-color()`, and `gray()` functions in favor of variables. [See #29083](https://github.com/twbs/bootstrap/pull/29083).
+- <span class="badge bg-danger">Breaking</span> Dropped `color()`, `theme-color()`, and `gray()` functions in favor of variables. [See #29083](https://github.com/twbs/bootstrap/pull/29083).
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `theme-color-level()` function to `color-level()` and now accepts any color you want instead of only `$theme-color` colors. [See #29083](https://github.com/twbs/bootstrap/pull/29083) **Watch out:** `color-level()` was later on dropped in `v5.0.0-alpha3`.
+- <span class="badge bg-danger">Breaking</span> Renamed `theme-color-level()` function to `color-level()` and now accepts any color you want instead of only `$theme-color` colors. [See #29083](https://github.com/twbs/bootstrap/pull/29083) **Watch out:** `color-level()` was later on dropped in `v5.0.0-alpha3`.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `$enable-prefers-reduced-motion-media-query` and `$enable-pointer-cursor-for-buttons` to `$enable-reduced-motion` and `$enable-button-pointers` for brevity.
+- <span class="badge bg-danger">Breaking</span> Renamed `$enable-prefers-reduced-motion-media-query` and `$enable-pointer-cursor-for-buttons` to `$enable-reduced-motion` and `$enable-button-pointers` for brevity.
 
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Removed the `bg-gradient-variant()` mixin. Use the `.bg-gradient` class to add gradients to elements instead of the generated `.bg-gradient-*` classes.
+- <span class="badge bg-danger">Breaking</span> Removed the `bg-gradient-variant()` mixin. Use the `.bg-gradient` class to add gradients to elements instead of the generated `.bg-gradient-*` classes.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> **Removed previously deprecated mixins:**
+- <span class="badge bg-danger">Breaking</span> **Removed previously deprecated mixins:**
   - `hover`, `hover-focus`, `plain-hover-focus`, and `hover-focus-active`
   - `float()`
   - `form-control-mixin()`
@@ -806,7 +822,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
   - `visibility()`
   - `form-control-focus()`
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `scale-color()` function to `shift-color()` to avoid collision with Sass's own color scaling function.
+- <span class="badge bg-danger">Breaking</span> Renamed `scale-color()` function to `shift-color()` to avoid collision with Sass's own color scaling function.
 
 - `box-shadow` mixins now allow `null` values and drop `none` from multiple arguments. [See #30394](https://github.com/twbs/bootstrap/pull/30394).
 
@@ -828,15 +844,15 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - **Improved gutters.** Gutters are now set in rems, and are narrower than v4 (`1.5rem`, or about `24px`, down from `30px`). This aligns our grid system's gutters with our spacing utilities.
   - Added new [gutter class](/docs/{{< param docs_version >}}/layout/gutters/) (`.g-*`, `.gx-*`, and `.gy-*`) to control horizontal/vertical gutters, horizontal gutters, and vertical gutters.
-  - <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.no-gutters` to `.g-0` to match new gutter utilities.
+  - <span class="badge bg-danger">Breaking</span> Renamed `.no-gutters` to `.g-0` to match new gutter utilities.
 
 - Columns no longer have `position: relative` applied, so you may have to add `.position-relative` to some elements to restore that behavior.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped several `.order-*` classes that often went unused. We now only provide `.order-1` to `.order-5` out of the box.
+- <span class="badge bg-danger">Breaking</span> Dropped several `.order-*` classes that often went unused. We now only provide `.order-1` to `.order-5` out of the box.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped the `.media` component as it can be easily replicated with utilities. [See #28265](https://github.com/twbs/bootstrap/pull/28265) and the [flex utilities page for an example]({{< docsref "/utilities/flex#media-object" >}}).
+- <span class="badge bg-danger">Breaking</span> Dropped the `.media` component as it can be easily replicated with utilities. [See #28265](https://github.com/twbs/bootstrap/pull/28265) and the [flex utilities page for an example]({{< docsref "/utilities/flex#media-object" >}}).
 
-- <span class="badge bg-danger align-text-top">Breaking</span> `boosted-grid.css` now only applies `box-sizing: border-box` to the column instead of resetting the global box-sizing. This way, our grid styles can be used in more places without interference.
+- <span class="badge bg-danger">Breaking</span> `boosted-grid.css` now only applies `box-sizing: border-box` to the column instead of resetting the global box-sizing. This way, our grid styles can be used in more places without interference.
 
 - `$enable-grid-classes` no longer disables the generation of container classes anymore. [See #29146.](https://github.com/twbs/bootstrap/pull/29146)
 
@@ -844,11 +860,11 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ## Content, Reboot, etc
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Orange Helvetica CSS file names changed from `orangeHelvetica.*.css` to `orange-helvetica.*.css`.
+- <span class="badge bg-danger">Breaking</span> Orange Helvetica CSS file names changed from `orangeHelvetica.*.css` to `orange-helvetica.*.css`.
 
 - **[RFS]({{< docsref "/getting-started/rfs" >}}) is now enabled by default.** Headings using the `font-size()` mixin will automatically adjust their `font-size` to scale with the viewport. _This feature was previously opt-in with v4._
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Overhauled our display typography to replace our `$display-*` variables and with a `$display-font-sizes` Sass map. Also removed the individual `$display-*-weight` variables for a single `$display-font-weight` and adjusted `font-size`s.
+- <span class="badge bg-danger">Breaking</span> Overhauled our display typography to replace our `$display-*` variables and with a `$display-font-sizes` Sass map. Also removed the individual `$display-*-weight` variables for a single `$display-font-weight` and adjusted `font-size`s.
 
 - Added two new `.display-*` heading sizes, `.display-5` and `.display-6`.
 
@@ -856,21 +872,21 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - **Redesigned tables** to refresh their styles and rebuild them with CSS variables for more control over styling.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Nested tables do not inherit styles anymore.
+- <span class="badge bg-danger">Breaking</span> Nested tables do not inherit styles anymore.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> `.thead-light` and `.thead-dark` are dropped in favor of the `.table-*` variant classes which can be used for all table elements (`thead`, `tbody`, `tfoot`, `tr`, `th` and `td`).
+- <span class="badge bg-danger">Breaking</span> `.thead-light` and `.thead-dark` are dropped in favor of the `.table-*` variant classes which can be used for all table elements (`thead`, `tbody`, `tfoot`, `tr`, `th` and `td`).
 
-- <span class="badge bg-danger align-text-top">Breaking</span> The `table-row-variant()` mixin is renamed to `table-variant()` and accepts only 2 parameters: `$color` (color name) and `$value` (color code). The border color and accent colors are automatically calculated based on the table factor variables.
+- <span class="badge bg-danger">Breaking</span> The `table-row-variant()` mixin is renamed to `table-variant()` and accepts only 2 parameters: `$color` (color name) and `$value` (color code). The border color and accent colors are automatically calculated based on the table factor variables.
 
 - Split table cell padding variables into `-y` and `-x`.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `.pre-scrollable` class. [See #29135](https://github.com/twbs/bootstrap/pull/29135)
+- <span class="badge bg-danger">Breaking</span> Dropped `.pre-scrollable` class. [See #29135](https://github.com/twbs/bootstrap/pull/29135)
 
-- <span class="badge bg-danger align-text-top">Breaking</span> `.text-*` utilities do not add hover and focus states to links anymore. `.link-*` helper classes can be used instead. [See #29267](https://github.com/twbs/bootstrap/pull/29267)
+- <span class="badge bg-danger">Breaking</span> `.text-*` utilities do not add hover and focus states to links anymore. `.link-*` helper classes can be used instead. [See #29267](https://github.com/twbs/bootstrap/pull/29267)
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `.text-justify` class. [See #29793](https://github.com/twbs/bootstrap/pull/29793)
+- <span class="badge bg-danger">Breaking</span> Dropped `.text-justify` class. [See #29793](https://github.com/twbs/bootstrap/pull/29793)
 
-- <span class="badge bg-danger align-text-top">Breaking</span> ~~`<hr>` elements now use `height` instead of `border` to better support the `size` attribute. This also enables use of padding utilities to create thicker dividers (e.g., `<hr class="py-1">`).~~
+- <span class="badge bg-danger">Breaking</span> ~~`<hr>` elements now use `height` instead of `border` to better support the `size` attribute. This also enables use of padding utilities to create thicker dividers (e.g., `<hr class="py-1">`).~~
 
 - Reset default horizontal `padding-left` on `<ul>` and `<ol>` elements from browser default `40px` to `2rem`.
 
@@ -884,7 +900,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 <!--- Boosted mod: no floating labels -->
 
-- <span class="badge bg-danger align-text-top">Breaking</span> **Consolidated native and custom form elements.** Checkboxes, radios, selects, and other inputs that had native and custom classes in v4 have been consolidated. Now nearly all our form elements are entirely custom, most without the need for custom HTML.
+- <span class="badge bg-danger">Breaking</span> **Consolidated native and custom form elements.** Checkboxes, radios, selects, and other inputs that had native and custom classes in v4 have been consolidated. Now nearly all our form elements are entirely custom, most without the need for custom HTML.
   - `.custom-control.custom-checkbox` is now `.form-check`.
   - `.custom-control.custom-custom-radio` is now `.form-check`.
   - `.custom-control.custom-switch` is now `.form-check.form-switch`.
@@ -893,15 +909,15 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
   - `.custom-range` is now `.form-range`.
   - Dropped native `.form-control-file` and `.form-control-range`.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `.input-group-append` and `.input-group-prepend`. You can now just add buttons and `.input-group-text` as direct children of the input groups.
+- <span class="badge bg-danger">Breaking</span> Dropped `.input-group-append` and `.input-group-prepend`. You can now just add buttons and `.input-group-text` as direct children of the input groups.
 
 - The longstanding [Missing border radius on input group with validation feedback bug](https://github.com/twbs/bootstrap/issues/25110) is finally fixed by adding an additional `.has-validation` class to input groups with validation.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> **Dropped form-specific layout classes for our grid system.** Use our grid and utilities instead of `.form-group`, `.form-row`, or `.form-inline`.
+- <span class="badge bg-danger">Breaking</span> **Dropped form-specific layout classes for our grid system.** Use our grid and utilities instead of `.form-group`, `.form-row`, or `.form-inline`.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Form labels now require `.form-label`.
+- <span class="badge bg-danger">Breaking</span> Form labels now require `.form-label`.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> `.form-text` no longer sets `display`, allowing you to create inline or block help text as you wish just by changing the HTML element.
+- <span class="badge bg-danger">Breaking</span> `.form-text` no longer sets `display`, allowing you to create inline or block help text as you wish just by changing the HTML element.
 
 - Form controls no longer used fixed `height` when possible, instead deferring to `min-height` to improve customization and compatibility with other components.
 
@@ -927,11 +943,11 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Badges
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped all `.badge-*` color classes for background utilities (e.g., use `.bg-primary` instead of `.badge-primary`).
+- <span class="badge bg-danger">Breaking</span> Dropped all `.badge-*` color classes for background utilities (e.g., use `.bg-primary` instead of `.badge-primary`).
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `.badge-pill`—use the `.rounded-pill` utility instead.
+- <span class="badge bg-danger">Breaking</span> Dropped `.badge-pill`—use the `.rounded-pill` utility instead.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Removed hover and focus styles for `<a>` and `<button>` elements.
+- <span class="badge bg-danger">Breaking</span> Removed hover and focus styles for `<a>` and `<button>` elements.
 
 - Increased default padding for badges from `.25em`/`.5em` to `.35em`/`.65em`.
 
@@ -943,9 +959,9 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Buttons
 
-- <span class="badge bg-danger align-text-top">Breaking</span> **[Toggle buttons](/docs/{{< param docs_version >}}/forms/checks-radios/#toggle-buttons), with checkboxes or radios, no longer require JavaScript and have new markup.** We no longer require a wrapping element, add `.btn-check` to the `<input>`, and pair it with any `.btn` classes on the `<label>`. [See #30650](https://github.com/twbs/bootstrap/pull/30650). _The docs for this has moved from our Buttons page to the new Forms section._
+- <span class="badge bg-danger">Breaking</span> **[Toggle buttons](/docs/{{< param docs_version >}}/forms/checks-radios/#toggle-buttons), with checkboxes or radios, no longer require JavaScript and have new markup.** We no longer require a wrapping element, add `.btn-check` to the `<input>`, and pair it with any `.btn` classes on the `<label>`. [See #30650](https://github.com/twbs/bootstrap/pull/30650). _The docs for this has moved from our Buttons page to the new Forms section._
 
-- <span class="badge bg-danger align-text-top">Breaking</span> **Dropped `.btn-block` for utilities.** Instead of using `.btn-block` on the `.btn`, wrap your buttons with `.d-grid` and a `.gap-*` utility to space them as needed. Switch to responsive classes for even more control over them. [Read the docs for some examples.](/docs/{{< param docs_version >}}/components/buttons/#block-buttons)
+- <span class="badge bg-danger">Breaking</span> **Dropped `.btn-block` for utilities.** Instead of using `.btn-block` on the `.btn`, wrap your buttons with `.d-grid` and a `.gap-*` utility to space them as needed. Switch to responsive classes for even more control over them. [Read the docs for some examples.](/docs/{{< param docs_version >}}/components/buttons/#block-buttons)
 
 - Updated our `button-variant()` and `button-outline-variant()` mixins to support additional parameters.
 
@@ -955,11 +971,11 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Card
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `.card-deck` in favor of our grid. Wrap your cards in column classes and add a parent `.row-cols-*` container to recreate card decks (but with more control over responsive alignment).
+- <span class="badge bg-danger">Breaking</span> Dropped `.card-deck` in favor of our grid. Wrap your cards in column classes and add a parent `.row-cols-*` container to recreate card decks (but with more control over responsive alignment).
 
 - [#31035](https://github.com/twbs/bootstrap/pull/31035): Added new `null` variables for `font-size`, `font-weight`, `color`, and `:hover` `color` to the `.nav-link` class.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Replaced the `.card` based accordion with a [new Accordion component]({{< docsref "/components/accordion" >}}).
+- <span class="badge bg-danger">Breaking</span> Replaced the `.card` based accordion with a [new Accordion component]({{< docsref "/components/accordion" >}}).
 
 ### Carousel
 
@@ -969,7 +985,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Close button
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.close` to `.btn-close` for a less generic name.
+- <span class="badge bg-danger">Breaking</span> Renamed `.close` to `.btn-close` for a less generic name.
 
 - Close buttons now use a `background-image` (embedded SVG) instead of a `&times;` in the HTML, allowing for easier customization without the need to touch your markup.
 
@@ -987,11 +1003,11 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - Darkened the dropdown divider for improved contrast.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> All the events for the dropdown are now triggered on the dropdown toggle button and then bubbled up to the parent element.
+- <span class="badge bg-danger">Breaking</span> All the events for the dropdown are now triggered on the dropdown toggle button and then bubbled up to the parent element.
 
 - Dropdown menus now have a `data-bs-popper="static"` attribute set when the positioning of the dropdown is static, or dropdown is in the navbar. This is added by our JavaScript and helps us use custom position styles without interfering with Popper's positioning.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `flip` option for dropdown plugin in favor of native Popper configuration. You can now disable the flipping behavior by passing an empty array for [`fallbackPlacements`](https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements) option in [flip](https://popper.js.org/docs/v2/modifiers/flip/) modifier.
+- <span class="badge bg-danger">Breaking</span> Dropped `flip` option for dropdown plugin in favor of native Popper configuration. You can now disable the flipping behavior by passing an empty array for [`fallbackPlacements`](https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements) option in [flip](https://popper.js.org/docs/v2/modifiers/flip/) modifier.
 
 - Dropdown menus can now be clickable with a new `autoClose` option to handle the [auto close behavior]({{< docsref "/components/dropdowns#auto-close-behavior" >}}). You can use this option to accept the click inside or outside the dropdown menu to make it interactive.
 
@@ -999,11 +1015,11 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Footer
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Footers' HTML structure changed a lot as it works now with sub-components. They don't require `.o-footer-*` classes anymore, they need [`.footer-*` classes]({{< docsref "/components/footer" >}}).
+- <span class="badge bg-danger">Breaking</span> Footers' HTML structure changed a lot as it works now with sub-components. They don't require `.o-footer-*` classes anymore, they need [`.footer-*` classes]({{< docsref "/components/footer" >}}).
 
 ### Jumbotron
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Dropped the jumbotron component as it can be replicated with utilities.
+- <span class="badge bg-danger">Breaking</span> Dropped the jumbotron component as it can be replicated with utilities.
 
 ### List group
 
@@ -1015,8 +1031,8 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Navbars
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Navbars now require a container within (to drastically simplify spacing requirements and CSS required).
-- <span class="badge bg-danger align-text-top">Breaking</span> The `.active` class can no longer be applied to `.nav-item`s, it must be applied directly on `.nav-link`s.
+- <span class="badge bg-danger">Breaking</span> Navbars now require a container within (to drastically simplify spacing requirements and CSS required).
+- <span class="badge bg-danger">Breaking</span> The `.active` class can no longer be applied to `.nav-item`s, it must be applied directly on `.nav-link`s.
 
 ### Offcanvas
 
@@ -1024,7 +1040,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Orange navbar
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Supra bars now require a `.bg-dark` class.
+- <span class="badge bg-danger">Breaking</span> Supra bars now require a `.bg-dark` class.
 
 - Removed the `.global` class for the instantiation of global headers. You just need to declare your navbar with default `.navbar-*` classes.
 
@@ -1040,7 +1056,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Popovers
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.arrow` to `.popover-arrow` in our default popover template.
+- <span class="badge bg-danger">Breaking</span> Renamed `.arrow` to `.popover-arrow` in our default popover template.
 
 - Renamed `whiteList` option to `allowList`.
 
@@ -1060,15 +1076,15 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Tooltips
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.arrow` to `.tooltip-arrow` in our default tooltip template.
+- <span class="badge bg-danger">Breaking</span> Renamed `.arrow` to `.tooltip-arrow` in our default tooltip template.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> The default value for the `fallbackPlacements` is changed to `['top', 'right', 'bottom', 'left']` for better placement of popper elements.
+- <span class="badge bg-danger">Breaking</span> The default value for the `fallbackPlacements` is changed to `['top', 'right', 'bottom', 'left']` for better placement of popper elements.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `whiteList` option to `allowList`.
+- <span class="badge bg-danger">Breaking</span> Renamed `whiteList` option to `allowList`.
 
 ## Utilities
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed several utilities to use logical property names instead of directional names with the addition of RTL support:
+- <span class="badge bg-danger">Breaking</span> Renamed several utilities to use logical property names instead of directional names with the addition of RTL support:
   - Renamed `.left-*` and `.right-*` to `.start-*` and `.end-*`.
   - Renamed `.float-left` and `.float-right` to `.float-start` and `.float-end`.
   - Renamed `.border-left` and `.border-right` to `.border-start` and `.border-end`.
@@ -1077,7 +1093,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
   - Renamed `.pl-*` and `.pr-*` to `.ps-*` and `.pe-*`.
   - Renamed `.text-left` and `.text-right` to `.text-start` and `.text-end`.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Disabled negative margins by default.
+- <span class="badge bg-danger">Breaking</span> Disabled negative margins by default.
 
 - Added new `.bg-body` class for quickly setting the `<body>`'s background to additional elements.
 
@@ -1087,19 +1103,19 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - Added new [`border-width` utilities]({{< docsref "/utilities/borders#border-width" >}}).
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.text-monospace` to `.font-monospace`.
+- <span class="badge bg-danger">Breaking</span> Renamed `.text-monospace` to `.font-monospace`.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Removed `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore.
+- <span class="badge bg-danger">Breaking</span> Removed `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore.
 
 - Added `.fs-*` utilities for `font-size` utilities (with RFS enabled). These use the same scale as HTML's default headings (1-6, large to small), and can be modified via Sass map.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.font-weight-*` utilities as `.fw-*` for brevity and consistency.
+- <span class="badge bg-danger">Breaking</span> Renamed `.font-weight-*` utilities as `.fw-*` for brevity and consistency.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.font-style-*` utilities as `.fst-*` for brevity and consistency.
+- <span class="badge bg-danger">Breaking</span> Renamed `.font-style-*` utilities as `.fst-*` for brevity and consistency.
 
 - Added `.d-grid` to display utilities and new `gap` utilities (`.gap`) for CSS Grid and flexbox layouts.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Removed `.rounded-sm` and `rounded-lg`, and introduced a new scale of classes, `.rounded-0` to `.rounded-3`. [See #31687](https://github.com/twbs/bootstrap/pull/31687).
+- <span class="badge bg-danger">Breaking</span> Removed `.rounded-sm` and `rounded-lg`, and introduced a new scale of classes, `.rounded-0` to `.rounded-3`. [See #31687](https://github.com/twbs/bootstrap/pull/31687).
 
 - Added new `line-height` utilities: `.lh-1`, `.lh-sm`, `.lh-base` and `.lh-lg`. See [here]({{< docsref "/utilities/text#line-height" >}}).
 
@@ -1109,13 +1125,13 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ## Helpers
 
-- <span class="badge bg-danger align-text-top">Breaking</span> **Responsive embed helpers have been renamed to [ratio helpers]({{< docsref "/helpers/ratio" >}})** with new class names and improved behaviors, as well as a helpful CSS variable.
+- <span class="badge bg-danger">Breaking</span> **Responsive embed helpers have been renamed to [ratio helpers]({{< docsref "/helpers/ratio" >}})** with new class names and improved behaviors, as well as a helpful CSS variable.
   - Classes have been renamed to change `by` to `x` in the aspect ratio. For example, `.ratio-16by9` is now `.ratio-16x9`.
   - We've dropped the `.embed-responsive-item` and element group selector in favor of a simpler `.ratio > *` selector. No more class is needed, and the ratio helper now works with any HTML element.
   - The `$embed-responsive-aspect-ratios` Sass map has been renamed to `$aspect-ratios` and its values have been simplified to include the class name and the percentage as the `key: value` pair.
   - CSS variables are now generated and included for each value in the Sass map. Modify the `--bs-aspect-ratio` variable on the `.ratio` to create any [custom aspect ratio]({{< docsref "/helpers/ratio#custom-ratios" >}}).
 
-- <span class="badge bg-danger align-text-top">Breaking</span> **"Screen reader" classes are now ["visually hidden" classes]({{< docsref "/helpers/visually-hidden" >}}).**
+- <span class="badge bg-danger">Breaking</span> **"Screen reader" classes are now ["visually hidden" classes]({{< docsref "/helpers/visually-hidden" >}}).**
   - Changed the Sass file from `scss/helpers/_screenreaders.scss` to `scss/helpers/_visually-hidden.scss`
   - Renamed `.sr-only` and `.sr-only-focusable` to `.visually-hidden` and `.visually-hidden-focusable`
   - Renamed `sr-only()` and `sr-only-focusable()` mixins to `visually-hidden()` and `visually-hidden-focusable()`.
@@ -1126,7 +1142,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - **Dropped jQuery dependency** and rewrote plugins to be in regular JavaScript.
 
-- <span class="badge bg-danger align-text-top">Breaking</span> Data attributes for all JavaScript plugins are now namespaced to help distinguish Boosted functionality from third parties and your own code. For example, we use `data-bs-toggle` instead of `data-toggle`.
+- <span class="badge bg-danger">Breaking</span> Data attributes for all JavaScript plugins are now namespaced to help distinguish Boosted functionality from third parties and your own code. For example, we use `data-bs-toggle` instead of `data-toggle`.
 
 - **All plugins can now accept a CSS selector as the first argument.** You can either pass a DOM element or any valid CSS selector to create a new instance of the plugin:
 

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,8 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
+  * feat(components): new Tags component
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/988
   * fix(icons): use the right close icon
     - Change the SVG of the close icon used in modal, offcanvas and close buttons
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1566

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,10 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
+  * fix(a11y): fix(a11y): add aria-hidden=true and focusable=false to SVGs in tooltips examples
+    - SVGs in tooltips do not carry any specific information so they should not be readable by screen reader so we should add 'aria-hidden=true'
+    - In addition, replaced the missing 'focusable=false' on the first svg
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1555
   * fix(forms): add validation icons for <select>s and fix its position for `<textarea>`
     - Reset to Bootstrap default for feedback icon on select
     - Setting the icon in the top right corner instead of center right

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -21,6 +21,8 @@ toc: true
 
 - <span class="badge bg-warning">Warning</span> Changed the markup for **Toasts** with a custom content (toast message and close button). Please reflect this modification into your websites.
 
+- <span class="badge bg-warning">Warning</span> Changed the rendering of `<mark>` (and so `.mark`). Depending on your usage it may worth checking the impact in your websites.
+
 - <span class="badge bg-info">New</span> **Tags** component.
 
 ### Icons and images
@@ -53,6 +55,7 @@ toc: true
   - `--bs-btn-close-disabled-color`
   - `--bs-btn-close-hover-color`
   - `--bs-btn-close-padding`
+  - `--bs-highlight-color`
   - `--bs-tab-content-border-width`
   - `--bs-tab-content-padding-x`
   - `--bs-tab-content-padding-y`
@@ -79,35 +82,16 @@ toc: true
   - `$btn-close-white-color`
   - `$btn-close-white-disabled-color`
   - `$btn-close-white-hover-color`
+  - `$mark-bg-dark`
+  - `$mark-color`
+  - `$mark-color-dark`
+  - `$navbar-dark-border-color`
   - `$navbar-font-weight`
 
 - Dark text variants handling is now explained in [Customize > CSS variables > Dark text rule](https://boosted.orange.com/docs/5.2/customize/css-variables/#dark-text-rule).
 
 <!--
 ### TODO
-  * fix(navbar): minor fixes (#1498)
-    - Add a .mb-3 to offcanvases navbar examples to add some space between the last link and the search bar in mobile viewport
-    - New $navbar-dark-border-color used in `-bs-navbar-border-color` for .navbar-dark
-    - Change the default value of $navbar-border-color now used only for light navbars
-        Summary: Change the border-color management in navbar + small fix in example.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1498
-        Topics: Docs, Sass, Add functionality, Breaking change, Navbar
-        K/R: Keep
-  * <mark>/.mark: Improve rendering for accessibility (#1506)
-        Summary: Change the rendering for .mark.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1506
-        Topics: Sass, Add functionality, Reboot
-        K/R: Keep
-  * chore(workflows): replace percy/snapshot-action by Percy CLI (#1530)
-        Summary: Remove percy/snapshot and add @percy/cli dependency.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1530
-        Topics: CI, Dependencies
-        K/R: Remove
-  * chore: add a PR template (#1007)
-        Summary: Add a PR template on Github.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1007
-        Topics: Git
-        K/R: Remove
   * feat(list group): add dark variant (#1525)
         Summary: Add a dark variant to list group.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1525

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -41,41 +41,24 @@ If you need more details about the changes, please refer to the [v5.2.1 release]
   - <span class="badge bg-success">New</span> Stepped process now has a dark variant.
 
 - **Tags**
-  - <span class="badge bg-success">New</span> Tags now have a dark variant.
+  - <span class="badge bg-success">New</span> Tags are now a component.
 
 - **Toasts**
   - <span class="badge bg-warning">Warning</span> Changed the markup for Toasts with a custom content (toast message and close button). Please reflect this modification into your websites.
-    <details>
+    <details class="mt-2">
       <summary>More info</summary>
       {{< markdown >}}
 ```diff
 <div class="toast align-items-center" role="alert" aria-live="assertive" aria-atomic="true">
   <div class="d-flex">
--    <div class="toast-body">
-+    <div class="toast-body my-auto">
+-   <div class="toast-body">
++   <div class="toast-body my-auto">
       Hello, world! This is a toast message.
     </div>
--    <button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast"><span class="visually-hidden">Close</span></button>
-+    <button type="button" class="btn-close ms-auto" data-bs-dismiss="toast"><span class="visually-hidden">Close</span></button>
+-   <button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast"><span class="visually-hidden">Close</span></button>
++   <button type="button" class="btn-close ms-auto" data-bs-dismiss="toast"><span class="visually-hidden">Close</span></button>
   </div>
 </div>
-```
-      {{< /markdown >}}
-    </details>
-
-- **Tooltips**
-  - <span class="badge bg-warning">Warning</span> Tooltips examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites.
-    <details>
-      <summary>More info</summary>
-      {{< markdown >}}
-```diff
-<a href="#" class="d-inline-block" data-bs-toggle="tooltip" data-bs-title="Default tooltip" aria-label="Default tooltip">
--  <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100 100">
-+  <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100 100" focusable="false" aria-hidden="true">
-    <rect width="100%" height="100%" fill="#563d7c"/>
-    <circle cx="50" cy="50" r="30" fill="#007bff"/>
-  </svg>
-</a>
 ```
       {{< /markdown >}}
     </details>
@@ -83,6 +66,23 @@ If you need more details about the changes, please refer to the [v5.2.1 release]
 ### Contents
 
 - <span class="badge bg-warning">Warning</span> Changed the rendering of `<mark>` (and so `.mark`). Depending on your usage it may worth checking the impact in your websites.
+
+- <span class="badge bg-warning">Warning</span> Tooltips examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites.
+  <details class="mb-3">
+    <summary>More info</summary>
+    {{< markdown >}}
+```diff
+<a href="#" class="d-inline-block" data-bs-toggle="tooltip" data-bs-title="Default tooltip" aria-label="Default tooltip">
+- <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100 100">
++ <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100 100" focusable="false" aria-hidden="true">
+    <rect width="100%" height="100%" fill="#563d7c"/>
+    <circle cx="50" cy="50" r="30" fill="#007bff"/>
+  </svg>
+</a>
+```
+    {{< /markdown >}}
+  </details>
+  By the way check all the SVGs in your websites in order to apply this same modification if needed.
 
 - The close icon SVG rendering has changed in modals, offcanvases and close buttons. Although is has no direct impact, you might want apply this same modification within your websites.
 
@@ -96,7 +96,7 @@ If you need more details about the changes, please refer to the [v5.2.1 release]
 
 - <span class="badge bg-warning">Warning</span> `$accordion-color` was announced a deprecated in v5.2.0 but is finally not removed.
 
-- <details>
+- <details class="mb-2">
     <summary><span class="badge bg-success">New</span> CSS variables:</summary>
     <ul>
       <li><code>--bs-alert-btn-close-offset</code></li>
@@ -136,7 +136,7 @@ If you need more details about the changes, please refer to the [v5.2.1 release]
     </ul>
   </details>
 
-- <details>
+- <details class="mb-2">
     <summary><span class="badge bg-success">New</span> Sass variables:</summary>
     <ul>
       <li><code>$alert-heading-font-weight</code></li>
@@ -205,7 +205,7 @@ If you need more details about the changes, please refer to the [v5.2.1 release]
     </ul>
   </details>
 
-- Dark text variants handling is now explained in [Customize > CSS variables > Dark text rule](https://boosted.orange.com/docs/5.2/customize/css-variables/#dark-text-rule).
+- Dark text variants handling is now explained in [Customize > CSS variables > Dark text rule]({{< docsref "/customize/css-variables#dark-text-rule" >}}).
 
 ## v5.2.0
 
@@ -464,7 +464,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ## Forms
 
-<!--- Boosted mod: no floating labels -->
+<!-- Boosted mod: no floating labels -->
 
 - <span class="badge bg-danger">Breaking</span> **Consolidated native and custom form elements.** Checkboxes, radios, selects, and other inputs that had native and custom classes in v4 have been consolidated. Now nearly all our form elements are entirely custom, most without the need for custom HTML.
   - `.custom-control.custom-checkbox` is now `.form-check`.

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -13,43 +13,91 @@ toc: true
 
 <hr class="mb-4">
 
+Boosted v5.2.1 is here with fixes from our latest minor release, v5.2. These changes include bug fixes, documentation updates, and some dependency updates, but also a new Tags component and a lot of new dark variants for our components.
+
+If you need more details about the changes, please refer to the [v5.2.1 release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/tag/v5.2.0).
+
 ### Components
 
-- <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
+- **Back to top**
+  - <span class="badge bg-danger">Breaking</span> Back to top 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
-- <span class="badge bg-warning">Warning</span> All **Footers** examples have been modified to use the "Terms and conditions" wording instead of "Terms & Conditions". Please reflect this modification into your websites.
+- **Breacrumb**
+  - <span class="badge bg-success">New</span> Breadcrumb now has a dark variant.
 
-- <span class="badge bg-warning">Warning</span> Changed the markup for **Toasts** with a custom content (toast message and close button). Please reflect this modification into your websites.
+- **Footers**
+  - <span class="badge bg-warning">Warning</span> All Footers examples have been modified to use the "Terms and conditions" wording instead of "Terms & Conditions". Please reflect this modification into your websites.
+
+- **List group**
+  - <span class="badge bg-success">New</span> List group now has a dark variant.
+
+- **Pagination**
+  - <span class="badge bg-success">New</span> Pagination now has a dark variant.
+
+- **Scrollspy**
+  - <span class="badge bg-success">New</span> Scrollspy has a new `data-bs-threshold` data attribute.
+
+- **Stepped process**
+  - <span class="badge bg-success">New</span> Stepped process now has a dark variant.
+
+- **Tags**
+  - <span class="badge bg-success">New</span> Tags now have a dark variant.
+
+- **Toasts**
+  - <span class="badge bg-warning">Warning</span> Changed the markup for Toasts with a custom content (toast message and close button). Please reflect this modification into your websites.
+    <details>
+      <summary>More info</summary>
+      {{< markdown >}}
+```diff
+<div class="toast align-items-center" role="alert" aria-live="assertive" aria-atomic="true">
+  <div class="d-flex">
+-    <div class="toast-body">
++    <div class="toast-body my-auto">
+      Hello, world! This is a toast message.
+    </div>
+-    <button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast"><span class="visually-hidden">Close</span></button>
++    <button type="button" class="btn-close ms-auto" data-bs-dismiss="toast"><span class="visually-hidden">Close</span></button>
+  </div>
+</div>
+```
+      {{< /markdown >}}
+    </details>
+
+- **Tooltips**
+  - <span class="badge bg-warning">Warning</span> Tooltips examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites.
+    <details>
+      <summary>More info</summary>
+      {{< markdown >}}
+```diff
+<a href="#" class="d-inline-block" data-bs-toggle="tooltip" data-bs-title="Default tooltip" aria-label="Default tooltip">
+-  <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100 100">
++  <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100 100" focusable="false" aria-hidden="true">
+    <rect width="100%" height="100%" fill="#563d7c"/>
+    <circle cx="50" cy="50" r="30" fill="#007bff"/>
+  </svg>
+</a>
+```
+      {{< /markdown >}}
+    </details>
+
+### Content
 
 - <span class="badge bg-warning">Warning</span> Changed the rendering of `<mark>` (and so `.mark`). Depending on your usage it may worth checking the impact in your websites.
 
-- <span class="badge bg-info">New</span> **Tags** component.
+- The close icon SVG rendering has changed in modals, offcanvases and close buttons. Although is has no direct impact, you might want apply this same modification within your websites.
 
-#### Dark variants
+### Helpers and utilities
 
-- <span class="badge bg-info">New</span> **Breadcrumb** dark variant.
-- <span class="badge bg-info">New</span> **List group** dark variant.
-- <span class="badge bg-info">New</span> **Pagination** dark variant.
-- <span class="badge bg-info">New</span> **Stepped process** dark variant.
-
-#### Usage
-
-- <span class="badge bg-info">New</span> `data-bs-threshold` data attribute for the Scrollspy.
-
-### Icons and images
-
-- <span class="badge bg-warning">Warning</span> **Tooltips** examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites.
-
-- The close icon SVG has changed in modals, offcanvases and close buttons. Although is has no direct impact, you might want apply this same modification within your websites.
-
-### Helpers
-
-- <span class="badge bg-info">New</span> `.img-thumbnail` officially supported.
+- <span class="badge bg-success">New</span> `.img-thumbnail` is now officially supported.
 
 ### CSS and Sass variables
 
+- <span class="badge bg-danger">Breaking</span> `--bs-pagination-margin-start` and `--bs-pagination-focus-outline` are now deprecated.
+
+- <span class="badge bg-warning">Warning</span> `$accordion-color` was announced a deprecated in v5.2.0 but is finally not removed.
+
 - <details>
-    <summary><span class="badge bg-info">New</span> CSS variables:</summary>
+    <summary><span class="badge bg-success">New</span> CSS variables:</summary>
     <ul>
       <li><code>--bs-alert-btn-close-offset</code></li>
       <li><code>--bs-alert-dismissible-padding-right</code></li>
@@ -89,7 +137,7 @@ toc: true
   </details>
 
 - <details>
-    <summary><span class="badge bg-info">New</span> Sass variables:</summary>
+    <summary><span class="badge bg-success">New</span> Sass variables:</summary>
     <ul>
       <li><code>$alert-heading-font-weight</code></li>
       <li><code>$alert-icon-size-sm</code></li>
@@ -156,10 +204,6 @@ toc: true
       <li><code>$step-link-next-color</code></li>
     </ul>
   </details>
-
-- <span class="badge bg-danger">Breaking</span> `--bs-pagination-margin-start` and `--bs-pagination-focus-outline` are now deprecated.
-
-- <span class="badge bg-warning">Warning</span> `$accordion-color` was announced a deprecated in v5.2.0 but is finally not removed.
 
 - Dark text variants handling is now explained in [Customize > CSS variables > Dark text rule](https://boosted.orange.com/docs/5.2/customize/css-variables/#dark-text-rule).
 

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,17 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
+  * feat(css): add CSS vars to alerts
+    - NEW CSS vars:
+        - --#{$prefix}alert-line-height
+        - --#{$prefix}alert-logo-size: #{$alert-logo-size};
+        - --#{$prefix}alert-icon-size: #{$alert-icon-size};
+        - --#{$prefix}alert-icon-margin-y: #{$alert-icon-margin-y};
+        - --#{$prefix}alert-link-font-weight: #{$alert-link-font-weight};
+        - --#{$prefix}alert-heading-font-weight: #{$alert-heading-font-weight};
+        - --#{$prefix}alert-dismissible-padding-right: #{$alert-dismissible-padding-r};
+        - --#{$prefix}alert-btn-close-offset: #{$alert-btn-close-offset};
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1424
   * feat(css): add CSS vars to navbars
     - NEW `$navbar-font-weight` for SCSS vars.
     - NEW `--#{$prefix}navbar-nav-font-size` and `--#{$prefix}navbar-nav-line-height` for .supra

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -19,6 +19,8 @@ toc: true
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
 <!---
+  * fix(css): rename `$prefix` by `$func-prefix` in `get-color-from-rgba-string` function
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1567
   * feat(components): new Tags component
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/988
   * fix(icons): use the right close icon

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -15,24 +15,21 @@ toc: true
 
 ### Components
 
-<!--- * fix(back to top): remove 'Label inside' variant (#1520) -->
-- <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
-<!---
+<!-- * fix(back to top): remove 'Label inside' variant (#1520) -->
+- <span class="badge bg-danger align-text-top">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
+
+<!--
   * fix(footers): change 'Terms & Conditions' to 'Terms and conditions'
     This information is important for the users in order to change the label they could have used
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1564
 -->
-- <span class="badge bg-warning">Warning</span> All **Footers** examples have been modified to use the "Terms and conditions" wording instead of "Terms & Conditions". Please reflect this modification into your websites.
+- <span class="badge bg-warning align-text-top">Warning</span> All **Footers** examples have been modified to use the "Terms and conditions" wording instead of "Terms & Conditions". Please reflect this modification into your websites.
+
+- <span class="badge bg-info align-text-top">New</span> **Tags** component.
 
 
 <!--
-### Elements that should not appear in this migration guide because it has no impact for the developers
-
-* fix(css): rename `$prefix` by `$func-prefix` in `get-color-from-rgba-string` function
-    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1567
-
 ### TODO
-  
   * feat(components): new Tags component
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/988
   * fix(icons): use the right close icon
@@ -612,6 +609,12 @@ toc: true
         Topics: Dependency
         K/R: ?
     - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide >> Done
+
+
+### Elements that should not appear in this migration guide because it has no impact for the developers
+
+* fix(css): rename `$prefix` by `$func-prefix` in `get-color-from-rgba-string` function
+    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1567
 -->
 
 ## v5.2.0
@@ -697,7 +700,7 @@ Your custom Boosted CSS builds should now look something like this with a separa
 
 - Added [striped columns]({{< docsref "/content/tables#striped-columns" >}}) support to tables via the new `.table-striped-columns` class.
 
-- <span class="badge bg-danger">Breaking</span> Changed `data-o-label` to `data-bs-label` in Back to top component.
+- <span class="badge bg-danger align-text-top">Breaking</span> Changed `data-o-label` to `data-bs-label` in Back to top component.
 
 For a complete list of changes, [see the v5.2.0 project on GitHub](https://github.com/twbs/bootstrap/projects/32).
 
@@ -765,27 +768,27 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - We've ditched the default Sass map merges to make it easier to remove redundant values. Keep in mind you now have to define all values in the Sass maps like `$theme-colors`. Check out how to deal with [Sass maps]({{< docsref "/customize/sass#maps-and-loops" >}}).
 
-- <span class="badge bg-danger">Breaking</span> Renamed `color-yiq()` function and related variables to `color-contrast()` as it's no longer related to YIQ color space. [See #30168.](https://github.com/twbs/bootstrap/pull/30168/)
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `color-yiq()` function and related variables to `color-contrast()` as it's no longer related to YIQ color space. [See #30168.](https://github.com/twbs/bootstrap/pull/30168/)
   - `$yiq-contrasted-threshold` is renamed to `$min-contrast-ratio`.
   - `$yiq-text-dark` and `$yiq-text-light` are respectively renamed to `$color-contrast-dark` and `$color-contrast-light`.
 
-- <span class="badge bg-danger">Breaking</span> Media query mixins parameters have changed for a more logical approach.
+- <span class="badge bg-danger align-text-top">Breaking</span> Media query mixins parameters have changed for a more logical approach.
   - `media-breakpoint-down()` uses the breakpoint itself instead of the next breakpoint (e.g., `media-breakpoint-down(lg)` instead of `media-breakpoint-down(md)` targets viewports smaller than `lg`).
   - Similarly, the second parameter in `media-breakpoint-between()` also uses the breakpoint itself instead of the next breakpoint (e.g., `media-between(sm, lg)` instead of `media-breakpoint-between(sm, md)` targets viewports between `sm` and `lg`).
 
-- <span class="badge bg-danger">Breaking</span> Removed print styles and `$enable-print-styles` variable. Print display classes are still around. [See #28339](https://github.com/twbs/bootstrap/pull/28339).
+- <span class="badge bg-danger align-text-top">Breaking</span> Removed print styles and `$enable-print-styles` variable. Print display classes are still around. [See #28339](https://github.com/twbs/bootstrap/pull/28339).
 
 
-- <span class="badge bg-danger">Breaking</span> Dropped `color()`, `theme-color()`, and `gray()` functions in favor of variables. [See #29083](https://github.com/twbs/bootstrap/pull/29083).
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `color()`, `theme-color()`, and `gray()` functions in favor of variables. [See #29083](https://github.com/twbs/bootstrap/pull/29083).
 
-- <span class="badge bg-danger">Breaking</span> Renamed `theme-color-level()` function to `color-level()` and now accepts any color you want instead of only `$theme-color` colors. [See #29083](https://github.com/twbs/bootstrap/pull/29083) **Watch out:** `color-level()` was later on dropped in `v5.0.0-alpha3`.
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `theme-color-level()` function to `color-level()` and now accepts any color you want instead of only `$theme-color` colors. [See #29083](https://github.com/twbs/bootstrap/pull/29083) **Watch out:** `color-level()` was later on dropped in `v5.0.0-alpha3`.
 
-- <span class="badge bg-danger">Breaking</span> Renamed `$enable-prefers-reduced-motion-media-query` and `$enable-pointer-cursor-for-buttons` to `$enable-reduced-motion` and `$enable-button-pointers` for brevity.
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `$enable-prefers-reduced-motion-media-query` and `$enable-pointer-cursor-for-buttons` to `$enable-reduced-motion` and `$enable-button-pointers` for brevity.
 
 
-- <span class="badge bg-danger">Breaking</span> Removed the `bg-gradient-variant()` mixin. Use the `.bg-gradient` class to add gradients to elements instead of the generated `.bg-gradient-*` classes.
+- <span class="badge bg-danger align-text-top">Breaking</span> Removed the `bg-gradient-variant()` mixin. Use the `.bg-gradient` class to add gradients to elements instead of the generated `.bg-gradient-*` classes.
 
-- <span class="badge bg-danger">Breaking</span> **Removed previously deprecated mixins:**
+- <span class="badge bg-danger align-text-top">Breaking</span> **Removed previously deprecated mixins:**
   - `hover`, `hover-focus`, `plain-hover-focus`, and `hover-focus-active`
   - `float()`
   - `form-control-mixin()`
@@ -795,7 +798,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
   - `visibility()`
   - `form-control-focus()`
 
-- <span class="badge bg-danger">Breaking</span> Renamed `scale-color()` function to `shift-color()` to avoid collision with Sass's own color scaling function.
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `scale-color()` function to `shift-color()` to avoid collision with Sass's own color scaling function.
 
 - `box-shadow` mixins now allow `null` values and drop `none` from multiple arguments. [See #30394](https://github.com/twbs/bootstrap/pull/30394).
 
@@ -817,15 +820,15 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - **Improved gutters.** Gutters are now set in rems, and are narrower than v4 (`1.5rem`, or about `24px`, down from `30px`). This aligns our grid system's gutters with our spacing utilities.
   - Added new [gutter class](/docs/{{< param docs_version >}}/layout/gutters/) (`.g-*`, `.gx-*`, and `.gy-*`) to control horizontal/vertical gutters, horizontal gutters, and vertical gutters.
-  - <span class="badge bg-danger">Breaking</span> Renamed `.no-gutters` to `.g-0` to match new gutter utilities.
+  - <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.no-gutters` to `.g-0` to match new gutter utilities.
 
 - Columns no longer have `position: relative` applied, so you may have to add `.position-relative` to some elements to restore that behavior.
 
-- <span class="badge bg-danger">Breaking</span> Dropped several `.order-*` classes that often went unused. We now only provide `.order-1` to `.order-5` out of the box.
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped several `.order-*` classes that often went unused. We now only provide `.order-1` to `.order-5` out of the box.
 
-- <span class="badge bg-danger">Breaking</span> Dropped the `.media` component as it can be easily replicated with utilities. [See #28265](https://github.com/twbs/bootstrap/pull/28265) and the [flex utilities page for an example]({{< docsref "/utilities/flex#media-object" >}}).
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped the `.media` component as it can be easily replicated with utilities. [See #28265](https://github.com/twbs/bootstrap/pull/28265) and the [flex utilities page for an example]({{< docsref "/utilities/flex#media-object" >}}).
 
-- <span class="badge bg-danger">Breaking</span> `boosted-grid.css` now only applies `box-sizing: border-box` to the column instead of resetting the global box-sizing. This way, our grid styles can be used in more places without interference.
+- <span class="badge bg-danger align-text-top">Breaking</span> `boosted-grid.css` now only applies `box-sizing: border-box` to the column instead of resetting the global box-sizing. This way, our grid styles can be used in more places without interference.
 
 - `$enable-grid-classes` no longer disables the generation of container classes anymore. [See #29146.](https://github.com/twbs/bootstrap/pull/29146)
 
@@ -833,11 +836,11 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ## Content, Reboot, etc
 
-- <span class="badge bg-danger">Breaking</span> Orange Helvetica CSS file names changed from `orangeHelvetica.*.css` to `orange-helvetica.*.css`.
+- <span class="badge bg-danger align-text-top">Breaking</span> Orange Helvetica CSS file names changed from `orangeHelvetica.*.css` to `orange-helvetica.*.css`.
 
 - **[RFS]({{< docsref "/getting-started/rfs" >}}) is now enabled by default.** Headings using the `font-size()` mixin will automatically adjust their `font-size` to scale with the viewport. _This feature was previously opt-in with v4._
 
-- <span class="badge bg-danger">Breaking</span> Overhauled our display typography to replace our `$display-*` variables and with a `$display-font-sizes` Sass map. Also removed the individual `$display-*-weight` variables for a single `$display-font-weight` and adjusted `font-size`s.
+- <span class="badge bg-danger align-text-top">Breaking</span> Overhauled our display typography to replace our `$display-*` variables and with a `$display-font-sizes` Sass map. Also removed the individual `$display-*-weight` variables for a single `$display-font-weight` and adjusted `font-size`s.
 
 - Added two new `.display-*` heading sizes, `.display-5` and `.display-6`.
 
@@ -845,21 +848,21 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - **Redesigned tables** to refresh their styles and rebuild them with CSS variables for more control over styling.
 
-- <span class="badge bg-danger">Breaking</span> Nested tables do not inherit styles anymore.
+- <span class="badge bg-danger align-text-top">Breaking</span> Nested tables do not inherit styles anymore.
 
-- <span class="badge bg-danger">Breaking</span> `.thead-light` and `.thead-dark` are dropped in favor of the `.table-*` variant classes which can be used for all table elements (`thead`, `tbody`, `tfoot`, `tr`, `th` and `td`).
+- <span class="badge bg-danger align-text-top">Breaking</span> `.thead-light` and `.thead-dark` are dropped in favor of the `.table-*` variant classes which can be used for all table elements (`thead`, `tbody`, `tfoot`, `tr`, `th` and `td`).
 
-- <span class="badge bg-danger">Breaking</span> The `table-row-variant()` mixin is renamed to `table-variant()` and accepts only 2 parameters: `$color` (color name) and `$value` (color code). The border color and accent colors are automatically calculated based on the table factor variables.
+- <span class="badge bg-danger align-text-top">Breaking</span> The `table-row-variant()` mixin is renamed to `table-variant()` and accepts only 2 parameters: `$color` (color name) and `$value` (color code). The border color and accent colors are automatically calculated based on the table factor variables.
 
 - Split table cell padding variables into `-y` and `-x`.
 
-- <span class="badge bg-danger">Breaking</span> Dropped `.pre-scrollable` class. [See #29135](https://github.com/twbs/bootstrap/pull/29135)
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `.pre-scrollable` class. [See #29135](https://github.com/twbs/bootstrap/pull/29135)
 
-- <span class="badge bg-danger">Breaking</span> `.text-*` utilities do not add hover and focus states to links anymore. `.link-*` helper classes can be used instead. [See #29267](https://github.com/twbs/bootstrap/pull/29267)
+- <span class="badge bg-danger align-text-top">Breaking</span> `.text-*` utilities do not add hover and focus states to links anymore. `.link-*` helper classes can be used instead. [See #29267](https://github.com/twbs/bootstrap/pull/29267)
 
-- <span class="badge bg-danger">Breaking</span> Dropped `.text-justify` class. [See #29793](https://github.com/twbs/bootstrap/pull/29793)
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `.text-justify` class. [See #29793](https://github.com/twbs/bootstrap/pull/29793)
 
-- <span class="badge bg-danger">Breaking</span> ~~`<hr>` elements now use `height` instead of `border` to better support the `size` attribute. This also enables use of padding utilities to create thicker dividers (e.g., `<hr class="py-1">`).~~
+- <span class="badge bg-danger align-text-top">Breaking</span> ~~`<hr>` elements now use `height` instead of `border` to better support the `size` attribute. This also enables use of padding utilities to create thicker dividers (e.g., `<hr class="py-1">`).~~
 
 - Reset default horizontal `padding-left` on `<ul>` and `<ol>` elements from browser default `40px` to `2rem`.
 
@@ -873,7 +876,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 <!--- Boosted mod: no floating labels -->
 
-- <span class="badge bg-danger">Breaking</span> **Consolidated native and custom form elements.** Checkboxes, radios, selects, and other inputs that had native and custom classes in v4 have been consolidated. Now nearly all our form elements are entirely custom, most without the need for custom HTML.
+- <span class="badge bg-danger align-text-top">Breaking</span> **Consolidated native and custom form elements.** Checkboxes, radios, selects, and other inputs that had native and custom classes in v4 have been consolidated. Now nearly all our form elements are entirely custom, most without the need for custom HTML.
   - `.custom-control.custom-checkbox` is now `.form-check`.
   - `.custom-control.custom-custom-radio` is now `.form-check`.
   - `.custom-control.custom-switch` is now `.form-check.form-switch`.
@@ -882,15 +885,15 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
   - `.custom-range` is now `.form-range`.
   - Dropped native `.form-control-file` and `.form-control-range`.
 
-- <span class="badge bg-danger">Breaking</span> Dropped `.input-group-append` and `.input-group-prepend`. You can now just add buttons and `.input-group-text` as direct children of the input groups.
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `.input-group-append` and `.input-group-prepend`. You can now just add buttons and `.input-group-text` as direct children of the input groups.
 
 - The longstanding [Missing border radius on input group with validation feedback bug](https://github.com/twbs/bootstrap/issues/25110) is finally fixed by adding an additional `.has-validation` class to input groups with validation.
 
-- <span class="badge bg-danger">Breaking</span> **Dropped form-specific layout classes for our grid system.** Use our grid and utilities instead of `.form-group`, `.form-row`, or `.form-inline`.
+- <span class="badge bg-danger align-text-top">Breaking</span> **Dropped form-specific layout classes for our grid system.** Use our grid and utilities instead of `.form-group`, `.form-row`, or `.form-inline`.
 
-- <span class="badge bg-danger">Breaking</span> Form labels now require `.form-label`.
+- <span class="badge bg-danger align-text-top">Breaking</span> Form labels now require `.form-label`.
 
-- <span class="badge bg-danger">Breaking</span> `.form-text` no longer sets `display`, allowing you to create inline or block help text as you wish just by changing the HTML element.
+- <span class="badge bg-danger align-text-top">Breaking</span> `.form-text` no longer sets `display`, allowing you to create inline or block help text as you wish just by changing the HTML element.
 
 - Form controls no longer used fixed `height` when possible, instead deferring to `min-height` to improve customization and compatibility with other components.
 
@@ -916,11 +919,11 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Badges
 
-- <span class="badge bg-danger">Breaking</span> Dropped all `.badge-*` color classes for background utilities (e.g., use `.bg-primary` instead of `.badge-primary`).
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped all `.badge-*` color classes for background utilities (e.g., use `.bg-primary` instead of `.badge-primary`).
 
-- <span class="badge bg-danger">Breaking</span> Dropped `.badge-pill`—use the `.rounded-pill` utility instead.
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `.badge-pill`—use the `.rounded-pill` utility instead.
 
-- <span class="badge bg-danger">Breaking</span> Removed hover and focus styles for `<a>` and `<button>` elements.
+- <span class="badge bg-danger align-text-top">Breaking</span> Removed hover and focus styles for `<a>` and `<button>` elements.
 
 - Increased default padding for badges from `.25em`/`.5em` to `.35em`/`.65em`.
 
@@ -932,9 +935,9 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Buttons
 
-- <span class="badge bg-danger">Breaking</span> **[Toggle buttons](/docs/{{< param docs_version >}}/forms/checks-radios/#toggle-buttons), with checkboxes or radios, no longer require JavaScript and have new markup.** We no longer require a wrapping element, add `.btn-check` to the `<input>`, and pair it with any `.btn` classes on the `<label>`. [See #30650](https://github.com/twbs/bootstrap/pull/30650). _The docs for this has moved from our Buttons page to the new Forms section._
+- <span class="badge bg-danger align-text-top">Breaking</span> **[Toggle buttons](/docs/{{< param docs_version >}}/forms/checks-radios/#toggle-buttons), with checkboxes or radios, no longer require JavaScript and have new markup.** We no longer require a wrapping element, add `.btn-check` to the `<input>`, and pair it with any `.btn` classes on the `<label>`. [See #30650](https://github.com/twbs/bootstrap/pull/30650). _The docs for this has moved from our Buttons page to the new Forms section._
 
-- <span class="badge bg-danger">Breaking</span> **Dropped `.btn-block` for utilities.** Instead of using `.btn-block` on the `.btn`, wrap your buttons with `.d-grid` and a `.gap-*` utility to space them as needed. Switch to responsive classes for even more control over them. [Read the docs for some examples.](/docs/{{< param docs_version >}}/components/buttons/#block-buttons)
+- <span class="badge bg-danger align-text-top">Breaking</span> **Dropped `.btn-block` for utilities.** Instead of using `.btn-block` on the `.btn`, wrap your buttons with `.d-grid` and a `.gap-*` utility to space them as needed. Switch to responsive classes for even more control over them. [Read the docs for some examples.](/docs/{{< param docs_version >}}/components/buttons/#block-buttons)
 
 - Updated our `button-variant()` and `button-outline-variant()` mixins to support additional parameters.
 
@@ -944,11 +947,11 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Card
 
-- <span class="badge bg-danger">Breaking</span> Dropped `.card-deck` in favor of our grid. Wrap your cards in column classes and add a parent `.row-cols-*` container to recreate card decks (but with more control over responsive alignment).
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `.card-deck` in favor of our grid. Wrap your cards in column classes and add a parent `.row-cols-*` container to recreate card decks (but with more control over responsive alignment).
 
 - [#31035](https://github.com/twbs/bootstrap/pull/31035): Added new `null` variables for `font-size`, `font-weight`, `color`, and `:hover` `color` to the `.nav-link` class.
 
-- <span class="badge bg-danger">Breaking</span> Replaced the `.card` based accordion with a [new Accordion component]({{< docsref "/components/accordion" >}}).
+- <span class="badge bg-danger align-text-top">Breaking</span> Replaced the `.card` based accordion with a [new Accordion component]({{< docsref "/components/accordion" >}}).
 
 ### Carousel
 
@@ -958,7 +961,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Close button
 
-- <span class="badge bg-danger">Breaking</span> Renamed `.close` to `.btn-close` for a less generic name.
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.close` to `.btn-close` for a less generic name.
 
 - Close buttons now use a `background-image` (embedded SVG) instead of a `&times;` in the HTML, allowing for easier customization without the need to touch your markup.
 
@@ -976,11 +979,11 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - Darkened the dropdown divider for improved contrast.
 
-- <span class="badge bg-danger">Breaking</span> All the events for the dropdown are now triggered on the dropdown toggle button and then bubbled up to the parent element.
+- <span class="badge bg-danger align-text-top">Breaking</span> All the events for the dropdown are now triggered on the dropdown toggle button and then bubbled up to the parent element.
 
 - Dropdown menus now have a `data-bs-popper="static"` attribute set when the positioning of the dropdown is static, or dropdown is in the navbar. This is added by our JavaScript and helps us use custom position styles without interfering with Popper's positioning.
 
-- <span class="badge bg-danger">Breaking</span> Dropped `flip` option for dropdown plugin in favor of native Popper configuration. You can now disable the flipping behavior by passing an empty array for [`fallbackPlacements`](https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements) option in [flip](https://popper.js.org/docs/v2/modifiers/flip/) modifier.
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped `flip` option for dropdown plugin in favor of native Popper configuration. You can now disable the flipping behavior by passing an empty array for [`fallbackPlacements`](https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements) option in [flip](https://popper.js.org/docs/v2/modifiers/flip/) modifier.
 
 - Dropdown menus can now be clickable with a new `autoClose` option to handle the [auto close behavior]({{< docsref "/components/dropdowns#auto-close-behavior" >}}). You can use this option to accept the click inside or outside the dropdown menu to make it interactive.
 
@@ -988,11 +991,11 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Footer
 
-- <span class="badge bg-danger">Breaking</span> Footers' HTML structure changed a lot as it works now with sub-components. They don't require `.o-footer-*` classes anymore, they need [`.footer-*` classes]({{< docsref "/components/footer" >}}).
+- <span class="badge bg-danger align-text-top">Breaking</span> Footers' HTML structure changed a lot as it works now with sub-components. They don't require `.o-footer-*` classes anymore, they need [`.footer-*` classes]({{< docsref "/components/footer" >}}).
 
 ### Jumbotron
 
-- <span class="badge bg-danger">Breaking</span> Dropped the jumbotron component as it can be replicated with utilities.
+- <span class="badge bg-danger align-text-top">Breaking</span> Dropped the jumbotron component as it can be replicated with utilities.
 
 ### List group
 
@@ -1004,8 +1007,8 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Navbars
 
-- <span class="badge bg-danger">Breaking</span> Navbars now require a container within (to drastically simplify spacing requirements and CSS required).
-- <span class="badge bg-danger">Breaking</span> The `.active` class can no longer be applied to `.nav-item`s, it must be applied directly on `.nav-link`s.
+- <span class="badge bg-danger align-text-top">Breaking</span> Navbars now require a container within (to drastically simplify spacing requirements and CSS required).
+- <span class="badge bg-danger align-text-top">Breaking</span> The `.active` class can no longer be applied to `.nav-item`s, it must be applied directly on `.nav-link`s.
 
 ### Offcanvas
 
@@ -1013,7 +1016,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Orange navbar
 
-- <span class="badge bg-danger">Breaking</span> Supra bars now require a `.bg-dark` class.
+- <span class="badge bg-danger align-text-top">Breaking</span> Supra bars now require a `.bg-dark` class.
 
 - Removed the `.global` class for the instantiation of global headers. You just need to declare your navbar with default `.navbar-*` classes.
 
@@ -1029,7 +1032,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Popovers
 
-- <span class="badge bg-danger">Breaking</span> Renamed `.arrow` to `.popover-arrow` in our default popover template.
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.arrow` to `.popover-arrow` in our default popover template.
 
 - Renamed `whiteList` option to `allowList`.
 
@@ -1049,15 +1052,15 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ### Tooltips
 
-- <span class="badge bg-danger">Breaking</span> Renamed `.arrow` to `.tooltip-arrow` in our default tooltip template.
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.arrow` to `.tooltip-arrow` in our default tooltip template.
 
-- <span class="badge bg-danger">Breaking</span> The default value for the `fallbackPlacements` is changed to `['top', 'right', 'bottom', 'left']` for better placement of popper elements.
+- <span class="badge bg-danger align-text-top">Breaking</span> The default value for the `fallbackPlacements` is changed to `['top', 'right', 'bottom', 'left']` for better placement of popper elements.
 
-- <span class="badge bg-danger">Breaking</span> Renamed `whiteList` option to `allowList`.
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `whiteList` option to `allowList`.
 
 ## Utilities
 
-- <span class="badge bg-danger">Breaking</span> Renamed several utilities to use logical property names instead of directional names with the addition of RTL support:
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed several utilities to use logical property names instead of directional names with the addition of RTL support:
   - Renamed `.left-*` and `.right-*` to `.start-*` and `.end-*`.
   - Renamed `.float-left` and `.float-right` to `.float-start` and `.float-end`.
   - Renamed `.border-left` and `.border-right` to `.border-start` and `.border-end`.
@@ -1066,7 +1069,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
   - Renamed `.pl-*` and `.pr-*` to `.ps-*` and `.pe-*`.
   - Renamed `.text-left` and `.text-right` to `.text-start` and `.text-end`.
 
-- <span class="badge bg-danger">Breaking</span> Disabled negative margins by default.
+- <span class="badge bg-danger align-text-top">Breaking</span> Disabled negative margins by default.
 
 - Added new `.bg-body` class for quickly setting the `<body>`'s background to additional elements.
 
@@ -1076,19 +1079,19 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - Added new [`border-width` utilities]({{< docsref "/utilities/borders#border-width" >}}).
 
-- <span class="badge bg-danger">Breaking</span> Renamed `.text-monospace` to `.font-monospace`.
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.text-monospace` to `.font-monospace`.
 
-- <span class="badge bg-danger">Breaking</span> Removed `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore.
+- <span class="badge bg-danger align-text-top">Breaking</span> Removed `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore.
 
 - Added `.fs-*` utilities for `font-size` utilities (with RFS enabled). These use the same scale as HTML's default headings (1-6, large to small), and can be modified via Sass map.
 
-- <span class="badge bg-danger">Breaking</span> Renamed `.font-weight-*` utilities as `.fw-*` for brevity and consistency.
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.font-weight-*` utilities as `.fw-*` for brevity and consistency.
 
-- <span class="badge bg-danger">Breaking</span> Renamed `.font-style-*` utilities as `.fst-*` for brevity and consistency.
+- <span class="badge bg-danger align-text-top">Breaking</span> Renamed `.font-style-*` utilities as `.fst-*` for brevity and consistency.
 
 - Added `.d-grid` to display utilities and new `gap` utilities (`.gap`) for CSS Grid and flexbox layouts.
 
-- <span class="badge bg-danger">Breaking</span> Removed `.rounded-sm` and `rounded-lg`, and introduced a new scale of classes, `.rounded-0` to `.rounded-3`. [See #31687](https://github.com/twbs/bootstrap/pull/31687).
+- <span class="badge bg-danger align-text-top">Breaking</span> Removed `.rounded-sm` and `rounded-lg`, and introduced a new scale of classes, `.rounded-0` to `.rounded-3`. [See #31687](https://github.com/twbs/bootstrap/pull/31687).
 
 - Added new `line-height` utilities: `.lh-1`, `.lh-sm`, `.lh-base` and `.lh-lg`. See [here]({{< docsref "/utilities/text#line-height" >}}).
 
@@ -1098,13 +1101,13 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ## Helpers
 
-- <span class="badge bg-danger">Breaking</span> **Responsive embed helpers have been renamed to [ratio helpers]({{< docsref "/helpers/ratio" >}})** with new class names and improved behaviors, as well as a helpful CSS variable.
+- <span class="badge bg-danger align-text-top">Breaking</span> **Responsive embed helpers have been renamed to [ratio helpers]({{< docsref "/helpers/ratio" >}})** with new class names and improved behaviors, as well as a helpful CSS variable.
   - Classes have been renamed to change `by` to `x` in the aspect ratio. For example, `.ratio-16by9` is now `.ratio-16x9`.
   - We've dropped the `.embed-responsive-item` and element group selector in favor of a simpler `.ratio > *` selector. No more class is needed, and the ratio helper now works with any HTML element.
   - The `$embed-responsive-aspect-ratios` Sass map has been renamed to `$aspect-ratios` and its values have been simplified to include the class name and the percentage as the `key: value` pair.
   - CSS variables are now generated and included for each value in the Sass map. Modify the `--bs-aspect-ratio` variable on the `.ratio` to create any [custom aspect ratio]({{< docsref "/helpers/ratio#custom-ratios" >}}).
 
-- <span class="badge bg-danger">Breaking</span> **"Screen reader" classes are now ["visually hidden" classes]({{< docsref "/helpers/visually-hidden" >}}).**
+- <span class="badge bg-danger align-text-top">Breaking</span> **"Screen reader" classes are now ["visually hidden" classes]({{< docsref "/helpers/visually-hidden" >}}).**
   - Changed the Sass file from `scss/helpers/_screenreaders.scss` to `scss/helpers/_visually-hidden.scss`
   - Renamed `.sr-only` and `.sr-only-focusable` to `.visually-hidden` and `.visually-hidden-focusable`
   - Renamed `sr-only()` and `sr-only-focusable()` mixins to `visually-hidden()` and `visually-hidden-focusable()`.
@@ -1115,7 +1118,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - **Dropped jQuery dependency** and rewrote plugins to be in regular JavaScript.
 
-- <span class="badge bg-danger">Breaking</span> Data attributes for all JavaScript plugins are now namespaced to help distinguish Boosted functionality from third parties and your own code. For example, we use `data-bs-toggle` instead of `data-toggle`.
+- <span class="badge bg-danger align-text-top">Breaking</span> Data attributes for all JavaScript plugins are now namespaced to help distinguish Boosted functionality from third parties and your own code. For example, we use `data-bs-toggle` instead of `data-toggle`.
 
 - **All plugins can now accept a CSS selector as the first argument.** You can either pass a DOM element or any valid CSS selector to create a new instance of the plugin:
 

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -27,7 +27,14 @@ toc: true
 
 #### Dark variants
 
+- <span class="badge bg-info">New</span> **Breadcrumb** dark variant.
 - <span class="badge bg-info">New</span> **List group** dark variant.
+- <span class="badge bg-info">New</span> **Pagination** dark variant.
+- <span class="badge bg-info">New</span> **Stepped process** dark variant.
+
+#### Usage
+
+- <span class="badge bg-info">New</span> `data-bs-threshold` data attribute for the Scrollspy.
 
 ### Icons and images
 
@@ -50,6 +57,7 @@ toc: true
   - `--bs-alert-line-height`
   - `--bs-alert-link-font-weight`
   - `--bs-alert-logo-size`
+  - `--bs-breadcrumb-color`
   - `--bs-btn-close-active-border-color`
   - `--bs-btn-close-active-color`
   - `--bs-btn-close-bg`
@@ -59,7 +67,11 @@ toc: true
   - `--bs-btn-close-disabled-color`
   - `--bs-btn-close-hover-color`
   - `--bs-btn-close-padding`
+  - `--bs-btn-hover-border-color`
+  - `--bs-dropdown-zindex`
   - `--bs-highlight-color`
+  - `--bs-pagination-active-item-color`
+  - `--bs-pagination-padding-end`
   - `--bs-tab-content-border-width`
   - `--bs-tab-content-padding-x`
   - `--bs-tab-content-padding-y`
@@ -69,10 +81,17 @@ toc: true
   - `--bs-nav-tabs-link-padding-x`
   - `--bs-navbar-font-weight`
   - `--bs-navbar-toggler-icon-filter`
+  - `--bs-stepped-process-link-next-color`
+  - `--bs-toast-zindex`
 
 - <span class="badge bg-info">New</span> Here is an exhaustive list of new Sass variables:
   - `$alert-heading-font-weight`
   - `$alert-icon-size-sm`
+  - `$breadcrumb-color`
+  - `$breadcrumb-dark-active-color`
+  - `$breadcrumb-dark-bg`
+  - `$breadcrumb-dark-color`
+  - `$breadcrumb-dark-divider-color`
   - `$btn-close-active-border-color`
   - `$btn-close-active-color`
   - `$btn-close-border-color`
@@ -103,129 +122,38 @@ toc: true
   - `$mark-color-dark`
   - `$navbar-dark-border-color`
   - `$navbar-font-weight`
+  - `$pagination-active-item-color`
+  - `$pagination-dark-active-bg`
+  - `$pagination-dark-active-border-color`
+  - `$pagination-dark-active-color`
+  - `$pagination-dark-active-item-bg`
+  - `$pagination-dark-active-item-border-color`
+  - `$pagination-dark-active-item-color`
+  - `$pagination-dark-bg`
+  - `$pagination-dark-border-color`
+  - `$pagination-dark-color`
+  - `$pagination-dark-disabled-bg`
+  - `$pagination-dark-disabled-border-color`
+  - `$pagination-dark-disabled-color`
+  - `$pagination-dark-focus-bg`
+  - `$pagination-dark-focus-color`
+  - `$pagination-dark-hover-bg`
+  - `$pagination-dark-hover-border-color`
+  - `$pagination-dark-hover-color`
+  - `$step-item-dark-active-bg`
+  - `$step-item-dark-bg`
+  - `$step-item-dark-drop-shadow`
+  - `$step-item-dark-next-bg`
+  - `$step-link-dark-active-color`
+  - `$step-link-dark-color`
+  - `$step-link-dark-next-color`
+  - `$step-link-next-color`
+
+- <span class="badge bg-danger">Breaking</span> `--bs-pagination-margin-start` and `--bs-pagination-focus-outline` are now deprecated.
+
+- <span class="badge bg-warning">Warning</span> `$accordion-color` was announced a deprecated in v5.2.0 but is finally not removed.
 
 - Dark text variants handling is now explained in [Customize > CSS variables > Dark text rule](https://boosted.orange.com/docs/5.2/customize/css-variables/#dark-text-rule).
-
-<!--
-### TODO
-  * chore(merge main patched commit) → 23fb7a7 (#1521)
-    - https://github.com/twbs/bootstrap/commit/97a9060a8fa643484fbe70d1e527267841670c9d (same as the one following, should have been squashed)
-    - https://github.com/twbs/bootstrap/commit/9b943880fc38ccde372973111fe5872b5960e75d
-        Summary: Remove the left margin when not necessary in first button group button.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1521/commits/8cc92657fca4a62966ad6185df2811a2e70c7f19
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1521/commits/fb182fcbc702c869437065b50422be2e1b6caaea
-        Topics: Sass, Fix, Button group
-        K/R: ?
-    - https://github.com/twbs/bootstrap/commit/7a7469b8ab3e86dc522d3cf030b307364b1ada0b
-        Summary: Use the good Sass variable to initialize the CSS var in accordion.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1521/commits/efdf62a61304e0e4f63f6a9665245b6a3757ed4b
-        Topics: Sass, Add a functionality, Breaking changes, Accordion
-        K/R: Keep
-    - https://github.com/twbs/bootstrap/commit/949456984aa21536afd35eddf7ea38b3648830a3
-        Summary: Manage the hover state on manual triggering in tooltip.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1521/commits/145b93615b461b598bc820397be5a88f7eff3e1d
-        Topics: Javascript, Fix, Tooltips
-        K/R: ?
-    - https://github.com/twbs/bootstrap/commit/23fb7a79156d1ea4ce2ab5713debbbc251b4e22f
-        Summary: Fix the click on scrollbar inside modal.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1521/commits/896a692e9b27e828309b47ad69abe6b8bebea856
-        Topics: Javascript, Fix, Modal
-        K/R: ?
-  * chore(merge main) patched commit → 2504b89 (#1513)
-    - https://github.com/twbs/bootstrap/commit/32c457db4b6ff389efbd35772b24746c7ffb0b6d
-        Summary: Change the focus management of buttons (use of :focus-visible instead of :focus).
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/f225846843ba8708980c1c4bf9c993845172acb0
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/a9bce73086fedf34cc3fdd50b0016754a50572a9
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/ee874a7fabbaa3da45a1595b68a196c6ea54cb2b
-                 https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1513/commits/a3fa822704747ee61a895a8151ae88f789b19e2f
-        Topics: Sass, Breaking changes, Button
-        K/R: Keep
-    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
-        - TODO
-  * chore(merge main) patched commit → 337068f (#1510)
-    - https://github.com/twbs/bootstrap/commit/b14190b5095195fbe803f81bf4ce56d09be5378d
-        Summary: Update popperjs dependency.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/363e4fee27febd22630716e8d88d716fe45b8cea
-        Topics: Dependencies
-        K/R: Keep
-    - https://github.com/twbs/bootstrap/commit/a0238d126b385044bd7cb16bdc9118f3d44e016f
-        Summary: Add a CSS var to toast.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/405215a187e037eee4f1192d31681c4bf317e2c6
-        Topics: Sass, Add functionality, Toast
-        K/R: Keep
-    - https://github.com/twbs/bootstrap/commit/bc2ec7c7583bed6f51571501739c9e7d57e3ba2f
-        Summary: Initialize a CSS var for button.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/290a0e37a09c23a45df6193147eee9b3933e60b2
-        Topics: Sass
-    - https://github.com/twbs/bootstrap/commit/2f3aec819ae7bd04c00cc55fee977d12e11a46c6
-        Summary: Fix z-index issues on input group + support z-index for floating labels.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/da975b0442a063ed4530adea167ba30a89b02734
-        Topics: Sass, Add functionality, Input group
-        K/R: Keep to prevent issues with zindex
-    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
-        - TODO
-  * feat(breadcrumb): add dark variant (#1430)
-        Summary: Add a dark variant and a CSS var for breadcrumb.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1430
-        Topics: Docs, Sass, Add functionality, Breadcrumb
-        K/R: Keep
-  * feat(pagination): add dark variant (#1433)
-        Summary: Add a dark variant and a CSS var for pagination.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1433
-        Topics: Docs, Sass, Add functionality, Pagination
-        K/R: Keep
-  * fix(dropdowns): add and trim CSS vars (#1423)
-        Summary: Add and remove some CSS var in dropdown.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1423
-        Topics: Sass, Add functionality, Breaking changes, Dropdowns
-        K/R: Keep
-  * fix(docs): fix Orange Helvetica CSS file name in docs (#1487)
-        Summary: Fix documentation for Helvetica files.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1487
-        Topics: Docs
-        K/R: Keep (Don't know if this is mentioned anywhere)
-  * feat(stepped process): add dark variant (#1434)
-        Summary: Add a dark variant for stepped process.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1434
-        Topics: Docs, Sass, Add functionality, Stepped process
-        K/R: Keep
-  * fix(dropdown toggle split): same width for all `.dropdown-toggle-split`s orientations (#1451)
-        Summary: Add `min-width` to `.dropdown-toggle-split`.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1451
-        Topics: Sass, Add functionality, Dropdown
-        K/R: Keep
-  * fix(modal): remove unused CSS variables (#1418)
-        Summary: Remove some CSS var in modal.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1418
-        Topics: Sass, Breaking changes, Modal
-        K/R: Keep
-  * fix(pagination): remove CSS variables (#1457)
-        Summary: Remove some CSS var in pagination.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1457
-        Topics: Sass, Breaking changes, Pagination
-        K/R: Keep
-  * fix(alerts): increase height when additional content (#1425)
-        Summary: Change the line-height inside alerts.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1425
-        Topics: Sass, Add functionality, Alerts
-        K/R: Keep
-  * chore(merge main) patched commit → c3c6591 [#1469](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469)
-    - https://github.com/twbs/bootstrap/commit/db86607c088bd307aa21f4b4bd0258262262a4e4
-        Summary: Add a threshold option on Scrollspy.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1469/commits/399ba677af1bf46098c797bf0419302e8b58dc03
-        Topics: Javascript, Add functionality, Scrollspy
-        K/R: Keep
-  * feat(pagination): new `#{$prefix}pagination-padding-end` CSS var [#1416](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1416)
-        Summary: new `#{$prefix}pagination-padding-end` CSS var
-        Boosted: None
-        Topics: Sass, Minor change, Pagination
-        K/R: Keep
-  * fix(css): drop unused $list-group-hover-bg and `#{$prefix}list-group-action-hover-bg` [#1417](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1417)
-        Summary: drop unused $list-group-hover-bg and `#{$prefix}list-group-action-hover-bg`
-        Boosted: None
-        Topics: Sass, Deprecated, List-group
-        K/R: Keep
--->
 
 ## v5.2.0
 

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -21,58 +21,59 @@ toc: true
 <!--
   * fix(footers): change 'Terms & Conditions' to 'Terms and conditions'
     This information is important for the users in order to change the label they could have used
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1564
+    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1564
 -->
 - <span class="badge bg-warning align-text-top">Warning</span> All **Footers** examples have been modified to use the "Terms and conditions" wording instead of "Terms & Conditions". Please reflect this modification into your websites.
 
+<!--
+  * feat(components): new Tags component
+    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/988
+-->
 - <span class="badge bg-info align-text-top">New</span> **Tags** component.
+
+### Icons and images
+
+<!--
+* fix(a11y): fix(a11y): add aria-hidden=true and focusable=false to SVGs in tooltips examples
+  - SVGs in tooltips do not carry any specific information so they should not be readable by screen reader so we should add 'aria-hidden=true'
+  - In addition, replaced the missing 'focusable=false' on the first svg
+    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1555
+-->
+- <span class="badge bg-warning align-text-top">Warning</span> **Tooltips** examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites.
+
+<!--
+* fix(icons): use the right close icon
+  - Change the SVG of the close icon used in modal, offcanvas and close buttons
+    Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1566
+-->
+- The close icon SVG has changed in modals, offcanvases and close buttons. Although is has no direct impact, you might want apply this same modification within your websites.
+
+### Helpers
+
+- <span class="badge bg-info align-text-top">New</span> `.img-thumbnail` officially supported.
+
+### CSS and Sass variables
+
+- <span class="badge bg-info align-text-top">New</span> Here is an exhaustive list of new CSS variables:
+  - `--bs-alert-btn-close-offset`
+  - `--bs-alert-dismissible-padding-right`
+  - `--bs-alert-heading-font-weight`
+  - `--bs-alert-icon-margin-y`
+  - `--bs-alert-icon-size`
+  - `--bs-alert-line-height`
+  - `--bs-alert-link-font-weight`
+  - `--bs-alert-logo-size`
+  - `--bs-navbar-font-weight`
+  - `--bs-navbar-toggler-icon-filter`
+
+- <span class="badge bg-info align-text-top">New</span> Here is an exhaustive list of new Sass variables:
+  - `$alert-heading-font-weight`
+  - `$alert-icon-size-sm`
+  - `$navbar-font-weight`
 
 
 <!--
 ### TODO
-  * feat(components): new Tags component
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/988
-  * fix(icons): use the right close icon
-    - Change the SVG of the close icon used in modal, offcanvas and close buttons
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1566
-  * fix(forms): prevent that valid icon hides input content
-    - Valid icons don't hide anymore content in inputs when too long
-    - Quantity selector doesn't display valid icon anymore
-    - .form-control-color display the valid icon correctly and doesn't change its width when invalid
-    - .form-check-input -> switches are displayed correctly when invalid (no blue border)
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1306
-  * fix(a11y): fix(a11y): add aria-hidden=true and focusable=false to SVGs in tooltips examples
-    - SVGs in tooltips do not carry any specific information so they should not be readable by screen reader so we should add 'aria-hidden=true'
-    - In addition, replaced the missing 'focusable=false' on the first svg
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1555
-  * fix(forms): add validation icons for <select>s and fix its position for `<textarea>`
-    - Reset to Bootstrap default for feedback icon on select
-    - Setting the icon in the top right corner instead of center right
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1371
-  * feat(css): add CSS vars to alerts
-    - NEW CSS vars:
-        - #{$prefix}alert-line-height
-        - #{$prefix}alert-logo-size: #{$alert-logo-size};
-        - #{$prefix}alert-icon-size: #{$alert-icon-size};
-        - #{$prefix}alert-icon-margin-y: #{$alert-icon-margin-y};
-        - #{$prefix}alert-link-font-weight: #{$alert-link-font-weight};
-        - #{$prefix}alert-heading-font-weight: #{$alert-heading-font-weight};
-        - #{$prefix}alert-dismissible-padding-right: #{$alert-dismissible-padding-r};
-        - #{$prefix}alert-btn-close-offset: #{$alert-btn-close-offset};
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1424
-  * feat(css): add CSS vars to navbars
-    - NEW `$navbar-font-weight` for SCSS vars.
-    - NEW `#{$prefix}navbar-nav-font-size` and `#{$prefix}navbar-nav-line-height` for .supra
-    - NEW `#{$prefix}navbar-toggler-icon-filter` and `#{$prefix}navbar-font-weight` for .navbar
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1422
-  * feat(css): define `.btn-no-outline`, `.btn-link` and `.btn-social` with CSS vars
-    - Reuse of buttons CSS variables to define `.btn-no-outline`, `.btn-link` and `.btn-social`
-    - Probably not any impacts for the users
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1426
-  * feat(utilities): revamp `.img-thumbnail` and add desc in docs
-    - Revamp rendering of `.img-thumbnail`
-    - Add a new section in the Content > Images > Image thumbnails docs
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1441
   * doc(examples): remove Bootstrap examples unused in Boosted
     - Mainly removed the files. No impact for the user. Only concerns the docs.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1542
@@ -615,6 +616,16 @@ toc: true
 
 * fix(css): rename `$prefix` by `$func-prefix` in `get-color-from-rgba-string` function
     Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1567
+* fix(forms): prevent that valid icon hides input content
+    - Valid icons don't hide anymore content in inputs when too long
+    - Quantity selector doesn't display valid icon anymore
+    - .form-control-color display the valid icon correctly and doesn't change its width when invalid
+    - .form-check-input -> switches are displayed correctly when invalid (no blue border)
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1306
+* fix(forms): add validation icons for <select>s and fix its position for `<textarea>`
+    - Reset to Bootstrap default for feedback icon on select
+    - Setting the icon in the top right corner instead of center right
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1371
 -->
 
 ## v5.2.0

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -15,11 +15,14 @@ toc: true
 
 ### Components
 
-<!--* fix(back to top): remove 'Label inside' variant (#1520) -->
+<!--- * fix(back to top): remove 'Label inside' variant (#1520) -->
 - <span class="badge bg-danger">Breaking</span> **Back to top** 'Label inside' variant was removed because not compliant with Orange Design System. Even if the rendering could still work, it is recommended to only use the versions presented in the documentation.
 
-<!--
-  * fix(css):
+<!---
+  * doc(examples): remove Bootstrap examples unused in Boosted
+    - Mainly removed the files. No impact for the user. Only concerns the docs.
+        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1542
+  * fix(css): reduce the scope of root dark text rule
     - Changed the CSS rule to apply text style with a dark variant (was it already there in v5.2.0?)
     - Added a section Customize > CSS variables > Dark text rule in docs
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1293
@@ -551,7 +554,7 @@ toc: true
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1421/commits/1d00904aec9702cf9c23525658b7752c935eb4a2
         Topics: Dependency
         K/R: ?
-    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide -> Done
+    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide >> Done
 -->
 
 ## v5.2.0
@@ -811,7 +814,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 ## Forms
 
-<!-- Boosted mod: no floating labels -->
+<!--- Boosted mod: no floating labels -->
 
 - <span class="badge bg-danger">Breaking</span> **Consolidated native and custom form elements.** Checkboxes, radios, selects, and other inputs that had native and custom classes in v4 have been consolidated. Now nearly all our form elements are entirely custom, most without the need for custom HTML.
   - `.custom-control.custom-checkbox` is now `.form-check`.

--- a/site/content/docs/5.2/migration.md
+++ b/site/content/docs/5.2/migration.md
@@ -25,6 +25,10 @@ toc: true
 
 - <span class="badge bg-info">New</span> **Tags** component.
 
+#### Dark variants
+
+- <span class="badge bg-info">New</span> **List group** dark variant.
+
 ### Icons and images
 
 - <span class="badge bg-warning">Warning</span> **Tooltips** examples applied on SVGs have been updated to use `focusable="false"` and `aria-hidden="true"` because SVGs do not carry any specific information so they should not be readable by screen readers. Please reflect this modification in your websites.
@@ -82,6 +86,18 @@ toc: true
   - `$btn-close-white-color`
   - `$btn-close-white-disabled-color`
   - `$btn-close-white-hover-color`
+  - `$list-group-dark-action-active-bg`
+  - `$list-group-dark-action-active-color`
+  - `$list-group-dark-action-color`
+  - `$list-group-dark-action-hover-color`
+  - `$list-group-dark-active-bg`
+  - `$list-group-dark-active-border-color`
+  - `$list-group-dark-active-color`
+  - `$list-group-dark-bg`
+  - `$list-group-dark-border-color`
+  - `$list-group-dark-color`
+  - `$list-group-dark-disabled-bg`
+  - `$list-group-dark-disabled-color`
   - `$mark-bg-dark`
   - `$mark-color`
   - `$mark-color-dark`
@@ -92,17 +108,6 @@ toc: true
 
 <!--
 ### TODO
-  * feat(list group): add dark variant (#1525)
-        Summary: Add a dark variant to list group.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1525
-        Topics: Docs, Sass, Add a functionality, List group
-        K/R: Keep
-  * fix(css): add workaround for postcss value parser error (#1524)
-    - Note: linked to previous chore(merge) from Bootstrap. Just forgot to fix this one
-        Summary: Update Sass file for postcss parser.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1524
-        Topics: Sass, Fix, Navbar
-        K/R: Remove
   * chore(merge main patched commit) → 23fb7a7 (#1521)
     - https://github.com/twbs/bootstrap/commit/97a9060a8fa643484fbe70d1e527267841670c9d (same as the one following, should have been squashed)
     - https://github.com/twbs/bootstrap/commit/9b943880fc38ccde372973111fe5872b5960e75d
@@ -161,64 +166,17 @@ toc: true
         Topics: Sass, Button
         K/R: ?
     - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
-  * fix(docs): change responsive values in utility API examples (#1488)
-        Summary: Change the responsive values in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1488
-        Topics: Docs, API
-        K/R: Remove
   * chore(merge main) patched commit → 337068f (#1510)
     - https://github.com/twbs/bootstrap/commit/b14190b5095195fbe803f81bf4ce56d09be5378d
         Summary: Update popperjs dependency.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/363e4fee27febd22630716e8d88d716fe45b8cea
         Topics: Dependencies
         K/R: Keep
-    - https://github.com/twbs/bootstrap/commit/77e17e3b8deb4d5467203f4e3cd903b7cd06bde4
-        Summary: Fix typo in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/9e31e675975fd0a135f571268bba4f26f6407be1
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/b5f2d5a31e24455447939c3a7487a4fe89a66ba6
-        Summary: Fix typo in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/349987f4f76e2fa66231abbb8300f640c6c3d2fa
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/4f97d8fabda142685e36391da2c37c7e09955ac6
-        Summary: Update Webpack guide doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/22ad93727a051a3f11b9459e300766e4a985f0b6
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/279363783759323c988d227145d5f6bc6c683efd
-        Summary: Fix 'precompiled' in the doc.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/0da15f756831a113c89a043ece5f094864d19849
-        Topics: Docs
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/8c380b2676eb5eb76716b94763ef21e98c86b9b7
-        Summary: Update the accordion Sass for accordion-flush.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/ab72fa70bb78d0bfc4ca6639070403c10bba82f0
-        Topics: Sass
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/54b4b2c66a6f0f403a8120a0c7720f29aaa71f7c
-        Summary: Explain a bit better vertical gutters.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/72d7d58f5feb514cc8c38ad219d29e9d763a5fb2
-        Topics: Docs, Gutters
-        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/337068f8b1044004f4b9abfffbb433694ae87993
         Summary: Fix wrong dropdown menu opening when severals dropdowns in one element.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1510/commits/7961a7acb10d49a0831711b983169641a3e30571
         Topics: Javascript, Fix, Dropdown
         K/R: ?
-    - Check also the content of the diff to see if anything specific to Boosted was done and must be mentioned in the guide
-  * chore(merge main) patched commit → 3ad8551 (#1507)
-    - ~~https://github.com/twbs/bootstrap/commit/af1bd974bba7f6e7f90c5ed3f42738bd101926cb~~ - Was already done via Dependabot
-        Summary: Update @rollup dependency.
-        Boosted: None
-        Topics: Dependencies
-        K/R: Remove
-    - https://github.com/twbs/bootstrap/commit/29332a954f86671d39f60007fb0c2ea633731e88
-        Summary: Doc update in tables.
-        Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/33c99bde00d0fe76202ffaf48f5634a5e388afd5
-        Topics: Docs
-        K/R: Remove
     - https://github.com/twbs/bootstrap/commit/15318674fb086214e095c61af780a7d889f0f11e
         Summary: Reorder offcanvas doc.
         Boosted: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1507/commits/125f0f1b83dfc334049a355724a72aa793e16dcb


### PR DESCRIPTION
- [x] Integrate in comments all Bootstrap and Boosted commits
  - Latest commit integrated in this list is https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/commit/b7b16d57c35bb1352ac114776359f1df3c4ee5e8
- [x] Remove from this list things that are purely documentation updates
  - :warning: If the markups are modified in the documentation, it could mean that something should be integrated in the migration guide
- [x] Remove from this list things that modify the dependencies if they have no impact for the users
- [x] For each item, write an explanation to help the user migration from v5.2.0 to v5.2.1 (by trying to evaluate the impact)
  - Try to add temporarily a comment next to the new sentence in order for the reviewers to be able to go directly to the commit in Bootstrap or Boosted. Example is done for the back to top component
- [x] Group together topics than can for better readability. During a migration, users will tackle topics by topics.
- [x] Remove all comments before merging

/cc @louismaximepiton 

### [Live preview](https://deploy-preview-1522--boosted.netlify.app/docs/5.2/migration/#v521)