### PR TITLE
CSS: Fix compilation issue when `$enable-rounded: true`

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -274,7 +274,7 @@
         transform-origin: left;
         // stylelint-disable-next-line function-disallowed-list
         animation: carousel-progress calc(#{$carousel-indicator-animation-interval} / 2) linear infinite, carousel-progress-half $carousel-indicator-animation-interval step-end infinite;
-        @include border-radius($carousel-indicator-active-radius, $carousel-indicator-active-radius);
+        @include border-radius(inspect($carousel-indicator-active-radius), $carousel-indicator-active-radius);
       }
 
       @keyframes carousel-progress {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -389,7 +389,7 @@ $orange-filter:         invert(46%) sepia(60%) saturate(2878%) hue-rotate(6deg) 
 // Quickly modify global styling by enabling or disabling optional features.
 
 $enable-caret:                true !default;
-$enable-rounded:              false !default;
+$enable-rounded:              true !default;
 $enable-shadows:              false !default;
 $enable-gradients:            false !default;
 $enable-transitions:          true !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -389,7 +389,7 @@ $orange-filter:         invert(46%) sepia(60%) saturate(2878%) hue-rotate(6deg) 
 // Quickly modify global styling by enabling or disabling optional features.
 
 $enable-caret:                true !default;
-$enable-rounded:              true !default;
+$enable-rounded:              false !default;
 $enable-shadows:              false !default;
 $enable-gradients:            false !default;
 $enable-transitions:          true !default;


### PR DESCRIPTION
### Related issues

Fixes #1508.

### Description

Add an `inspect` function around the used Sass var in order to avoid the trailing spaces around the `/` to avoid it to become a division.

### Motivation & Context

Even if `$enable-rounded` shouldn't be used in the context of Orange, let's try to make things good.

### Types of change

- Bug fix (non-breaking which fixes an issues)

### Live previews

* https://deploy-preview-1604--boosted.netlify.app/

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed
