### PR TITLE
Script: Removing an issue on certain windows config running `docs-accessibility`.

### DIFF
--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -2,6 +2,11 @@
   "standard": "WCAG2AA",
   "level": "error",
   "defaults": {
+    "chromeLaunchConfig": {
+        "args": [
+            "--no-sandbox"
+        ]
+    },
     "runners": [
       "axe"
     ],


### PR DESCRIPTION
### Related issues

NA

### Description

Adding a parameter to make it work on windows with certain config: 

```sh
Running Pa11y on 123 URLs:

> http://localhost:9001/docs/5.2/about/overview/ - Failed to run
> http://localhost:9001/docs/5.2/getting-started/accessibility/ - Failed to run
> http://localhost:9001/docs/5.2/components/accordion/ - Failed to run
> http://localhost:9001/docs/5.2/components/alerts/ - Failed to run
> http://localhost:9001/docs/5.2/extend/approach/ - Failed to run
> http://localhost:9001/docs/5.2/components/back-to-top/ - Failed to run
> http://localhost:9001/docs/5.2/utilities/background/ - Failed to run
> http://localhost:9001/docs/5.2/components/badge/ - Failed to run
```

### Motivation & Context

Running Puppeteer can be tough on certain windows config. Here the Puppeteer config for `docs-accessibility` should not break anything anywhere else.

### Types of change

- Refactoring (non-breaking change)

### Live previews

Check that the `npm run docs-accessibility` isn't break on local.
Check that the ci looks fine with this config. ✔️ 

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] My change introduces changes to the migration guide
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed


### Development

- [x] Run linters
- [x] Run compilers

### Reviews

- [ ] Code review