### PR TITLE
fix(range): realign input range thumb margin on Webkit

### DIFF
--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -34,7 +34,7 @@
     box-sizing: content-box; // Boosted mod
     width: $form-range-thumb-width;
     height: $form-range-thumb-height;
-    margin-top: subtract(($form-range-track-height - $form-range-thumb-height) * .5, $form-range-thumb-focus-box-shadow-width); // Webkit specific // Boosted mod
+    margin-top: ($form-range-track-height - ($form-range-thumb-height + $border-width * 2)) * .5; // Webkit specific // Boosted mod
     cursor: grab; // Boosted mod
     @include gradient-bg($form-range-thumb-bg);
     border: $form-range-thumb-border;

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -34,7 +34,7 @@
     box-sizing: content-box; // Boosted mod
     width: $form-range-thumb-width;
     height: $form-range-thumb-height;
-    margin-top: ($form-range-track-height - $form-range-thumb-height) * .5; // Webkit specific
+    margin-top: subtract(($form-range-track-height - $form-range-thumb-height) * .5, $form-range-thumb-focus-box-shadow-width); // Webkit specific // Boosted mod
     cursor: grab; // Boosted mod
     @include gradient-bg($form-range-thumb-bg);
     border: $form-range-thumb-border;


### PR DESCRIPTION
### Related issues

Fixes #1606 

### Description

Change the calculation to position the input range thumb on Webkit.

TBH I haven't checked on all browsers. Dear reviewer, could you help me doing that 🙏

### Types of change

- Bug fix (non-breaking which fixes an issues)

### Live previews

* https://deploy-preview-1632--boosted.netlify.app/docs/5.2/forms/range/

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed
