### PR TITLE
Fix close button inside tags on Chrome

### DIFF
--- a/scss/_tags.scss
+++ b/scss/_tags.scss
@@ -47,7 +47,7 @@
     width: var(--#{$prefix}tag-close-size);
     min-width: var(--#{$prefix}tag-close-size); // Here to avoid weird behavior on wrap
     height: var(--#{$prefix}tag-close-size);
-    padding: 0;
+    padding: 0; // Force padding on button to have a circle on iOS - Safari and Chrome
     margin: add(calc(-.5 * var(--#{$prefix}tag-close-size)), var(--#{$prefix}tag-font-shift)) var(--#{$prefix}tag-close-margin-end) calc(-.5 * var(--#{$prefix}tag-close-size)) var(--#{$prefix}tag-close-margin-start);
     color: inherit;
     background-color: transparent;

--- a/scss/_tags.scss
+++ b/scss/_tags.scss
@@ -47,6 +47,7 @@
     width: var(--#{$prefix}tag-close-size);
     min-width: var(--#{$prefix}tag-close-size); // Here to avoid weird behavior on wrap
     height: var(--#{$prefix}tag-close-size);
+    padding: 0;
     margin: add(calc(-.5 * var(--#{$prefix}tag-close-size)), var(--#{$prefix}tag-font-shift)) var(--#{$prefix}tag-close-margin-end) calc(-.5 * var(--#{$prefix}tag-close-size)) var(--#{$prefix}tag-close-margin-start);
     color: inherit;
     background-color: transparent;
@@ -66,14 +67,12 @@
 
     &::after {
       display: block;
-      height: 100%;
+      min-width: subtract(var(--#{$prefix}tag-close-size), .625rem);
+      min-height: subtract(var(--#{$prefix}tag-close-size), .625rem);
       content: "";
       background-color: currentcolor;
-      -webkit-mask-image: escape-svg(var(--#{$boosted-prefix}close-icon)); //stylelint-disable-line property-no-vendor-prefix
-      mask-image: escape-svg(var(--#{$boosted-prefix}close-icon));
-      mask-repeat: no-repeat;
-      mask-position: 50%;
-      mask-size: subtract(var(--#{$prefix}tag-close-size), .625rem);
+      -webkit-mask: escape-svg(var(--#{$boosted-prefix}close-icon)) no-repeat 50% / subtract(var(--#{$prefix}tag-close-size), .625rem); // stylelint-disable-line property-no-vendor-prefix
+      mask: escape-svg(var(--#{$boosted-prefix}close-icon)) no-repeat 50% / subtract(var(--#{$prefix}tag-close-size), .625rem);
     }
 
     &:hover,

--- a/scss/_tags.scss
+++ b/scss/_tags.scss
@@ -69,6 +69,7 @@
       height: 100%;
       content: "";
       background-color: currentcolor;
+      -webkit-mask-image: escape-svg(var(--#{$boosted-prefix}close-icon)); //stylelint-disable-line property-no-vendor-prefix
       mask-image: escape-svg(var(--#{$boosted-prefix}close-icon));
       mask-repeat: no-repeat;
       mask-position: 50%;

--- a/site/content/docs/5.2/components/tags.md
+++ b/site/content/docs/5.2/components/tags.md
@@ -124,7 +124,7 @@ We add an extra `<p>` around the `<span>` here for accessibility concerns.
 
 Add `.tag-dark` to the `.tag` for a dark variant.
 
-{{< example class="d-flex gap-2 align-items-center bg-dark" >}}
+{{< example class="d-flex flex-wrap gap-2 align-items-center bg-dark" >}}
 <p class="mb-0"><span class="tag tag-dark">Informative</span></p>
 <button class="tag tag-dark">Filter</button>
 <a class="tag tag-dark" href="#">Navigation</a>
@@ -145,7 +145,7 @@ We add an extra `<p>` around the `<span>` here for accessibility concerns.
 
 Add `.tag-sm` to the `.tag` for a small variant.
 
-{{< example class="d-flex gap-2 align-items-center" >}}
+{{< example class="d-flex flex-wrap gap-2 align-items-center" >}}
 <h3 class="visually-hidden">Small tag variant</h3>
 <p class="mb-0"><span class="tag tag-sm">Informative</span></p>
 <button class="tag tag-sm">Filter</button>
@@ -174,7 +174,7 @@ Disabled tags using the `<a>` element behave a bit different:
 - Disabled tags using `<a>` should include the `aria-disabled="true"` attribute to indicate the state of the element to assistive technologies.
 - Disabled tags using `<a>` *should not* include the `href` attribute.
 
-{{< example class="d-flex gap-2 align-items-center" >}}
+{{< example class="d-flex flex-wrap gap-2 align-items-center" >}}
 <h3 class="visually-hidden">Disabled tags for the different variants</h3>
 <p class="mb-0"><span class="tag disabled" aria-disabled="true">Informative</span></p>
 <button class="tag" disabled>Filter</button>


### PR DESCRIPTION
### Description

Missing one vendor prefix for Chrome in order to display close button correctly.
![screenshot-deploy-preview-1574--boosted netlify app-2022 10 26-17_06_15](https://user-images.githubusercontent.com/92363071/198063693-b7f750df-669e-43e3-9677-e6a47f55ac40.png)

### Motivation & Context

We saw with @louismaximepiton that the close button inside some tags was missing in Chrome because there was a vendor prefix missing for this browser.

⚠️ : need to fix it before release by @julien-deramond 

### Types of change

<!-- What types of changes does you code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issues)

### Live previews

* https://deploy-preview-1574--boosted.netlify.app/docs/5.2/components/tags/

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

<!------------------------->
<!-- /!\ Core Team Only -->
<!------------------------->

<!-- Uncomment the following for a feature DoD -->

<!--
### Development

- [ ] Should match specs (eg. either the Web UI Kit or any pattern from the WAI — or both…)
- [ ] Docs added:
  - including the "Sass" part using `scss-docs` shortcode
  - in /about/overview/#custom-components if it is a new Orange custom component
  - in /getting-started/introduction/#components if it is a new Orange custom component that requires JavaScript (and Popper)
  - in /customize/overview#csps-and-embedded-svgs if it is a new Orange custom component that includes embedded SVGs in our CSS
  - in /forms/validation/?#supported-elements if it is a new Orange custom component that is a form control
  - in /forms/overview/ if it is a new Orange custom component that is a form control
- [ ] Check (and fix) RTL version
- [ ] Run linters
- [ ] Run compilers
- [ ] Tests added for JS-side
- [ ] Run tests
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] Cross-browser test:
  - [ ] Chrome
  - [ ] Firefox (including ESR)
  - [ ] Edge
  - [ ] Safari
  - [ ] iOS Safari
  - [ ] Chrome & Firefox on Android
- [ ] Responsive tests: desktop and small screens
- [ ] Clean up the branch using `rebase -i`
- [ ] Commited with `feat(…): …` message
- [ ] Mention it in Migration Guide (if `back-from-v4`): renamed variables, changes in markup requirement,  etc.

### Reviews

- [ ] Code review
- [ ] A11y review
- [ ] Design review
-->



<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `config.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
    - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] Ensure Algolia indexes new release content ([probably requires a PR](https://github.com/algolia/docsearch-configs/pull/1954))
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
- [ ] if year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, update SRI hashes in doc and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (eg for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] merge (on `v4-dev` or `main`)
- [ ] tag your version, and push your tag
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach zip file
  - paste CHANGELOG / Ship list in the release's description
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in NPM (with a personnal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you're releasing a pre-release, use `--tag`, eg for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch
  - [ ] check every `index.html` used as redirections to be redirecting to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurences
- [ ] make an announcement in Plazza :tada:
-->
