### PR TITLE
Change pause button position for carousels

### DIFF
--- a/site/content/docs/5.2/components/carousel.md
+++ b/site/content/docs/5.2/components/carousel.md
@@ -103,9 +103,13 @@ Carousel progress indicator is paused under multiple conditions:
 {{< added-in "5.2.0" >}}
 
 Adding a pause and play button is recommended to setup an accessible carousel.
-This `button` must immediately follow your carousel and have the custom `data-bs-control="play-button"` attribute. In addition, it must also have a `data-bs-target` attribute that matches the `id` of the `.carousel` element.
+This `button` must have the custom `data-bs-control="play-button"` attribute. In addition, it must also have a `data-bs-target` attribute that matches the `id` of the `.carousel` element.
 
 'Play' and 'Pause' texts can be changed by modifying `data-bs-play-text` and `data-bs-pause-text` custom attributes.
+
+{{< callout warning >}}
+For accessibility purposes, the pause/play button must be placed before the carousel.
+{{< /callout >}}
 
 {{< example >}}
 <button type="button" class="btn btn-icon btn-secondary carousel-control-play-pause pause mt-1" data-bs-target="#carouselExamplePause" data-bs-play-text="Play Carousel" data-bs-pause-text="Pause Carousel" title="Pause Carousel">

--- a/site/content/docs/5.2/components/carousel.md
+++ b/site/content/docs/5.2/components/carousel.md
@@ -108,6 +108,9 @@ This `button` must immediately follow your carousel and have the custom `data-bs
 'Play' and 'Pause' texts can be changed by modifying `data-bs-play-text` and `data-bs-pause-text` custom attributes.
 
 {{< example >}}
+<button type="button" class="btn btn-icon btn-secondary carousel-control-play-pause pause mt-1" data-bs-target="#carouselExamplePause" data-bs-play-text="Play Carousel" data-bs-pause-text="Pause Carousel" title="Pause Carousel">
+  <span class="visually-hidden">Pause Carousel</span>
+</button>
 <div id="carouselExamplePause" class="carousel slide" data-bs-ride="carousel">
   <div class="carousel-indicators">
     <button type="button" data-bs-target="#carouselExamplePause" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
@@ -134,9 +137,6 @@ This `button` must immediately follow your carousel and have the custom `data-bs
     <span class="visually-hidden">Next</span>
   </button>
 </div>
-<button type="button" class="btn btn-icon btn-secondary carousel-control-play-pause pause mt-1" data-bs-target="#carouselExamplePause" data-bs-play-text="Play Carousel" data-bs-pause-text="Pause Carousel" title="Pause Carousel">
-  <span class="visually-hidden">Pause Carousel</span>
-</button>
 {{< /example >}}
 <!-- End mod -->
 

--- a/site/content/docs/5.2/components/carousel.md
+++ b/site/content/docs/5.2/components/carousel.md
@@ -108,7 +108,7 @@ This `button` must have the custom `data-bs-control="play-button"` attribute. In
 'Play' and 'Pause' texts can be changed by modifying `data-bs-play-text` and `data-bs-pause-text` custom attributes.
 
 {{< callout warning >}}
-For accessibility purposes, the pause/play button must be placed before the carousel.
+For accessibility purposes, the pause/play button should be placed before the carousel.
 {{< /callout >}}
 
 {{< example >}}


### PR DESCRIPTION
### Related issues

[#1578](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/1578) 

### Description

Change the position of the pause button for better accessibility compliance.

### Motivation & Context

Users of assistives technologies need to have the choice to pause or play a carousel before receiving the information.

### Types of change

<!-- What types of changes does you code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

* https://deploy-preview-1593--boosted.netlify.app/docs/5.2/components/carousel/#with-pauseplay-button

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

<!------------------------->
<!-- /!\ Core Team Only -->
<!------------------------->

<!-- Uncomment the following for a feature DoD -->

<!--
### Development

- [ ] Should match specs (eg. either the Web UI Kit or any pattern from the WAI — or both…)
- [ ] Docs added:
  - including the "Sass" part using `scss-docs` shortcode
  - in /about/overview/#custom-components if it is a new Orange custom component
  - in /getting-started/introduction/#components if it is a new Orange custom component that requires JavaScript (and Popper)
  - in /customize/overview#csps-and-embedded-svgs if it is a new Orange custom component that includes embedded SVGs in our CSS
  - in /forms/validation/?#supported-elements if it is a new Orange custom component that is a form control
  - in /forms/overview/ if it is a new Orange custom component that is a form control
- [ ] Check (and fix) RTL version
- [ ] Run linters
- [ ] Run compilers
- [ ] Tests added for JS-side
- [ ] Run tests
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] Cross-browser test:
  - [ ] Chrome
  - [ ] Firefox (including ESR)
  - [ ] Edge
  - [ ] Safari
  - [ ] iOS Safari
  - [ ] Chrome & Firefox on Android
- [ ] Responsive tests: desktop and small screens
- [ ] Clean up the branch using `rebase -i`
- [ ] Commited with `feat(…): …` message
- [ ] Mention it in Migration Guide (if `back-from-v4`): renamed variables, changes in markup requirement,  etc.

### Reviews

- [ ] Code review
- [ ] A11y review
- [ ] Design review
-->



<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `config.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
    - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
- [ ] if year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, update SRI hashes in doc and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (eg for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] merge (on `v4-dev` or `main`)
- [ ] tag your version, and push your tag
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach zip file
  - paste CHANGELOG / Ship list in the release's description
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in NPM (with a personnal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you're releasing a pre-release, use `--tag`, eg for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch
  - [ ] check every `index.html` used as redirections to be redirecting to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurences
- [ ] make an announcement in Plazza :tada:
-->
