### PR TITLE
fix(css): add workaround for postcss value parser error

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -293,7 +293,7 @@
 // Button for toggling the navbar when in its collapsed state
 .navbar-toggler {
   padding: var(--#{$prefix}navbar-toggler-padding-y) calc(var(--#{$prefix}navbar-toggler-padding-x) / 2) var(--#{$prefix}navbar-toggler-padding-y) var(--#{$prefix}navbar-toggler-padding-x); /* stylelint-disable-line function-disallowed-list */ // Boosted mod
-  margin-right: calc(var(--#{$prefix}navbar-toggler-padding-x) / -2); /* stylelint-disable-line function-disallowed-list */ // Boosted mod
+  margin-right: calc(-.5 * var(--#{$prefix}navbar-toggler-padding-x)); /* stylelint-disable-line function-disallowed-list */ // Boosted mod
   @include font-size(var(--#{$prefix}navbar-toggler-font-size));
   line-height: 1;
   color: var(--#{$prefix}navbar-color);


### PR DESCRIPTION
Fixes #1523

`postcss-values-parser` returns a syntax error when a negative value is provided in a `calc` function after a CSS variable. We learnt that with https://github.com/twbs/bootstrap/commit/b8880e5eec6bb4f33578578ba2413f0d91424382 but we didn't know the issue could happen with divisions as well; at least we didn't think about it.

In order to review this PR, please execute the steps explained in the issue but instead of copying the code from the _main_ branch of the Boosted repository, please use the code provided in this branch.