### PR TITLE
Close button: Adding CSS var

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "36.75 kB"
+      "maxSize": "37.0 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "./dist/css/boosted.min.css",
-      "maxSize": "33.75 kB"
+      "maxSize": "34.0 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.js",

--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -4,17 +4,31 @@
 // See https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
 
 .btn-close {
-  padding: $btn-close-padding;
-  color: $btn-close-color;
-  background-color: transparent; // include transparent for button elements
-  border: $btn-border-width solid transparent; // Boosted mod
+  // scss-docs-start btn-close-css-vars
+  --#{$prefix}btn-close-padding: #{$btn-close-padding}; // Boosted mod
+  --#{$prefix}btn-close-margin: 0; // Boosted mod
+  --#{$prefix}btn-close-border-width: #{$btn-close-border-width}; // Boosted mod
+  --#{$prefix}btn-close-color: #{$btn-close-color}; // Boosted mod
+  --#{$prefix}btn-close-bg: #{$btn-close-bg}; // Boosted mod
+  --#{$prefix}btn-close-border-color: #{$btn-close-border-color}; // Boosted mod
+  --#{$prefix}btn-close-hover-color: #{$btn-close-hover-color}; // Boosted mod
+  --#{$prefix}btn-close-active-color: #{$btn-close-active-color}; // Boosted mod
+  --#{$prefix}btn-close-active-border-color: #{$btn-close-active-border-color}; // Boosted mod
+  --#{$prefix}btn-close-disabled-color: #{$btn-close-disabled-color}; // Boosted mod
+  // scss-docs-end btn-close-css-vars
+
+  padding: var(--#{$prefix}btn-close-padding); // Boosted mod
+  margin: var(--#{$prefix}btn-close-margin); // Boosted mod
+  color: var(--#{$prefix}btn-close-color); // Boosted mod
+  background-color: var(--#{$prefix}btn-close-bg); // Boosted mod
+  border: var(--#{$prefix}btn-close-border-width) solid var(--#{$prefix}btn-close-border-color); // Boosted mod
   outline-offset: map-get($spacers, 2); // Boosted mod
   @include border-radius();
   @include button-icon($btn-close-bg, $btn-close-width, $btn-close-height, $btn-close-icon-size); // Boosted mod: using mask instead of background
 
   // Override <a>'s hover style
   &:hover {
-    color: $btn-close-color;
+    color: var(--#{$prefix}btn-close-hover-color); // Boosted mod
     text-decoration: none;
   }
 
@@ -22,7 +36,7 @@
   &:hover,
   &:focus,
   &:active {
-    border-color: $gray-500;
+    border: var(--#{$prefix}btn-close-border-width) solid var(--#{$prefix}btn-close-active-border-color);
   }
 
   &:focus {
@@ -35,13 +49,13 @@
   }
 
   &:active {
-    color: $primary;
+    color: var(--#{$prefix}btn-close-active-color);
   }
   // End mod
 
   &:disabled,
   &.disabled {
-    color: $gray-500; // Boosted mod
+    color: var(--#{$prefix}btn-close-disabled-color);
     pointer-events: none;
     user-select: none;
   }
@@ -49,26 +63,20 @@
 
 // Boosted mod: changing color instead of using filter
 .btn-close-white {
-  &,
-  &:hover:not(:active) {
-    color: $white;
-  }
-
-  &:hover,
-  &:focus,
-  &:active {
-    border-color: $gray-700;
-  }
+  // scss-docs-start btn-close-white-css-vars
+  --#{$prefix}btn-close-color: #{$btn-close-white-color}; // Boosted mod
+  --#{$prefix}btn-close-bg: #{$btn-close-white-bg}; // Boosted mod
+  --#{$prefix}btn-close-border-color: #{$btn-close-white-border-color}; // Boosted mod
+  --#{$prefix}btn-close-hover-color: #{$btn-close-white-hover-color}; // Boosted mod
+  --#{$prefix}btn-close-active-color: #{$btn-close-white-active-color}; // Boosted mod
+  --#{$prefix}btn-close-active-border-color: #{$btn-close-white-active-border-color}; // Boosted mod
+  --#{$prefix}btn-close-disabled-color: #{$btn-close-white-disabled-color}; // Boosted mod
+  // scss-docs-end btn-close-white-css-vars
 
   &:focus {
     &[data-focus-visible-added] {
       box-shadow: 0 0 0 $btn-focus-width $black;
     }
-  }
-
-  &:disabled,
-  &.disabled {
-    color: $gray-700;
   }
 }
 // End mod

--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -6,7 +6,6 @@
 .btn-close {
   // scss-docs-start btn-close-css-vars
   --#{$prefix}btn-close-padding: #{$btn-close-padding}; // Boosted mod
-  --#{$prefix}btn-close-margin: 0; // Boosted mod
   --#{$prefix}btn-close-border-width: #{$btn-close-border-width}; // Boosted mod
   --#{$prefix}btn-close-color: #{$btn-close-color}; // Boosted mod
   --#{$prefix}btn-close-bg: #{$btn-close-bg}; // Boosted mod
@@ -18,7 +17,6 @@
   // scss-docs-end btn-close-css-vars
 
   padding: var(--#{$prefix}btn-close-padding); // Boosted mod
-  margin: var(--#{$prefix}btn-close-margin); // Boosted mod
   color: var(--#{$prefix}btn-close-color); // Boosted mod
   background-color: var(--#{$prefix}btn-close-bg); // Boosted mod
   border: var(--#{$prefix}btn-close-border-width) solid var(--#{$prefix}btn-close-border-color); // Boosted mod

--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -55,7 +55,7 @@
 
   &:disabled,
   &.disabled {
-    color: var(--#{$prefix}btn-close-disabled-color);
+    color: var(--#{$prefix}btn-close-disabled-color); // Boosted mod
     pointer-events: none;
     user-select: none;
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1940,18 +1940,36 @@ $spinner-border-width-lg: $border-width * 4 !default;
 // Close
 
 // scss-docs-start close-variables
-$btn-close-width:            $spacer !default;
-$btn-close-height:           $btn-close-width !default;
-$btn-close-padding:          var(--#{$boosted-prefix}icon-spacing, #{$btn-icon-padding-x}) !default;
-$btn-close-color:            $black !default;
-$btn-close-bg:               var(--#{$boosted-prefix}close-icon) !default;
-$btn-close-focus-shadow:     $btn-focus-box-shadow !default;
+$btn-close-width:               $spacer !default; // Boosted mod
+$btn-close-height:              $btn-close-width !default;
+$btn-close-padding:             var(--#{$boosted-prefix}icon-spacing, #{$btn-icon-padding-x}) !default; // Boosted mod
+$btn-close-border-width:        $border-width !default; // Boosted mod
+$btn-close-border-color:        transparent !default; // Boosted mod
+$btn-close-color:               $black !default;
+$btn-close-bg:                  var(--#{$boosted-prefix}close-icon) !default; // Boosted mod
+$btn-close-focus-shadow:        $btn-focus-box-shadow !default;
+// Boosted mod: no opacity/filter
 
 // Boosted mod
-$btn-close-icon-size:        1rem auto !default;
-$btn-close-padding-sm:       subtract($btn-icon-padding-x, $spacer * .25) !default;
+$btn-close-hover-color:         $btn-close-color !default;
+$btn-close-active-color:        $primary !default;
+$btn-close-active-border-color: $gray-500 !default;
+$btn-close-disabled-color:      $gray-500 !default;
+
+$btn-close-icon-size:           1rem auto !default;
+$btn-close-padding-sm:          subtract($btn-icon-padding-x, $spacer * .25) !default;
 // End mod
 // scss-docs-end close-variables
+
+// scss-docs-start close-white-variables
+$btn-close-white-color:               $white !default; // Boosted mod
+$btn-close-white-bg:                  transparent !default; // Boosted mod
+$btn-close-white-border-color:        transparent !default; // Boosted mod
+$btn-close-white-hover-color:         $btn-close-white-color !default; // Boosted mod
+$btn-close-white-active-color:        $primary !default; // Boosted mod
+$btn-close-white-active-border-color: $gray-700 !default; // Boosted mod
+$btn-close-white-disabled-color:      $gray-700 !default; // Boosted mod
+// scss-docs-end close-white-variables
 
 // Offcanvas
 

--- a/site/content/docs/5.2/components/close-button.md
+++ b/site/content/docs/5.2/components/close-button.md
@@ -33,7 +33,7 @@ Add `.btn-close-white` to the `.btn-close` for a dark variant.
 
 ## Without specific class
 
-Close buttons can also be created without `.btn-close` to avoid importing too much CSS bundle.
+Close buttons can also be created without `.btn-close` to reduce the size of your CSS bundle.
 
 {{< example >}}
 <button type="button" class="btn btn-icon btn-no-outline">
@@ -61,7 +61,6 @@ As part of Boosted’s evolving CSS variables approach, close buttons now use lo
 Customization through CSS variables can be seen on the `.btn-close-white` modifier class where we override specific values without adding duplicate CSS selectors.
 
 {{< scss-docs name="btn-close-white-css-vars" file="scss/_close.scss" >}}
-<!-- End mod -->
 
 ### Sass variables
 
@@ -69,8 +68,7 @@ Variables for all close buttons:
 
 {{< scss-docs name="close-variables" file="scss/_variables.scss" >}}
 
-<!-- Boosted mod -->
-Variables for the [white close button](#dark-variant):
+Variables for the [dark close button](#dark-variant):
 
 {{< scss-docs name="close-white-variables" file="scss/_variables.scss" >}}
 <!-- End mod -->

--- a/site/content/docs/5.2/components/close-button.md
+++ b/site/content/docs/5.2/components/close-button.md
@@ -33,7 +33,7 @@ Add `.btn-close-white` to the `.btn-close` for a dark variant.
 
 ## Without specific class
 
-Close buttons can also be created without `.btn-close`.
+Close buttons can also be created without `.btn-close` to avoid importing too much CSS bundle.
 
 {{< example >}}
 <button type="button" class="btn btn-icon btn-no-outline">
@@ -47,8 +47,30 @@ Close buttons can also be created without `.btn-close`.
 </button>
 {{< /example >}}
 
-## Sass
+## CSS
 
+<!-- Boosted mod: CSS var -->
 ### Variables
 
+{{< added-in "5.2.1" >}}
+
+As part of Boosted’s evolving CSS variables approach, close buttons now use local CSS variables on `.btn-close` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+
+{{< scss-docs name="btn-close-css-vars" file="scss/_close.scss" >}}
+
+Customization through CSS variables can be seen on the `.btn-close-white` modifier class where we override specific values without adding duplicate CSS selectors.
+
+{{< scss-docs name="btn-close-white-css-vars" file="scss/_close.scss" >}}
+<!-- End mod -->
+
+### Sass variables
+
+Variables for all close buttons:
+
 {{< scss-docs name="close-variables" file="scss/_variables.scss" >}}
+
+<!-- Boosted mod -->
+Variables for the [white close button](#dark-variant):
+
+{{< scss-docs name="close-white-variables" file="scss/_variables.scss" >}}
+<!-- End mod -->


### PR DESCRIPTION
### Related issues

#1196.

### Description

Adding CSS var to close buttons.

### Motivation & Context

Bootstrap probably won't do it on their side since they use filter for their variants. Moreover, we'll need them later to introduce more variants such as the outlined one.

### Types of change

New feature (non-breaking change which adds functionality)

### Live previews

* https://deploy-preview-1531--twbs-bootstrap.netlify.app/5.2/components/close

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly

### Development

- [x] Should match specs (eg. either the Web UI Kit or any pattern from the WAI — or both…)
- [x] Docs added:
  - including the "Sass" part using `scss-docs` shortcode
  - in /about/overview/#custom-components if it is a new Orange custom component
  - in /getting-started/introduction/#components if it is a new Orange custom component that requires JavaScript (and Popper)
  - in /customize/overview#csps-and-embedded-svgs if it is a new Orange custom component that includes embedded SVGs in our CSS
  - in /forms/validation/?#supported-elements if it is a new Orange custom component that is a form control
  - in /forms/overview/ if it is a new Orange custom component that is a form control
- [x] Check (and fix) RTL version
- [x] Run linters
- [x] Run compilers
- [x] Tests added for JS-side
- [x] Run tests
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] Cross-browser test:
  - [x] Chrome
  - [x] Firefox (including ESR)
  - [x] Edge
  - [ ] Safari
  - [ ] iOS Safari
  - [ ] Chrome & Firefox on Android
- [x] Responsive tests: desktop and small screens
- [ ] Clean up the branch using `rebase -i`
- [ ] Commited with `feat(…): …` message
- [ ] Mention it in Migration Guide (if `back-from-v4`): renamed variables, changes in markup requirement,  etc.

### Reviews

- [ ] Code review
- [ ] A11y review
- [ ] Design review



<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `config.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
    - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] Ensure Algolia indexes new release content ([probably requires a PR](https://github.com/algolia/docsearch-configs/pull/1954))
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
- [ ] if year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, update SRI hashes in doc and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (eg for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] merge (on `v4-dev` or `main`)
- [ ] tag your version, and push your tag
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach zip file
  - paste CHANGELOG / Ship list in the release's description
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in NPM (with a personnal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you're releasing a pre-release, use `--tag`, eg for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch
  - [ ] check every `index.html` used as redirections to be redirecting to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurences
- [ ] make an announcement in Plazza :tada:
-->
