### PR TITLE
chore(deps-dev): bump pa11y-ci-reporter-html from 3.0.3 to 4.0.0

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -52,10 +52,6 @@ jobs:
       - name: Run accessibility tests
         run: npm run docs-accessibility
 
-      - name: Generate HTML accessibility results
-        run: npm run docs-pa11y-html
-        if: failure()
-
       - name: Upload accessibility results
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ Thumbs.db
 /js/coverage/
 /node_modules/
 /.pa11y/
-/pa11y-ci-results.json
 /.github/release-drafter.yml
 
 # Storybook

--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -9,7 +9,8 @@
     },
     "reporters": [
       "cli",
-      ["json", { "fileName": "./pa11y-ci-results.json" }]
+      ["json", { "fileName": "./pa11y-ci-results.json" }],
+      ["pa11y-ci-reporter-html", {"destination": ".pa11y", "includeZeroIssues": true}]
     ],
     "runners": [
       "axe"

--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -15,7 +15,7 @@
       "axe"
     ],
     "useIncognitoBrowserContext": false,
-    "hideElements": "iframe, #text-decoration + p + div a.text-decoration-none, .accordion-collapse, #offcanvasResponsive, #bdSidebar",
+    "hideElements": "iframe, #text-decoration + p + div a.text-decoration-none, .accordion-collapse, #offcanvas, #offcanvasDark, #offcanvasResponsive, #bdSidebar",
     "ignore": [
       "color-contrast"
     ]

--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -9,7 +9,6 @@
     },
     "reporters": [
       "cli",
-      ["json", { "fileName": "./pa11y-ci-results.json" }],
       ["pa11y-ci-reporter-html", {"destination": ".pa11y", "includeZeroIssues": true}]
     ],
     "runners": [

--- a/build/.pa11yci.json
+++ b/build/.pa11yci.json
@@ -15,7 +15,7 @@
       "axe"
     ],
     "useIncognitoBrowserContext": false,
-    "hideElements": "iframe, #text-decoration + p + div a.text-decoration-none, .accordion-collapse, #offcanvas, #offcanvasDark, #offcanvasResponsive, #bdSidebar",
+    "hideElements": "iframe, #text-decoration + p + div a.text-decoration-none, .accordion-collapse, #offcanvasResponsive, #bdSidebar",
     "ignore": [
       "color-contrast"
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "npm-run-all": "^4.1.5",
         "ods-storybook-theme": "^0.1.0",
         "pa11y-ci": "^3.0.1",
-        "pa11y-ci-reporter-html": "^3.0.3",
+        "pa11y-ci-reporter-html": "^4.0.0",
         "postcss": "^8.4.17",
         "postcss-cli": "^10.0.0",
         "rollup": "^2.79.1",
@@ -8224,12 +8224,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/chardet": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.0.tgz",
-      "integrity": "sha512-Nj3VehbbFs/1ZnJJJaL3ztEf3Nu5Fs6YV/NBs6lyz/iDDHUU+X9QNk5QgPy1/5Rjtb/cGVf+NyazP7kVEJqKRg==",
-      "dev": true
     },
     "node_modules/check-types": {
       "version": "11.2.2",
@@ -17746,31 +17740,20 @@
       }
     },
     "node_modules/pa11y-ci-reporter-html": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pa11y-ci-reporter-html/-/pa11y-ci-reporter-html-3.0.3.tgz",
-      "integrity": "sha512-PMeBYtghkoShPV67V4DsZHYBRUj9AZCJEzL3KUuQULNp59HwfhIc4YSukA1eiPK3Uttp8TtDreeDnh14mDghEw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pa11y-ci-reporter-html/-/pa11y-ci-reporter-html-4.0.0.tgz",
+      "integrity": "sha512-JWnJiuY3aWaEqL/MLfciuTbMd/0qVMsWJR5bnOPdHUlvhSUy59DKPcCMKeyc2p5pX4O6O4E0YUeuwZ4aAB5swg==",
       "dev": true,
       "dependencies": {
-        "chardet": "^1.4.0",
         "ci-logger": "^4.0.1",
-        "commander": "^8.3.0",
         "handlebars": "^4.7.7",
-        "pa11y-reporter-html": "^1.0.0"
-      },
-      "bin": {
-        "pa11y-ci-reporter-html": "bin/pa11y-ci-reporter-html.js"
+        "pa11y": "^6.1.1"
       },
       "engines": {
         "node": "^12.20.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/pa11y-ci-reporter-html/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "pa11y-ci": "^3.0.1"
       }
     },
     "node_modules/pa11y-ci/node_modules/array-union": {
@@ -17826,18 +17809,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pa11y-reporter-html": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pa11y-reporter-html/-/pa11y-reporter-html-1.0.0.tgz",
-      "integrity": "sha512-xF4TQVyDgVCtfIlYBAjvEnbTfoolKPu7AfAHD67mbiqjkdw2D28av1O62s2DcW1ho8Gb1aFZT1iFeP4HSs8SeQ==",
-      "dev": true,
-      "dependencies": {
-        "hogan.js": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pa11y/node_modules/commander": {
@@ -31288,12 +31259,6 @@
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
       "dev": true
     },
-    "chardet": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.0.tgz",
-      "integrity": "sha512-Nj3VehbbFs/1ZnJJJaL3ztEf3Nu5Fs6YV/NBs6lyz/iDDHUU+X9QNk5QgPy1/5Rjtb/cGVf+NyazP7kVEJqKRg==",
-      "dev": true
-    },
     "check-types": {
       "version": "11.2.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.2.tgz",
@@ -38728,33 +38693,14 @@
       }
     },
     "pa11y-ci-reporter-html": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pa11y-ci-reporter-html/-/pa11y-ci-reporter-html-3.0.3.tgz",
-      "integrity": "sha512-PMeBYtghkoShPV67V4DsZHYBRUj9AZCJEzL3KUuQULNp59HwfhIc4YSukA1eiPK3Uttp8TtDreeDnh14mDghEw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pa11y-ci-reporter-html/-/pa11y-ci-reporter-html-4.0.0.tgz",
+      "integrity": "sha512-JWnJiuY3aWaEqL/MLfciuTbMd/0qVMsWJR5bnOPdHUlvhSUy59DKPcCMKeyc2p5pX4O6O4E0YUeuwZ4aAB5swg==",
       "dev": true,
       "requires": {
-        "chardet": "^1.4.0",
         "ci-logger": "^4.0.1",
-        "commander": "^8.3.0",
         "handlebars": "^4.7.7",
-        "pa11y-reporter-html": "^1.0.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-          "dev": true
-        }
-      }
-    },
-    "pa11y-reporter-html": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pa11y-reporter-html/-/pa11y-reporter-html-1.0.0.tgz",
-      "integrity": "sha512-xF4TQVyDgVCtfIlYBAjvEnbTfoolKPu7AfAHD67mbiqjkdw2D28av1O62s2DcW1ho8Gb1aFZT1iFeP4HSs8SeQ==",
-      "dev": true,
-      "requires": {
-        "hogan.js": "^3.0.2"
+        "pa11y": "^6.1.1"
       }
     },
     "pako": {

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "npm-run-all": "^4.1.5",
     "ods-storybook-theme": "^0.1.0",
     "pa11y-ci": "^3.0.1",
-    "pa11y-ci-reporter-html": "^3.0.3",
+    "pa11y-ci-reporter-html": "^4.0.0",
     "postcss": "^8.4.17",
     "postcss-cli": "^10.0.0",
     "rollup": "^2.79.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "docs-vnu": "node build/vnu-jar.js",
     "docs-lint": "npm run docs-vnu",
     "docs-pa11y": "pa11y-ci --config build/.pa11yci.json --sitemap http://localhost:9001/sitemap.xml --sitemap-find https://boosted.orange.com --sitemap-replace http://localhost:9001",
-    "docs-pa11y-html": "pa11y-ci-reporter-html -d .pa11y",
     "docs-accessibility": "npm-run-all --parallel --race docs-serve-only docs-pa11y",
     "docs-serve": "hugo server --port 9001 --disableFastRender",
     "docs-serve-only": "sirv _site --no-clear --port 9001",

--- a/site/layouts/sitemap.xml
+++ b/site/layouts/sitemap.xml
@@ -1,5 +1,12 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{- range .Data.Pages -}}{{ if and .Permalink (ne .Params.sitemap_exclude true) }}
   <url>
-    <loc>http://localhost:9001/docs/5.2/components/offcanvas/</loc>
-  </url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML (.Lastmod.Format "2006-01-02T15:04:05-07:00") }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}"/>{{ end }}
+    <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}"/>{{ end }}
+  </url>{{ end }}{{ end }}
 </urlset>

--- a/site/layouts/sitemap.xml
+++ b/site/layouts/sitemap.xml
@@ -1,12 +1,5 @@
-{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{- range .Data.Pages -}}{{ if and .Permalink (ne .Params.sitemap_exclude true) }}
   <url>
-    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
-    <lastmod>{{ safeHTML (.Lastmod.Format "2006-01-02T15:04:05-07:00") }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
-    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
-    <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}"/>{{ end }}
-    <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}"/>{{ end }}
-  </url>{{ end }}{{ end }}
+    <loc>http://localhost:9001/docs/5.2/components/offcanvas/</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
### Description

This PR bumps pa11y-ci-reporter-html from 3.0.3 to 4.0.0 (first step before a bump to the latest version).

### Details

The [pa11y-ci-reporter-html 4.0.0 changelog](https://gitlab.com/gitlab-ci-utils/pa11y-ci-reporter-html/-/tags/4.0.0) mentions that the CLI interface to post-process Pa11y CI JSON reports is no longer supported.

Meaning that running `npm run docs-pa11y-html` doesn't work anymore and generates the following error: `sh: pa11y-ci-reporter-html: command not found` **locally** or **via GitHub Actions (CI)**.

This PR follows the [migration guide](https://gitlab.com/gitlab-ci-utils/pa11y-ci-reporter-html/-/blob/master/docs/upgrade-guide.md) to update our env.

### Non-regression testing

#### Locally

* Modify `site/layouts/sitemap.xml` to have only:
```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <loc>http://localhost:9001/docs/5.2/components/offcanvas/</loc>
  </url>
</urlset>
```
* Modify `build/.pa11yci.json` to remove `#offcanvas, #offcanvasDark` `hideElements` rules.
* Run `npm run docs` then `npm run docs-accessibility`

You can see errors in the console and `.pa11y` is generated and contains errors in the HTML.

#### GitHub Actions (CI)

* https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/runs/3702043958/jobs/6271895975 contains in the console the error
* In https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/runs/3702043958, by clicking on "Summary", download the artifacts. It contains both HTML files whose display the introduced error.