### PR TITLE
fix(css): no more compilation issue when `$enable-rounded: true`

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,3 +1,5 @@
+@use "sass:list"; // Boosted mod: needed by $carousel-indicator-active-radius with $enable-rounded: true
+
 // Variables
 //
 // Variables should follow the `$component-state-property-size` formula for
@@ -1896,7 +1898,7 @@ $carousel-indicator-transition:      null !default;
 // Boosted mod
 $carousel-indicator-hover-scale:        1.5 !default;
 $carousel-indicator-active-scale:       calc(2 / 3) !default; // stylelint-disable-line function-disallowed-list
-$carousel-indicator-active-radius:      0 100% 100% 0 / 50% !default;
+$carousel-indicator-active-radius:      0 100% 100% list.slash(0, 50%) !default;
 $carousel-indicator-animation-duration: 5000ms !default;
 $carousel-indicator-animation-interval: var(--carousel-interval, #{$carousel-indicator-animation-duration}) !default;
 $carousel-indicators-padding-y:         $spacer * .5 !default;

--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -17,6 +17,7 @@
 // scss-docs-start border-radius-mixins
 @mixin border-radius($radius: $border-radius, $fallback-border-radius: false) {
   @if $enable-rounded {
+    @debug $radius;
     border-radius: valid-radius($radius);
   }
   @else if $fallback-border-radius != false {


### PR DESCRIPTION
> **Warning**
> Doesn't seem to work in the context of GitHub actions

### Related issues

Fixes #1508 

### Description

Use `sass:list` and `list.slash()` instead of `/` for `$carousel-indicator-active-radius` definition as mentioned in https://sass-lang.com/documentation/breaking-changes/slash-div.

⚠️ Not 100% sure that this is the correct fix. If you have other ideas, please let me know in the comments.

### Motivation & Context

Even if `$enable-rounded` shouldn't be used in the context of Orange, let's try to make things good.

### Types of change

- Bug fix (non-breaking which fixes an issues)

### Live previews

* https://deploy-preview-1600--boosted.netlify.app/

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed