### PR TITLE
Changing the link to Solaris icons

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -67,7 +67,7 @@ params:
   repo:                             "https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap"
   twitter:                          "getbootstrap"
   blog:                             "https://blog.getbootstrap.com/"
-  icons:                            "https://design.orange.com/icons-libraries/"
+  icons:                            "https://system.design.orange.com/0c1af118d/p/847054-solaris-icons/b/84c5ca"
   bootstrap:                        "https://getbootstrap.com"
   ods:
     web:                            "https://system.design.orange.com/0c1af118d/n/76065f"

--- a/site/content/docs/5.2/extend/icons.md
+++ b/site/content/docs/5.2/extend/icons.md
@@ -16,7 +16,7 @@ Solaris is a growing library of SVG icons that are designed by [Orange's Global 
 
 They are not open-source though and should only be used for Orange branded projects. Please refer to our [`NOTICE.txt` file for legal information]({{< param repo >}}/blob/v{{< param current_version >}}/NOTICE.txt).
 
-[Learn more about Solaris]({{< param icons >}}) (requires an `@orange.com` email to sign-up).
+[Learn more about Solaris]({{< param icons >}}).
 
 ### Use Solaris icons
 


### PR DESCRIPTION
### Related issues

Linked to #901.

### Description

Changed the link to Solaris Icons to redirect on the DSM directly

### Motivation & Context

Redirect people on the DSM is the best.

### Types of change

- Refactoring (non-breaking change)

### Live previews

* https://deploy-preview-1634--boosted.netlify.app/docs/extend/icons

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] My change introduces changes to the migration guide
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed