### PR TITLE
chore(workflows): replace percy/snapshot-action by Percy CLI

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm run docs-build
 
       - name: Percy Test
-        run: npx percy snapshot _site/
+        run: npx percy snapshot _site/ --include="./docs/**/components/**/*.html"
         # run: npx percy snapshot _site/ --include ./docs/**/components/**/*.html --include ./docs/**/forms/**/*.html -v
         # uses: percy/snapshot-action@v0.1.2
         # with:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm run docs-build
 
       - name: Percy Test
-        run: npx percy snapshot _site/ --include="./docs/**/components/**/*.html"
+        run: npx percy snapshot _site/ --include '/docs/**/components/**/*.html'
         # run: npx percy snapshot _site/ --include ./docs/**/components/**/*.html --include ./docs/**/forms/**/*.html -v
         # uses: percy/snapshot-action@v0.1.2
         # with:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm run docs-build
 
       - name: Percy Test
-        run: npx percy snapshot _site/ --include ./docs/**/components/**/*.html --include ./docs/**/forms/**/*.html" -v
+        run: npx percy snapshot _site/ --include ./docs/**/components/**/*.html --include ./docs/**/forms/**/*.html -v
         # uses: percy/snapshot-action@v0.1.2
         # with:
           # build-directory: "_site/"

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,14 +1,14 @@
 name: Percy
 on:
   push:
-  #  paths:
-  #    - 'js/**'
-  #    - 'scss/**'
-  #    - 'site/content/docs/**/components/**'
-  #    - 'site/content/docs/**/forms/**'
-  #  branches:
-  #    - main
-  #    - v4-dev
+    paths:
+      - 'js/**'
+      - 'scss/**'
+      - 'site/content/docs/**/components/**'
+      - 'site/content/docs/**/forms/**'
+    branches:
+      - main
+      - v4-dev
   workflow_dispatch:
 
 env:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -46,7 +46,8 @@ jobs:
         run: npm run docs-build
 
       - name: Percy Test
-        run: npx percy snapshot _site/ --include ./docs/**/components/**/*.html --include ./docs/**/forms/**/*.html -v
+        run: npx percy snapshot _site/
+        # run: npx percy snapshot _site/ --include ./docs/**/components/**/*.html --include ./docs/**/forms/**/*.html -v
         # uses: percy/snapshot-action@v0.1.2
         # with:
           # build-directory: "_site/"

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -46,12 +46,6 @@ jobs:
         run: npm run docs-build
 
       - name: Percy Test
-        run: npx percy snapshot _site/ --include '/docs/**/components/**/*.html'
-        # run: npx percy snapshot _site/ --include ./docs/**/components/**/*.html --include ./docs/**/forms/**/*.html -v
-        # uses: percy/snapshot-action@v0.1.2
-        # with:
-          # build-directory: "_site/"
-          # flags: "--snapshot-files ./docs/**/components/**/*.html,./docs/**/forms/**/*.html"
-          # verbose: true
+        run: npx percy snapshot _site/ --include '/docs/**/components/**/*.html' --include '/docs/**/forms/**/*.html'
         env:
           PERCY_TOKEN: "${{ secrets.PERCY_TOKEN }}"

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,6 +1,6 @@
 name: Percy
-#on:
-  #push:
+on:
+  push:
   #  paths:
   #    - 'js/**'
   #    - 'scss/**'
@@ -9,7 +9,7 @@ name: Percy
   #  branches:
   #    - main
   #    - v4-dev
-  #workflow_dispatch:
+  workflow_dispatch:
 
 env:
   FORCE_COLOR: 2

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,15 +1,15 @@
 name: Percy
-on:
-  push:
-    paths:
-      - 'js/**'
-      - 'scss/**'
-      - 'site/content/docs/**/components/**'
-      - 'site/content/docs/**/forms/**'
-    branches:
-      - main
-      - v4-dev
-  workflow_dispatch:
+#on:
+  #push:
+  #  paths:
+  #    - 'js/**'
+  #    - 'scss/**'
+  #    - 'site/content/docs/**/components/**'
+  #    - 'site/content/docs/**/forms/**'
+  #  branches:
+  #    - main
+  #    - v4-dev
+  #workflow_dispatch:
 
 env:
   FORCE_COLOR: 2
@@ -46,10 +46,11 @@ jobs:
         run: npm run docs-build
 
       - name: Percy Test
-        uses: percy/snapshot-action@v0.1.2
-        with:
-          build-directory: "_site/"
-          flags: "--snapshot-files ./docs/**/components/**/*.html,./docs/**/forms/**/*.html"
-          verbose: true
+        run: npx percy snapshot _site/ --include ./docs/**/components/**/*.html,./docs/**/forms/**/*.html"
+        # uses: percy/snapshot-action@v0.1.2
+        # with:
+          # build-directory: "_site/"
+          # flags: "--snapshot-files ./docs/**/components/**/*.html,./docs/**/forms/**/*.html"
+          # verbose: true
         env:
           PERCY_TOKEN: "${{ secrets.PERCY_TOKEN }}"

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm run docs-build
 
       - name: Percy Test
-        run: npx percy snapshot _site/ --include ./docs/**/components/**/*.html,./docs/**/forms/**/*.html"
+        run: npx percy snapshot _site/ --include ./docs/**/components/**/*.html --include ./docs/**/forms/**/*.html" -v
         # uses: percy/snapshot-action@v0.1.2
         # with:
           # build-directory: "_site/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/cli": "^7.18.10",
         "@babel/core": "^7.18.13",
         "@babel/preset-env": "^7.18.10",
+        "@percy/cli": "^1.10.2",
         "@popperjs/core": "^2.11.6",
         "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-commonjs": "^22.0.2",
@@ -1933,6 +1934,322 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@percy/cli": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.10.2.tgz",
+      "integrity": "sha512-jol4tLkafI01qgDNcuiMiIIwovCkABi8eeWsqrkpHCn4ovJkKgzWYxswBEQt1xmG5weRJGrvqwgZWFDzCjzIeg==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-app": "1.10.2",
+        "@percy/cli-build": "1.10.2",
+        "@percy/cli-command": "1.10.2",
+        "@percy/cli-config": "1.10.2",
+        "@percy/cli-exec": "1.10.2",
+        "@percy/cli-snapshot": "1.10.2",
+        "@percy/cli-upload": "1.10.2",
+        "@percy/client": "1.10.2",
+        "@percy/logger": "1.10.2"
+      },
+      "bin": {
+        "percy": "bin/run.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-app": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.10.2.tgz",
+      "integrity": "sha512-1Ysyqsupfr8/PjcFqoNRVEdCsk8ssRMoxUQFb88r6fkfaR+1UQGq1feKQcc2EAeZtizu4HZvkFmTsNKIaccmVQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2",
+        "@percy/cli-exec": "1.10.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-build": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.10.2.tgz",
+      "integrity": "sha512-k/obA7JLl6rl8WNrz1U687/igYjwbAxGVjTK8Ipxmy0D1GG0JU+QI+kAx+1HflUTLMqLrecXDxbgAIPEXHbi3A==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-command": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.10.2.tgz",
+      "integrity": "sha512-5V8zEPbtn7FXI9i6RIeUrTHawbdD0Fipby1W/fw/qBN6yiXgeSEwCQ5l2YUHZdkfrDOaXZEzjWDBcWV89M+QAQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/config": "1.10.2",
+        "@percy/core": "1.10.2",
+        "@percy/logger": "1.10.2"
+      },
+      "bin": {
+        "percy-cli-readme": "bin/readme.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-config": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.10.2.tgz",
+      "integrity": "sha512-bxAU/KIHItWmUDoNwwMj2wNY0HfizUa/Vp8/ahikTTuxsREXZ7WQK+ExZEgKo6r7/Cw5AN6N5Bs2A1qwcbZv2w==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-exec": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.10.2.tgz",
+      "integrity": "sha512-qrGu9Zm0+ElYeT6IU1AVd/pBujH8Mce6MmrQyFpbkIX8Nu3NIAETwiaR0GwjiHqVvMQU5qbJVtupz4SAAe3PIQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2",
+        "cross-spawn": "^7.0.3",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-snapshot": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.10.2.tgz",
+      "integrity": "sha512-NxysEuQHmEo7W5knaYV0UJn+zPJBYUrXecQBfSTLl1o+N1M9OIUCiE7wkJvU2w+t9Nw+kVZvtZn0wHbCgLfQfw==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-snapshot/node_modules/yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@percy/cli-upload": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.10.2.tgz",
+      "integrity": "sha512-dCYBGBoeLdOUIkuy2KkKk2H3T4QNXuuIbxjCEpbCbY4uX9HeTOfpVnqMFQj4XX7JI83WwmHdrZ6CwVwqOVO3sg==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2",
+        "fast-glob": "^3.2.11",
+        "image-size": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.10.2.tgz",
+      "integrity": "sha512-Zvp37zN4rrtgB3XMUSdmk1bDvyoNfJfF61TWoHWe6H4qMHsed81vA11DKVX5OZf6f/e+pSdXae9Wi7VBVx7v1Q==",
+      "dev": true,
+      "dependencies": {
+        "@percy/env": "1.10.2",
+        "@percy/logger": "1.10.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/config": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.10.2.tgz",
+      "integrity": "sha512-9uPbmP64/9WwrGX4isMr4SqKrE1RQGiv0tRwWY2+iLJOgzuTBpXRH1W69ZaKPvf5B4WXicjQcs4qReIAy5WNcA==",
+      "dev": true,
+      "dependencies": {
+        "@percy/logger": "1.10.2",
+        "ajv": "^8.6.2",
+        "cosmiconfig": "^7.0.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/config/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@percy/config/node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@percy/config/node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@percy/config/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/@percy/config/node_modules/yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@percy/core": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.10.2.tgz",
+      "integrity": "sha512-ytxaaXhx1OHiV+LK9dD/pGLu3LfITBSPwtelcLpxiw7YlSy4gilGKnk3Vn2p04VCKebKVhnJOT+3IKyJ52NFqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@percy/client": "1.10.2",
+        "@percy/config": "1.10.2",
+        "@percy/dom": "1.10.2",
+        "@percy/logger": "1.10.2",
+        "content-disposition": "^0.5.4",
+        "cross-spawn": "^7.0.3",
+        "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
+        "mime-types": "^2.1.34",
+        "path-to-regexp": "^6.2.0",
+        "rimraf": "^3.0.2",
+        "ws": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/core/node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/@percy/core/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@percy/core/node_modules/ws": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@percy/dom": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.10.2.tgz",
+      "integrity": "sha512-BDCVfQlomn/pIbNbIMWc+EbSm2kCD3as0xSaWb+1BeSjf+pQZ700u6ZSBI2wJ1RXlXYy+gv0+B5VJQUtJo2riQ==",
+      "dev": true
+    },
+    "node_modules/@percy/env": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.10.2.tgz",
+      "integrity": "sha512-TKIjcR6CtPYf8JMtQX48vIY4dcxLErR+uJ+ylMPPqSm2C7BUswdkbHTYvK1vFlB1dBIY3wU8xt0khHQq01RPnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/logger": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.10.2.tgz",
+      "integrity": "sha512-Sg67QklLHM7oTv80RH2PovV4Ps0mjiRrLYzxbsAvDopn73alPvy5uWHtJAHnJc3EYCiBde43L1jOSsGCsOv0Tg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -2135,6 +2452,16 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@yarnpkg/parsers": {
       "version": "3.0.0-rc.15",
@@ -6216,6 +6543,21 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/image-size": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
+      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "dev": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -8589,6 +8931,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -9186,6 +9534,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -12615,7 +12972,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
       "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@eslint/eslintrc": {
       "version": "1.3.1",
@@ -12779,6 +13137,240 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@percy/cli": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.10.2.tgz",
+      "integrity": "sha512-jol4tLkafI01qgDNcuiMiIIwovCkABi8eeWsqrkpHCn4ovJkKgzWYxswBEQt1xmG5weRJGrvqwgZWFDzCjzIeg==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-app": "1.10.2",
+        "@percy/cli-build": "1.10.2",
+        "@percy/cli-command": "1.10.2",
+        "@percy/cli-config": "1.10.2",
+        "@percy/cli-exec": "1.10.2",
+        "@percy/cli-snapshot": "1.10.2",
+        "@percy/cli-upload": "1.10.2",
+        "@percy/client": "1.10.2",
+        "@percy/logger": "1.10.2"
+      }
+    },
+    "@percy/cli-app": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.10.2.tgz",
+      "integrity": "sha512-1Ysyqsupfr8/PjcFqoNRVEdCsk8ssRMoxUQFb88r6fkfaR+1UQGq1feKQcc2EAeZtizu4HZvkFmTsNKIaccmVQ==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2",
+        "@percy/cli-exec": "1.10.2"
+      }
+    },
+    "@percy/cli-build": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.10.2.tgz",
+      "integrity": "sha512-k/obA7JLl6rl8WNrz1U687/igYjwbAxGVjTK8Ipxmy0D1GG0JU+QI+kAx+1HflUTLMqLrecXDxbgAIPEXHbi3A==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2"
+      }
+    },
+    "@percy/cli-command": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.10.2.tgz",
+      "integrity": "sha512-5V8zEPbtn7FXI9i6RIeUrTHawbdD0Fipby1W/fw/qBN6yiXgeSEwCQ5l2YUHZdkfrDOaXZEzjWDBcWV89M+QAQ==",
+      "dev": true,
+      "requires": {
+        "@percy/config": "1.10.2",
+        "@percy/core": "1.10.2",
+        "@percy/logger": "1.10.2"
+      }
+    },
+    "@percy/cli-config": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.10.2.tgz",
+      "integrity": "sha512-bxAU/KIHItWmUDoNwwMj2wNY0HfizUa/Vp8/ahikTTuxsREXZ7WQK+ExZEgKo6r7/Cw5AN6N5Bs2A1qwcbZv2w==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2"
+      }
+    },
+    "@percy/cli-exec": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.10.2.tgz",
+      "integrity": "sha512-qrGu9Zm0+ElYeT6IU1AVd/pBujH8Mce6MmrQyFpbkIX8Nu3NIAETwiaR0GwjiHqVvMQU5qbJVtupz4SAAe3PIQ==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2",
+        "cross-spawn": "^7.0.3",
+        "which": "^2.0.2"
+      }
+    },
+    "@percy/cli-snapshot": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.10.2.tgz",
+      "integrity": "sha512-NxysEuQHmEo7W5knaYV0UJn+zPJBYUrXecQBfSTLl1o+N1M9OIUCiE7wkJvU2w+t9Nw+kVZvtZn0wHbCgLfQfw==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2",
+        "yaml": "^2.0.0"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+          "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/cli-upload": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.10.2.tgz",
+      "integrity": "sha512-dCYBGBoeLdOUIkuy2KkKk2H3T4QNXuuIbxjCEpbCbY4uX9HeTOfpVnqMFQj4XX7JI83WwmHdrZ6CwVwqOVO3sg==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2",
+        "fast-glob": "^3.2.11",
+        "image-size": "^1.0.0"
+      }
+    },
+    "@percy/client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.10.2.tgz",
+      "integrity": "sha512-Zvp37zN4rrtgB3XMUSdmk1bDvyoNfJfF61TWoHWe6H4qMHsed81vA11DKVX5OZf6f/e+pSdXae9Wi7VBVx7v1Q==",
+      "dev": true,
+      "requires": {
+        "@percy/env": "1.10.2",
+        "@percy/logger": "1.10.2"
+      }
+    },
+    "@percy/config": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.10.2.tgz",
+      "integrity": "sha512-9uPbmP64/9WwrGX4isMr4SqKrE1RQGiv0tRwWY2+iLJOgzuTBpXRH1W69ZaKPvf5B4WXicjQcs4qReIAy5WNcA==",
+      "dev": true,
+      "requires": {
+        "@percy/logger": "1.10.2",
+        "ajv": "^8.6.2",
+        "cosmiconfig": "^7.0.0",
+        "yaml": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "cosmiconfig": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          },
+          "dependencies": {
+            "yaml": {
+              "version": "1.10.2",
+              "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+              "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+              "dev": true
+            }
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "yaml": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+          "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/core": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.10.2.tgz",
+      "integrity": "sha512-ytxaaXhx1OHiV+LK9dD/pGLu3LfITBSPwtelcLpxiw7YlSy4gilGKnk3Vn2p04VCKebKVhnJOT+3IKyJ52NFqw==",
+      "dev": true,
+      "requires": {
+        "@percy/client": "1.10.2",
+        "@percy/config": "1.10.2",
+        "@percy/dom": "1.10.2",
+        "@percy/logger": "1.10.2",
+        "content-disposition": "^0.5.4",
+        "cross-spawn": "^7.0.3",
+        "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
+        "mime-types": "^2.1.34",
+        "path-to-regexp": "^6.2.0",
+        "rimraf": "^3.0.2",
+        "ws": "^8.0.0"
+      },
+      "dependencies": {
+        "extract-zip": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+          "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+          "dev": true,
+          "requires": {
+            "@types/yauzl": "^2.9.1",
+            "debug": "^4.1.1",
+            "get-stream": "^5.1.0",
+            "yauzl": "^2.10.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "ws": {
+          "version": "8.8.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+          "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "@percy/dom": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.10.2.tgz",
+      "integrity": "sha512-BDCVfQlomn/pIbNbIMWc+EbSm2kCD3as0xSaWb+1BeSjf+pQZ700u6ZSBI2wJ1RXlXYy+gv0+B5VJQUtJo2riQ==",
+      "dev": true
+    },
+    "@percy/env": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.10.2.tgz",
+      "integrity": "sha512-TKIjcR6CtPYf8JMtQX48vIY4dcxLErR+uJ+ylMPPqSm2C7BUswdkbHTYvK1vFlB1dBIY3wU8xt0khHQq01RPnw==",
+      "dev": true
+    },
+    "@percy/logger": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.10.2.tgz",
+      "integrity": "sha512-Sg67QklLHM7oTv80RH2PovV4Ps0mjiRrLYzxbsAvDopn73alPvy5uWHtJAHnJc3EYCiBde43L1jOSsGCsOv0Tg==",
+      "dev": true
     },
     "@polka/url": {
       "version": "1.0.0-next.21",
@@ -12944,6 +13536,16 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
+    "@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@yarnpkg/parsers": {
       "version": "3.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.15.tgz",
@@ -13001,7 +13603,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "4.3.0",
@@ -14569,7 +15172,8 @@
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
           "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -16016,6 +16620,15 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "image-size": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
+      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "dev": true,
+      "requires": {
+        "queue": "6.0.2"
+      }
+    },
     "immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -16687,7 +17300,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-2.0.0.tgz",
       "integrity": "sha512-SB8HNNiazAHXM1vGEzf8/tSyEhkfxuDdhYdPBX2Mwgzt0OuF2gicApQ+uvXLID/gXyJQgvrM9+1/2SxZFUUDIA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-rollup-preprocessor": {
       "version": "7.0.7",
@@ -17775,6 +18389,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -18004,13 +18624,15 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-scss": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
       "integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-selector-parser": {
       "version": "6.0.10",
@@ -18026,7 +18648,8 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
       "integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-value-parser": {
       "version": "4.2.0",
@@ -18179,6 +18802,15 @@
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.3"
       }
     },
     "queue-microtask": {
@@ -19205,7 +19837,8 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz",
       "integrity": "sha512-IK6dWvE000+xBv9jbnHOnBq01gt6HGVB2ZTsot+QsMpe82doDQ9hvplxfv4YnpEuUwVGGd9y6nbaAnhrjcxhZQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylelint-config-recommended-scss": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/cli": "^7.18.10",
         "@babel/core": "^7.18.13",
         "@babel/preset-env": "^7.18.10",
-        "@percy/cli": "^1.10.2",
         "@popperjs/core": "^2.11.6",
         "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-commonjs": "^22.0.2",
@@ -1934,322 +1933,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@percy/cli": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.10.2.tgz",
-      "integrity": "sha512-jol4tLkafI01qgDNcuiMiIIwovCkABi8eeWsqrkpHCn4ovJkKgzWYxswBEQt1xmG5weRJGrvqwgZWFDzCjzIeg==",
-      "dev": true,
-      "dependencies": {
-        "@percy/cli-app": "1.10.2",
-        "@percy/cli-build": "1.10.2",
-        "@percy/cli-command": "1.10.2",
-        "@percy/cli-config": "1.10.2",
-        "@percy/cli-exec": "1.10.2",
-        "@percy/cli-snapshot": "1.10.2",
-        "@percy/cli-upload": "1.10.2",
-        "@percy/client": "1.10.2",
-        "@percy/logger": "1.10.2"
-      },
-      "bin": {
-        "percy": "bin/run.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/cli-app": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.10.2.tgz",
-      "integrity": "sha512-1Ysyqsupfr8/PjcFqoNRVEdCsk8ssRMoxUQFb88r6fkfaR+1UQGq1feKQcc2EAeZtizu4HZvkFmTsNKIaccmVQ==",
-      "dev": true,
-      "dependencies": {
-        "@percy/cli-command": "1.10.2",
-        "@percy/cli-exec": "1.10.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/cli-build": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.10.2.tgz",
-      "integrity": "sha512-k/obA7JLl6rl8WNrz1U687/igYjwbAxGVjTK8Ipxmy0D1GG0JU+QI+kAx+1HflUTLMqLrecXDxbgAIPEXHbi3A==",
-      "dev": true,
-      "dependencies": {
-        "@percy/cli-command": "1.10.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/cli-command": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.10.2.tgz",
-      "integrity": "sha512-5V8zEPbtn7FXI9i6RIeUrTHawbdD0Fipby1W/fw/qBN6yiXgeSEwCQ5l2YUHZdkfrDOaXZEzjWDBcWV89M+QAQ==",
-      "dev": true,
-      "dependencies": {
-        "@percy/config": "1.10.2",
-        "@percy/core": "1.10.2",
-        "@percy/logger": "1.10.2"
-      },
-      "bin": {
-        "percy-cli-readme": "bin/readme.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/cli-config": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.10.2.tgz",
-      "integrity": "sha512-bxAU/KIHItWmUDoNwwMj2wNY0HfizUa/Vp8/ahikTTuxsREXZ7WQK+ExZEgKo6r7/Cw5AN6N5Bs2A1qwcbZv2w==",
-      "dev": true,
-      "dependencies": {
-        "@percy/cli-command": "1.10.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/cli-exec": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.10.2.tgz",
-      "integrity": "sha512-qrGu9Zm0+ElYeT6IU1AVd/pBujH8Mce6MmrQyFpbkIX8Nu3NIAETwiaR0GwjiHqVvMQU5qbJVtupz4SAAe3PIQ==",
-      "dev": true,
-      "dependencies": {
-        "@percy/cli-command": "1.10.2",
-        "cross-spawn": "^7.0.3",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/cli-snapshot": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.10.2.tgz",
-      "integrity": "sha512-NxysEuQHmEo7W5knaYV0UJn+zPJBYUrXecQBfSTLl1o+N1M9OIUCiE7wkJvU2w+t9Nw+kVZvtZn0wHbCgLfQfw==",
-      "dev": true,
-      "dependencies": {
-        "@percy/cli-command": "1.10.2",
-        "yaml": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/cli-snapshot/node_modules/yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@percy/cli-upload": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.10.2.tgz",
-      "integrity": "sha512-dCYBGBoeLdOUIkuy2KkKk2H3T4QNXuuIbxjCEpbCbY4uX9HeTOfpVnqMFQj4XX7JI83WwmHdrZ6CwVwqOVO3sg==",
-      "dev": true,
-      "dependencies": {
-        "@percy/cli-command": "1.10.2",
-        "fast-glob": "^3.2.11",
-        "image-size": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/client": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.10.2.tgz",
-      "integrity": "sha512-Zvp37zN4rrtgB3XMUSdmk1bDvyoNfJfF61TWoHWe6H4qMHsed81vA11DKVX5OZf6f/e+pSdXae9Wi7VBVx7v1Q==",
-      "dev": true,
-      "dependencies": {
-        "@percy/env": "1.10.2",
-        "@percy/logger": "1.10.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/config": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.10.2.tgz",
-      "integrity": "sha512-9uPbmP64/9WwrGX4isMr4SqKrE1RQGiv0tRwWY2+iLJOgzuTBpXRH1W69ZaKPvf5B4WXicjQcs4qReIAy5WNcA==",
-      "dev": true,
-      "dependencies": {
-        "@percy/logger": "1.10.2",
-        "ajv": "^8.6.2",
-        "cosmiconfig": "^7.0.0",
-        "yaml": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/config/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@percy/config/node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@percy/config/node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@percy/config/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/@percy/config/node_modules/yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@percy/core": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.10.2.tgz",
-      "integrity": "sha512-ytxaaXhx1OHiV+LK9dD/pGLu3LfITBSPwtelcLpxiw7YlSy4gilGKnk3Vn2p04VCKebKVhnJOT+3IKyJ52NFqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@percy/client": "1.10.2",
-        "@percy/config": "1.10.2",
-        "@percy/dom": "1.10.2",
-        "@percy/logger": "1.10.2",
-        "content-disposition": "^0.5.4",
-        "cross-spawn": "^7.0.3",
-        "extract-zip": "^2.0.1",
-        "fast-glob": "^3.2.11",
-        "micromatch": "^4.0.4",
-        "mime-types": "^2.1.34",
-        "path-to-regexp": "^6.2.0",
-        "rimraf": "^3.0.2",
-        "ws": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/core/node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/@percy/core/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@percy/core/node_modules/ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@percy/dom": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.10.2.tgz",
-      "integrity": "sha512-BDCVfQlomn/pIbNbIMWc+EbSm2kCD3as0xSaWb+1BeSjf+pQZ700u6ZSBI2wJ1RXlXYy+gv0+B5VJQUtJo2riQ==",
-      "dev": true
-    },
-    "node_modules/@percy/env": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.10.2.tgz",
-      "integrity": "sha512-TKIjcR6CtPYf8JMtQX48vIY4dcxLErR+uJ+ylMPPqSm2C7BUswdkbHTYvK1vFlB1dBIY3wU8xt0khHQq01RPnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@percy/logger": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.10.2.tgz",
-      "integrity": "sha512-Sg67QklLHM7oTv80RH2PovV4Ps0mjiRrLYzxbsAvDopn73alPvy5uWHtJAHnJc3EYCiBde43L1jOSsGCsOv0Tg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -2452,16 +2135,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@yarnpkg/parsers": {
       "version": "3.0.0-rc.15",
@@ -6543,21 +6216,6 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
-    "node_modules/image-size": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
-      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
-      "dev": true,
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -8931,12 +8589,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-      "dev": true
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -9534,15 +9186,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -13138,240 +12781,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@percy/cli": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.10.2.tgz",
-      "integrity": "sha512-jol4tLkafI01qgDNcuiMiIIwovCkABi8eeWsqrkpHCn4ovJkKgzWYxswBEQt1xmG5weRJGrvqwgZWFDzCjzIeg==",
-      "dev": true,
-      "requires": {
-        "@percy/cli-app": "1.10.2",
-        "@percy/cli-build": "1.10.2",
-        "@percy/cli-command": "1.10.2",
-        "@percy/cli-config": "1.10.2",
-        "@percy/cli-exec": "1.10.2",
-        "@percy/cli-snapshot": "1.10.2",
-        "@percy/cli-upload": "1.10.2",
-        "@percy/client": "1.10.2",
-        "@percy/logger": "1.10.2"
-      }
-    },
-    "@percy/cli-app": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.10.2.tgz",
-      "integrity": "sha512-1Ysyqsupfr8/PjcFqoNRVEdCsk8ssRMoxUQFb88r6fkfaR+1UQGq1feKQcc2EAeZtizu4HZvkFmTsNKIaccmVQ==",
-      "dev": true,
-      "requires": {
-        "@percy/cli-command": "1.10.2",
-        "@percy/cli-exec": "1.10.2"
-      }
-    },
-    "@percy/cli-build": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.10.2.tgz",
-      "integrity": "sha512-k/obA7JLl6rl8WNrz1U687/igYjwbAxGVjTK8Ipxmy0D1GG0JU+QI+kAx+1HflUTLMqLrecXDxbgAIPEXHbi3A==",
-      "dev": true,
-      "requires": {
-        "@percy/cli-command": "1.10.2"
-      }
-    },
-    "@percy/cli-command": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.10.2.tgz",
-      "integrity": "sha512-5V8zEPbtn7FXI9i6RIeUrTHawbdD0Fipby1W/fw/qBN6yiXgeSEwCQ5l2YUHZdkfrDOaXZEzjWDBcWV89M+QAQ==",
-      "dev": true,
-      "requires": {
-        "@percy/config": "1.10.2",
-        "@percy/core": "1.10.2",
-        "@percy/logger": "1.10.2"
-      }
-    },
-    "@percy/cli-config": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.10.2.tgz",
-      "integrity": "sha512-bxAU/KIHItWmUDoNwwMj2wNY0HfizUa/Vp8/ahikTTuxsREXZ7WQK+ExZEgKo6r7/Cw5AN6N5Bs2A1qwcbZv2w==",
-      "dev": true,
-      "requires": {
-        "@percy/cli-command": "1.10.2"
-      }
-    },
-    "@percy/cli-exec": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.10.2.tgz",
-      "integrity": "sha512-qrGu9Zm0+ElYeT6IU1AVd/pBujH8Mce6MmrQyFpbkIX8Nu3NIAETwiaR0GwjiHqVvMQU5qbJVtupz4SAAe3PIQ==",
-      "dev": true,
-      "requires": {
-        "@percy/cli-command": "1.10.2",
-        "cross-spawn": "^7.0.3",
-        "which": "^2.0.2"
-      }
-    },
-    "@percy/cli-snapshot": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.10.2.tgz",
-      "integrity": "sha512-NxysEuQHmEo7W5knaYV0UJn+zPJBYUrXecQBfSTLl1o+N1M9OIUCiE7wkJvU2w+t9Nw+kVZvtZn0wHbCgLfQfw==",
-      "dev": true,
-      "requires": {
-        "@percy/cli-command": "1.10.2",
-        "yaml": "^2.0.0"
-      },
-      "dependencies": {
-        "yaml": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-          "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
-          "dev": true
-        }
-      }
-    },
-    "@percy/cli-upload": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.10.2.tgz",
-      "integrity": "sha512-dCYBGBoeLdOUIkuy2KkKk2H3T4QNXuuIbxjCEpbCbY4uX9HeTOfpVnqMFQj4XX7JI83WwmHdrZ6CwVwqOVO3sg==",
-      "dev": true,
-      "requires": {
-        "@percy/cli-command": "1.10.2",
-        "fast-glob": "^3.2.11",
-        "image-size": "^1.0.0"
-      }
-    },
-    "@percy/client": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.10.2.tgz",
-      "integrity": "sha512-Zvp37zN4rrtgB3XMUSdmk1bDvyoNfJfF61TWoHWe6H4qMHsed81vA11DKVX5OZf6f/e+pSdXae9Wi7VBVx7v1Q==",
-      "dev": true,
-      "requires": {
-        "@percy/env": "1.10.2",
-        "@percy/logger": "1.10.2"
-      }
-    },
-    "@percy/config": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.10.2.tgz",
-      "integrity": "sha512-9uPbmP64/9WwrGX4isMr4SqKrE1RQGiv0tRwWY2+iLJOgzuTBpXRH1W69ZaKPvf5B4WXicjQcs4qReIAy5WNcA==",
-      "dev": true,
-      "requires": {
-        "@percy/logger": "1.10.2",
-        "ajv": "^8.6.2",
-        "cosmiconfig": "^7.0.0",
-        "yaml": "^2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "cosmiconfig": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-          "dev": true,
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.2.1",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.10.0"
-          },
-          "dependencies": {
-            "yaml": {
-              "version": "1.10.2",
-              "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-              "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-              "dev": true
-            }
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        },
-        "yaml": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-          "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
-          "dev": true
-        }
-      }
-    },
-    "@percy/core": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.10.2.tgz",
-      "integrity": "sha512-ytxaaXhx1OHiV+LK9dD/pGLu3LfITBSPwtelcLpxiw7YlSy4gilGKnk3Vn2p04VCKebKVhnJOT+3IKyJ52NFqw==",
-      "dev": true,
-      "requires": {
-        "@percy/client": "1.10.2",
-        "@percy/config": "1.10.2",
-        "@percy/dom": "1.10.2",
-        "@percy/logger": "1.10.2",
-        "content-disposition": "^0.5.4",
-        "cross-spawn": "^7.0.3",
-        "extract-zip": "^2.0.1",
-        "fast-glob": "^3.2.11",
-        "micromatch": "^4.0.4",
-        "mime-types": "^2.1.34",
-        "path-to-regexp": "^6.2.0",
-        "rimraf": "^3.0.2",
-        "ws": "^8.0.0"
-      },
-      "dependencies": {
-        "extract-zip": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-          "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-          "dev": true,
-          "requires": {
-            "@types/yauzl": "^2.9.1",
-            "debug": "^4.1.1",
-            "get-stream": "^5.1.0",
-            "yauzl": "^2.10.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "ws": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-          "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-          "dev": true,
-          "requires": {}
-        }
-      }
-    },
-    "@percy/dom": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.10.2.tgz",
-      "integrity": "sha512-BDCVfQlomn/pIbNbIMWc+EbSm2kCD3as0xSaWb+1BeSjf+pQZ700u6ZSBI2wJ1RXlXYy+gv0+B5VJQUtJo2riQ==",
-      "dev": true
-    },
-    "@percy/env": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.10.2.tgz",
-      "integrity": "sha512-TKIjcR6CtPYf8JMtQX48vIY4dcxLErR+uJ+ylMPPqSm2C7BUswdkbHTYvK1vFlB1dBIY3wU8xt0khHQq01RPnw==",
-      "dev": true
-    },
-    "@percy/logger": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.10.2.tgz",
-      "integrity": "sha512-Sg67QklLHM7oTv80RH2PovV4Ps0mjiRrLYzxbsAvDopn73alPvy5uWHtJAHnJc3EYCiBde43L1jOSsGCsOv0Tg==",
-      "dev": true
-    },
     "@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -13535,16 +12944,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
-    },
-    "@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@yarnpkg/parsers": {
       "version": "3.0.0-rc.15",
@@ -16620,15 +16019,6 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
-    "image-size": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
-      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
-      "dev": true,
-      "requires": {
-        "queue": "6.0.2"
-      }
-    },
     "immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -18389,12 +17779,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-      "dev": true
-    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -18802,15 +18186,6 @@
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
-      }
-    },
-    "queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "dev": true,
-      "requires": {
-        "inherits": "~2.0.3"
       }
     },
     "queue-microtask": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/cli": "^7.18.10",
         "@babel/core": "^7.18.13",
         "@babel/preset-env": "^7.18.10",
+        "@percy/cli": "^1.10.2",
         "@popperjs/core": "^2.11.6",
         "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-commonjs": "^22.0.2",
@@ -1933,6 +1934,322 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@percy/cli": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.10.2.tgz",
+      "integrity": "sha512-jol4tLkafI01qgDNcuiMiIIwovCkABi8eeWsqrkpHCn4ovJkKgzWYxswBEQt1xmG5weRJGrvqwgZWFDzCjzIeg==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-app": "1.10.2",
+        "@percy/cli-build": "1.10.2",
+        "@percy/cli-command": "1.10.2",
+        "@percy/cli-config": "1.10.2",
+        "@percy/cli-exec": "1.10.2",
+        "@percy/cli-snapshot": "1.10.2",
+        "@percy/cli-upload": "1.10.2",
+        "@percy/client": "1.10.2",
+        "@percy/logger": "1.10.2"
+      },
+      "bin": {
+        "percy": "bin/run.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-app": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.10.2.tgz",
+      "integrity": "sha512-1Ysyqsupfr8/PjcFqoNRVEdCsk8ssRMoxUQFb88r6fkfaR+1UQGq1feKQcc2EAeZtizu4HZvkFmTsNKIaccmVQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2",
+        "@percy/cli-exec": "1.10.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-build": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.10.2.tgz",
+      "integrity": "sha512-k/obA7JLl6rl8WNrz1U687/igYjwbAxGVjTK8Ipxmy0D1GG0JU+QI+kAx+1HflUTLMqLrecXDxbgAIPEXHbi3A==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-command": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.10.2.tgz",
+      "integrity": "sha512-5V8zEPbtn7FXI9i6RIeUrTHawbdD0Fipby1W/fw/qBN6yiXgeSEwCQ5l2YUHZdkfrDOaXZEzjWDBcWV89M+QAQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/config": "1.10.2",
+        "@percy/core": "1.10.2",
+        "@percy/logger": "1.10.2"
+      },
+      "bin": {
+        "percy-cli-readme": "bin/readme.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-config": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.10.2.tgz",
+      "integrity": "sha512-bxAU/KIHItWmUDoNwwMj2wNY0HfizUa/Vp8/ahikTTuxsREXZ7WQK+ExZEgKo6r7/Cw5AN6N5Bs2A1qwcbZv2w==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-exec": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.10.2.tgz",
+      "integrity": "sha512-qrGu9Zm0+ElYeT6IU1AVd/pBujH8Mce6MmrQyFpbkIX8Nu3NIAETwiaR0GwjiHqVvMQU5qbJVtupz4SAAe3PIQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2",
+        "cross-spawn": "^7.0.3",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-snapshot": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.10.2.tgz",
+      "integrity": "sha512-NxysEuQHmEo7W5knaYV0UJn+zPJBYUrXecQBfSTLl1o+N1M9OIUCiE7wkJvU2w+t9Nw+kVZvtZn0wHbCgLfQfw==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-snapshot/node_modules/yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@percy/cli-upload": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.10.2.tgz",
+      "integrity": "sha512-dCYBGBoeLdOUIkuy2KkKk2H3T4QNXuuIbxjCEpbCbY4uX9HeTOfpVnqMFQj4XX7JI83WwmHdrZ6CwVwqOVO3sg==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.10.2",
+        "fast-glob": "^3.2.11",
+        "image-size": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.10.2.tgz",
+      "integrity": "sha512-Zvp37zN4rrtgB3XMUSdmk1bDvyoNfJfF61TWoHWe6H4qMHsed81vA11DKVX5OZf6f/e+pSdXae9Wi7VBVx7v1Q==",
+      "dev": true,
+      "dependencies": {
+        "@percy/env": "1.10.2",
+        "@percy/logger": "1.10.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/config": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.10.2.tgz",
+      "integrity": "sha512-9uPbmP64/9WwrGX4isMr4SqKrE1RQGiv0tRwWY2+iLJOgzuTBpXRH1W69ZaKPvf5B4WXicjQcs4qReIAy5WNcA==",
+      "dev": true,
+      "dependencies": {
+        "@percy/logger": "1.10.2",
+        "ajv": "^8.6.2",
+        "cosmiconfig": "^7.0.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/config/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@percy/config/node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@percy/config/node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@percy/config/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/@percy/config/node_modules/yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@percy/core": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.10.2.tgz",
+      "integrity": "sha512-ytxaaXhx1OHiV+LK9dD/pGLu3LfITBSPwtelcLpxiw7YlSy4gilGKnk3Vn2p04VCKebKVhnJOT+3IKyJ52NFqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@percy/client": "1.10.2",
+        "@percy/config": "1.10.2",
+        "@percy/dom": "1.10.2",
+        "@percy/logger": "1.10.2",
+        "content-disposition": "^0.5.4",
+        "cross-spawn": "^7.0.3",
+        "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
+        "mime-types": "^2.1.34",
+        "path-to-regexp": "^6.2.0",
+        "rimraf": "^3.0.2",
+        "ws": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/core/node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/@percy/core/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@percy/core/node_modules/ws": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@percy/dom": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.10.2.tgz",
+      "integrity": "sha512-BDCVfQlomn/pIbNbIMWc+EbSm2kCD3as0xSaWb+1BeSjf+pQZ700u6ZSBI2wJ1RXlXYy+gv0+B5VJQUtJo2riQ==",
+      "dev": true
+    },
+    "node_modules/@percy/env": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.10.2.tgz",
+      "integrity": "sha512-TKIjcR6CtPYf8JMtQX48vIY4dcxLErR+uJ+ylMPPqSm2C7BUswdkbHTYvK1vFlB1dBIY3wU8xt0khHQq01RPnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/logger": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.10.2.tgz",
+      "integrity": "sha512-Sg67QklLHM7oTv80RH2PovV4Ps0mjiRrLYzxbsAvDopn73alPvy5uWHtJAHnJc3EYCiBde43L1jOSsGCsOv0Tg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -2135,6 +2452,16 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@yarnpkg/parsers": {
       "version": "3.0.0-rc.15",
@@ -6216,6 +6543,21 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/image-size": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
+      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "dev": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -8589,6 +8931,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -9186,6 +9534,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -12781,6 +13138,240 @@
         "fastq": "^1.6.0"
       }
     },
+    "@percy/cli": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.10.2.tgz",
+      "integrity": "sha512-jol4tLkafI01qgDNcuiMiIIwovCkABi8eeWsqrkpHCn4ovJkKgzWYxswBEQt1xmG5weRJGrvqwgZWFDzCjzIeg==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-app": "1.10.2",
+        "@percy/cli-build": "1.10.2",
+        "@percy/cli-command": "1.10.2",
+        "@percy/cli-config": "1.10.2",
+        "@percy/cli-exec": "1.10.2",
+        "@percy/cli-snapshot": "1.10.2",
+        "@percy/cli-upload": "1.10.2",
+        "@percy/client": "1.10.2",
+        "@percy/logger": "1.10.2"
+      }
+    },
+    "@percy/cli-app": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.10.2.tgz",
+      "integrity": "sha512-1Ysyqsupfr8/PjcFqoNRVEdCsk8ssRMoxUQFb88r6fkfaR+1UQGq1feKQcc2EAeZtizu4HZvkFmTsNKIaccmVQ==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2",
+        "@percy/cli-exec": "1.10.2"
+      }
+    },
+    "@percy/cli-build": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.10.2.tgz",
+      "integrity": "sha512-k/obA7JLl6rl8WNrz1U687/igYjwbAxGVjTK8Ipxmy0D1GG0JU+QI+kAx+1HflUTLMqLrecXDxbgAIPEXHbi3A==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2"
+      }
+    },
+    "@percy/cli-command": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.10.2.tgz",
+      "integrity": "sha512-5V8zEPbtn7FXI9i6RIeUrTHawbdD0Fipby1W/fw/qBN6yiXgeSEwCQ5l2YUHZdkfrDOaXZEzjWDBcWV89M+QAQ==",
+      "dev": true,
+      "requires": {
+        "@percy/config": "1.10.2",
+        "@percy/core": "1.10.2",
+        "@percy/logger": "1.10.2"
+      }
+    },
+    "@percy/cli-config": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.10.2.tgz",
+      "integrity": "sha512-bxAU/KIHItWmUDoNwwMj2wNY0HfizUa/Vp8/ahikTTuxsREXZ7WQK+ExZEgKo6r7/Cw5AN6N5Bs2A1qwcbZv2w==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2"
+      }
+    },
+    "@percy/cli-exec": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.10.2.tgz",
+      "integrity": "sha512-qrGu9Zm0+ElYeT6IU1AVd/pBujH8Mce6MmrQyFpbkIX8Nu3NIAETwiaR0GwjiHqVvMQU5qbJVtupz4SAAe3PIQ==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2",
+        "cross-spawn": "^7.0.3",
+        "which": "^2.0.2"
+      }
+    },
+    "@percy/cli-snapshot": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.10.2.tgz",
+      "integrity": "sha512-NxysEuQHmEo7W5knaYV0UJn+zPJBYUrXecQBfSTLl1o+N1M9OIUCiE7wkJvU2w+t9Nw+kVZvtZn0wHbCgLfQfw==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2",
+        "yaml": "^2.0.0"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+          "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/cli-upload": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.10.2.tgz",
+      "integrity": "sha512-dCYBGBoeLdOUIkuy2KkKk2H3T4QNXuuIbxjCEpbCbY4uX9HeTOfpVnqMFQj4XX7JI83WwmHdrZ6CwVwqOVO3sg==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.10.2",
+        "fast-glob": "^3.2.11",
+        "image-size": "^1.0.0"
+      }
+    },
+    "@percy/client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.10.2.tgz",
+      "integrity": "sha512-Zvp37zN4rrtgB3XMUSdmk1bDvyoNfJfF61TWoHWe6H4qMHsed81vA11DKVX5OZf6f/e+pSdXae9Wi7VBVx7v1Q==",
+      "dev": true,
+      "requires": {
+        "@percy/env": "1.10.2",
+        "@percy/logger": "1.10.2"
+      }
+    },
+    "@percy/config": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.10.2.tgz",
+      "integrity": "sha512-9uPbmP64/9WwrGX4isMr4SqKrE1RQGiv0tRwWY2+iLJOgzuTBpXRH1W69ZaKPvf5B4WXicjQcs4qReIAy5WNcA==",
+      "dev": true,
+      "requires": {
+        "@percy/logger": "1.10.2",
+        "ajv": "^8.6.2",
+        "cosmiconfig": "^7.0.0",
+        "yaml": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "cosmiconfig": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          },
+          "dependencies": {
+            "yaml": {
+              "version": "1.10.2",
+              "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+              "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+              "dev": true
+            }
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "yaml": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+          "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/core": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.10.2.tgz",
+      "integrity": "sha512-ytxaaXhx1OHiV+LK9dD/pGLu3LfITBSPwtelcLpxiw7YlSy4gilGKnk3Vn2p04VCKebKVhnJOT+3IKyJ52NFqw==",
+      "dev": true,
+      "requires": {
+        "@percy/client": "1.10.2",
+        "@percy/config": "1.10.2",
+        "@percy/dom": "1.10.2",
+        "@percy/logger": "1.10.2",
+        "content-disposition": "^0.5.4",
+        "cross-spawn": "^7.0.3",
+        "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
+        "mime-types": "^2.1.34",
+        "path-to-regexp": "^6.2.0",
+        "rimraf": "^3.0.2",
+        "ws": "^8.0.0"
+      },
+      "dependencies": {
+        "extract-zip": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+          "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+          "dev": true,
+          "requires": {
+            "@types/yauzl": "^2.9.1",
+            "debug": "^4.1.1",
+            "get-stream": "^5.1.0",
+            "yauzl": "^2.10.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "ws": {
+          "version": "8.8.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+          "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "@percy/dom": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.10.2.tgz",
+      "integrity": "sha512-BDCVfQlomn/pIbNbIMWc+EbSm2kCD3as0xSaWb+1BeSjf+pQZ700u6ZSBI2wJ1RXlXYy+gv0+B5VJQUtJo2riQ==",
+      "dev": true
+    },
+    "@percy/env": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.10.2.tgz",
+      "integrity": "sha512-TKIjcR6CtPYf8JMtQX48vIY4dcxLErR+uJ+ylMPPqSm2C7BUswdkbHTYvK1vFlB1dBIY3wU8xt0khHQq01RPnw==",
+      "dev": true
+    },
+    "@percy/logger": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.10.2.tgz",
+      "integrity": "sha512-Sg67QklLHM7oTv80RH2PovV4Ps0mjiRrLYzxbsAvDopn73alPvy5uWHtJAHnJc3EYCiBde43L1jOSsGCsOv0Tg==",
+      "dev": true
+    },
     "@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -12944,6 +13535,16 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
+    },
+    "@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@yarnpkg/parsers": {
       "version": "3.0.0-rc.15",
@@ -16019,6 +16620,15 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "image-size": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
+      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "dev": true,
+      "requires": {
+        "queue": "6.0.2"
+      }
+    },
     "immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -17779,6 +18389,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -18186,6 +18802,15 @@
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.3"
       }
     },
     "queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "@babel/cli": "^7.18.10",
     "@babel/core": "^7.18.13",
     "@babel/preset-env": "^7.18.10",
-    "@percy/cli": "^1.10.2",
     "@popperjs/core": "^2.11.6",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^22.0.2",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@babel/cli": "^7.18.10",
     "@babel/core": "^7.18.13",
     "@babel/preset-env": "^7.18.10",
+    "@percy/cli": "^1.10.2",
     "@popperjs/core": "^2.11.6",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^22.0.2",


### PR DESCRIPTION
### Related issues

Fixes #1527 

### Description

* Remove the use of the deprecated `percy/snapshot-action@v0.1.2`
* Used the [migration guide](https://github.com/percy/snapshot-action#deprecated) to rather use Percy CLI

### Motivation & Context

This change is needed because `percy/snapshot-action@v0.1.2` is deprecated.

### Types of change

- Technical debt (workflows)

### Live previews

Go to [Percy](https://percy.io/) - Boosted dashboard

### Checklist

- [x] Percy is well launched in this PR (the token still works)
- [x] Results are available in [Percy](https://percy.io/) - Boosted dashboard
- [x] Remove the comments regarding what triggers the job
- [x] Check that `flags: "--snapshot-files ./docs/**/components/**/*.html,./docs/**/forms/**/*.html"` still works as expected
- ~~Check that `verbose: true` is still enabled~~
