### PR TITLE
fix(docs): bad title for 'Image thumbnails' example

### DIFF
--- a/site/content/docs/5.2/content/images.md
+++ b/site/content/docs/5.2/content/images.md
@@ -19,7 +19,7 @@ Images in Boosted are made responsive with `.img-fluid`. This applies `max-width
 In addition to our [border-radius utilities]({{< docsref "/utilities/borders" >}}), you can use `.img-thumbnail` to give an image a 2px border appearance.
 
 {{< example >}}
-{{< placeholder width="200" height="200" class="img-thumbnail" title="A generic square placeholder image with a white border around it, making it resemble a photograph taken with an old instant camera" >}}
+{{< placeholder width="200" height="200" class="img-thumbnail" title="A generic square placeholder image with a gray border around it" >}}
 {{< /example >}}
 
 ## Aligning images


### PR DESCRIPTION
### Description

Just a quick modification about the `title` used for the example of "Image thumbnails" that was referencing the old style of image thumbnails.
