### PR TITLE
fix(forms): disabled `<select>` rendering

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1112,8 +1112,8 @@ $form-select-font-weight:           $input-font-weight !default;
 $form-select-line-height:           $input-line-height !default;
 $form-select-color:                 $input-color !default;
 $form-select-bg:                    $input-bg !default;
-$form-select-disabled-color:        $gray-700 !default;
-$form-select-disabled-bg:           $gray-300 !default;
+$form-select-disabled-color:        $gray-500 !default;
+$form-select-disabled-bg:           $white !default;
 $form-select-disabled-border-color: $input-disabled-border-color !default;
 $form-select-bg-position:           right $form-select-padding-x top add(50%, 1px) !default;
 $form-select-bg-size:               .875rem 1rem !default; // In pixels because image dimensions


### PR DESCRIPTION
### Related issues

Closes #1362 

### Description

Modify `$form-select-disabled-*` values to correspond to the [disabled dropdown design guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480)

### Motivation & Context

Compliance with the DSM.

### Types of change

- Bug fix (non-breaking which fixes an issues)

### Live previews

* https://deploy-preview-1615--boosted.netlify.app/docs/5.2/forms/select/#disabled
* https://deploy-preview-1615--boosted.netlify.app/docs/5.2/forms/input-group/#custom-select (for non-regression testing when both the buttons and selects are disabled)
* https://deploy-preview-1615--boosted.netlify.app/docs/5.2/forms/overview/#disabled-forms

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed
