### PR TITLE
fix(storybook): generate SB website in `_site` intead of `site`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,5 +6,4 @@
 /js/tests/integration/
 /site/static/sw.js
 /site/layouts/
-/site/storybook/
 /stories/auto/

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,3 @@ Thumbs.db
 
 # Storybook
 /stories/auto
-/site/storybook

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "release-zip-examples": "node build/zip-examples.js",
     "dist": "npm-run-all --aggregate-output --parallel css js fonts",
     "test": "npm-run-all lint dist js-test docs-build docs-lint",
-    "netlify": "cross-env-shell HUGO_BASEURL=$DEPLOY_PRIME_URL npm-run-all dist release-sri storybook-build docs-build",
+    "netlify": "cross-env-shell HUGO_BASEURL=$DEPLOY_PRIME_URL npm-run-all dist release-sri storybook-build-netlify docs-build",
     "watch": "npm-run-all --parallel watch-*",
     "watch-css-main": "nodemon --watch scss/ --ext scss --exec \"npm-run-all css-lint css-compile css-prefix\"",
     "watch-css-dist": "nodemon --watch dist/css/ --ext css --ignore \"dist/css/*.rtl.*\" --exec \"npm run css-rtl\"",
@@ -96,7 +96,8 @@
     "watch-js-docs": "nodemon --watch site/assets/js/ --ext js --exec \"npm run js-lint\"",
     "storybook": "npm run storybook-generate && start-storybook -p 6006 --no-manager-cache",
     "storybook-generate": "npm run docs && node stories/create-stories-from-doc.js",
-    "storybook-build": "npm run storybook-generate && build-storybook -o ./_site/storybook"
+    "storybook-build": "npm run storybook-generate && build-storybook -o ./_site/storybook",
+    "storybook-build-netlify": "npm run storybook-generate && build-storybook -o ./site/storybook"
   },
   "peerDependencies": {
     "@popperjs/core": "^2.11.6"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "watch-js-docs": "nodemon --watch site/assets/js/ --ext js --exec \"npm run js-lint\"",
     "storybook": "npm run storybook-generate && start-storybook -p 6006 --no-manager-cache",
     "storybook-generate": "npm run docs && node stories/create-stories-from-doc.js",
-    "storybook-build": "npm run storybook-generate && build-storybook -o ./site/storybook"
+    "storybook-build": "npm run storybook-generate && build-storybook -o ./_site/storybook"
   },
   "peerDependencies": {
     "@popperjs/core": "^2.11.6"


### PR DESCRIPTION
### Related issues

Linked to the following issue mentioned in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/1626:

Error message when running `npm run storybook-build` and then `npm run storybook`

```
...
> boosted@5.2.1 docs-vnu
> node build/vnu-jar.js

"file:/Users/ju/Orange-Boosted-Bootstrap/_site/storybook/index.html":1.38-1.60: info warning: Self-closing tag syntax in text/html documents is widely discouraged; it's unnecessary and interacts badly with other HTML features (e.g., unquoted attribute values). If you're using a tool that injects self-closing tag syntax into all void elements, without any option to prevent it from doing so, then consider switching to a different tool.
"file:/Users/ju/Orange-Boosted-Bootstrap/_site/storybook/index.html":1.87-^C
```

### Description

This error is generated by the HTML validator that scans our `site` directory. Since Storybook website is generated in `site`, the HTML validator is not very happy with the self-closing tags.

But in fact, there's no reason to generate Storybook website in `site`. After the release, we're going to copy `_site` and not `site` into `gh-pages`.

When running locally `npm run storybook`, Storybook website is not generated as HTML files.

So the only thing to change here is to keep it working with Netlify which needs to have `site/storybook` directory. I have created a special npm command to differenciate the normal build and the one reserved to Netlify.

### Non-regression testing

* `npm run storybook` works locally and doesn't generate `_site/storybook` nor `site/storybook`
* running `npm run storybook-build` and then `npm run storybook` works without the error mentioned in the description
* `npm run storybook-build` creates `_site/storybook` but nothing in `site`
* `npm run release` creates `_site/storybook` but nothing in `site`

### Types of change

- Bug fix (non-breaking which fixes an issues)

### Live previews

* https://deploy-preview-1660--boosted.netlify.app/storybook

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] All new and existing tests passed
