### PR TITLE
fix(paginations): add missing breakpoints after lg

### DIFF
--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -198,6 +198,14 @@
   @include media-breakpoint-between(md, lg) {
     @include pagination-max-items(8);
   }
+
+  @include media-breakpoint-between(lg, xl) {
+    @include pagination-max-items(10);
+  }
+
+  @include media-breakpoint-up(xl) {
+    @include pagination-max-items(12);
+  }
   // End mod
 }
 


### PR DESCRIPTION
### Related issues

Closes #1351 

### Description

Add breakpoints after lg to avoid what's mentioned in the issue.

### Types of change

- Bug fix (non-breaking which fixes an issues)

### Live previews

* https://deploy-preview-1579--boosted.netlify.app//docs/components/pagination/

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed
