### PR TITLE
fix(css): rename `$prefix` in `$func-prefix` in `get-color-from-rgba-string` function

### DIFF
--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -1,10 +1,10 @@
 // Boosted mod
 @function get-color-from-rgba-string($value) {
-  $prefix: "rgba(var(--bs-";
-  $rgba-string-index-before-color-name: str-index($value, $prefix);
+  $func-prefix: "rgba(var(--bs-";
+  $rgba-string-index-before-color-name: str-index($value, $func-prefix);
   @if $rgba-string-index-before-color-name == 1 {
     $rgba-string-index-after-color-name: str-index($value, "-rgb");
-    @return str-slice($value, $rgba-string-index-before-color-name + str-length($prefix), $rgba-string-index-after-color-name - 1);
+    @return str-slice($value, $rgba-string-index-before-color-name + str-length($func-prefix), $rgba-string-index-after-color-name - 1);
   }
   @return undefined;
 }


### PR DESCRIPTION
### Description

Issue reported by @Lausselloic with the following project: [demo-custom-build.zip](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/files/9838923/demo-custom-build.zip)

Download the zip file and run `unzip -d demo-custom-build demo-custom-build.zip && cd demo-custom-build/demo-custom-build && npm i && npm run css`

Error:

```
CssSyntaxError: /Users/ju/Downloads/demo-custom-build/node_modules/boosted/scss/mixins/_utilities.scss:82:16: Unclosed bracket

  80 |             @if $is-local-vars {
  81 |               @each $local-var, $variable in $is-local-vars {
> 82 |                 --#{$prefix}#{$local-var}: #{$variable};
     |                ^
  83 |               }
  84 |             }
```

Now open `node_modules/boosted/scss/mixins/_utilities.scss` and modify it to have the same content as in this PR.
If you re-run `npm run css` the compilation is now OK.

⚠️ Dear reviewer, please check that this modification has no impact in a normal usage regarding the usage of `get-color-from-rgba-string`.

### Motivation & Context

For security, IMO we should apply this patch to avoid unexpected results when having 2 `$prefix` definitions.
However, I don't understand for now the difference between this build and a fresh build with Vite for example where the issue doesn't seem to appear. It must be linked to:

```scss
.od-boosted-theme {
    @import "../../node_modules/boosted/scss/boosted";
}
```

### Types of change

<!-- What types of changes does you code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issues)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed
