### PR TITLE
fix(tests): fine tune Karma config to avoid BrowserStack failed jobs

### DIFF
--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -57,6 +57,12 @@ const config = {
   autoWatch: false,
   singleRun: true,
   concurrency: Number.POSITIVE_INFINITY,
+  // Configuration recommended by BrowserStack team
+  browserDisconnectedTimeout: 60000,
+  pingTimeout: 10000, // default is 5 secs
+  browserDisconnectTolerance: 3, // default is 0 attempt
+  browserNoActivityTimeout: 210000,
+  // End
   client: {
     clearContext: false
   },


### PR DESCRIPTION
Contacted BrowserStack support for our failing tests here and in Bootstrap.
Here is the first part of the answer.

---

Please find the findings of our engineering team below:
​
**Error_1: Disconnected reconnect failed before timeout of 2000ms :**
​
sample GitHub build shared by you where this error can be seen [https://github.com/twbs/bootstrap/runs/7120175035?check_suite_focus=true](https://email.browserstack.com/c/eJwVTsuOgzAM_Bq4BUHikOTAodKqv4HycEq2QGgeqrRfv8EayTO2xmNcppmribKRQe8WbrgTfVhmisA4F0og0yttZUbLUHptZkmlBADrhxwcvsOH-ISfimch3pEruppR5zKRQ4eTEbNXJByk5EZ6AGKPv6_oYMS23odmzZvD_B5sPPptUaA0pS1LekqlA5iVFGwEUDPjSot-X7ZSrtyxR0efDa9QtmpudxPla3JrJsaSS9JX46me90hMdJwEHxnv2NNuaN9rrqHg6qOt7dpPSRX7tPzWPeA5OEz6iKdrf8akzxfeAf8HTF4H)
​
We were able to reproduce this error and able to fix it as well. By increasing the timeout value from 2000 to something higher like 60000 for the karma config variable browserDisconnectTimeout . This variable can be seen in node_modules/karma/lib/config.js file.

Would also recommend to modify the following fields to improve the robustness of tests, these numbers can be experimented with by you, eg:

```js
browserDisconnectTimeout: 60000
pingTimeout: 10000, // default is 5 secs, can change this to 10 secs
browserDisconnectTolerance : 3, // default is 0 attempts, can change this to 3 attempts
browserNoActivityTimeout : 210000
```