### PR TITLE
chore(deps-dev): bump pa11y-ci-reporter-html from 4.0.0 to 5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "npm-run-all": "^4.1.5",
         "ods-storybook-theme": "^0.1.0",
         "pa11y-ci": "^3.0.1",
-        "pa11y-ci-reporter-html": "^4.0.0",
+        "pa11y-ci-reporter-html": "^5.0.2",
         "postcss": "^8.4.17",
         "postcss-cli": "^10.0.0",
         "rollup": "^2.79.1",
@@ -8354,27 +8354,12 @@
       }
     },
     "node_modules/ci-logger": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ci-logger/-/ci-logger-4.0.2.tgz",
-      "integrity": "sha512-cE5aWwGpvZMA6aGIRWzPiybj3trcZPssKiNW+VxrOtwgNt2pnwxOpaJZttXZnU/C0ihi/zCqk/FKLqHie2VjDA==",
-      "dev": true,
-      "dependencies": {
-        "@sindresorhus/is": "^4.6.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/ci-logger/node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ci-logger/-/ci-logger-5.1.0.tgz",
+      "integrity": "sha512-C1sVkBW3gEViqBsMKmR1PFk7A7/DRkJzUArxHD5Mwe/i1rwtyEuDXvWwR406eU/k01N7U21wwiiiLA/gCSKQLA==",
       "dev": true,
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
+        "node": "^14.15.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/cipher-base": {
@@ -17740,17 +17725,17 @@
       }
     },
     "node_modules/pa11y-ci-reporter-html": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pa11y-ci-reporter-html/-/pa11y-ci-reporter-html-4.0.0.tgz",
-      "integrity": "sha512-JWnJiuY3aWaEqL/MLfciuTbMd/0qVMsWJR5bnOPdHUlvhSUy59DKPcCMKeyc2p5pX4O6O4E0YUeuwZ4aAB5swg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/pa11y-ci-reporter-html/-/pa11y-ci-reporter-html-5.0.2.tgz",
+      "integrity": "sha512-zDRrIg8yQjQTP6heETQklAW4+1ytKi3g9RTdMwEfcU/dN61tYQG3C6WX3nM2UjhTBonThkO41B6jiWUwtzzWRA==",
       "dev": true,
       "dependencies": {
-        "ci-logger": "^4.0.1",
+        "ci-logger": "^5.1.0",
         "handlebars": "^4.7.7",
-        "pa11y": "^6.1.1"
+        "pa11y-reporter-html-plus": "^1.0.3"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.15.0 || ^16.13.0 || >=18.0.0"
       },
       "peerDependencies": {
         "pa11y-ci": "^3.0.1"
@@ -17809,6 +17794,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pa11y-reporter-html-plus": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pa11y-reporter-html-plus/-/pa11y-reporter-html-plus-1.0.3.tgz",
+      "integrity": "sha512-qjO0FXBHVqUU3wg79sKx+xVX9VGpd5cTPbR8hWh9Wh/8yJFQb7mG30tyIsnzKsa2l1VJ5RkaF0G5CXoUH8zR3w==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/pa11y/node_modules/commander": {
@@ -31352,21 +31349,10 @@
       "dev": true
     },
     "ci-logger": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ci-logger/-/ci-logger-4.0.2.tgz",
-      "integrity": "sha512-cE5aWwGpvZMA6aGIRWzPiybj3trcZPssKiNW+VxrOtwgNt2pnwxOpaJZttXZnU/C0ihi/zCqk/FKLqHie2VjDA==",
-      "dev": true,
-      "requires": {
-        "@sindresorhus/is": "^4.6.0"
-      },
-      "dependencies": {
-        "@sindresorhus/is": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-          "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-          "dev": true
-        }
-      }
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ci-logger/-/ci-logger-5.1.0.tgz",
+      "integrity": "sha512-C1sVkBW3gEViqBsMKmR1PFk7A7/DRkJzUArxHD5Mwe/i1rwtyEuDXvWwR406eU/k01N7U21wwiiiLA/gCSKQLA==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -38693,14 +38679,23 @@
       }
     },
     "pa11y-ci-reporter-html": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pa11y-ci-reporter-html/-/pa11y-ci-reporter-html-4.0.0.tgz",
-      "integrity": "sha512-JWnJiuY3aWaEqL/MLfciuTbMd/0qVMsWJR5bnOPdHUlvhSUy59DKPcCMKeyc2p5pX4O6O4E0YUeuwZ4aAB5swg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/pa11y-ci-reporter-html/-/pa11y-ci-reporter-html-5.0.2.tgz",
+      "integrity": "sha512-zDRrIg8yQjQTP6heETQklAW4+1ytKi3g9RTdMwEfcU/dN61tYQG3C6WX3nM2UjhTBonThkO41B6jiWUwtzzWRA==",
       "dev": true,
       "requires": {
-        "ci-logger": "^4.0.1",
+        "ci-logger": "^5.1.0",
         "handlebars": "^4.7.7",
-        "pa11y": "^6.1.1"
+        "pa11y-reporter-html-plus": "^1.0.3"
+      }
+    },
+    "pa11y-reporter-html-plus": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pa11y-reporter-html-plus/-/pa11y-reporter-html-plus-1.0.3.tgz",
+      "integrity": "sha512-qjO0FXBHVqUU3wg79sKx+xVX9VGpd5cTPbR8hWh9Wh/8yJFQb7mG30tyIsnzKsa2l1VJ5RkaF0G5CXoUH8zR3w==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7"
       }
     },
     "pako": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "npm-run-all": "^4.1.5",
     "ods-storybook-theme": "^0.1.0",
     "pa11y-ci": "^3.0.1",
-    "pa11y-ci-reporter-html": "^4.0.0",
+    "pa11y-ci-reporter-html": "^5.0.2",
     "postcss": "^8.4.17",
     "postcss-cli": "^10.0.0",
     "rollup": "^2.79.1",


### PR DESCRIPTION
This PR follows https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1707 to finally use the latest version of `pa11y-ci-reporter-html`.

Here are the intermediate versions from 4.0.0 to 5.0.2:
- [5.0.0](https://gitlab.com/gitlab-ci-utils/pa11y-ci-reporter-html/-/tags/5.0.0)
- [5.0.1](https://gitlab.com/gitlab-ci-utils/pa11y-ci-reporter-html/-/tags/5.0.1)
- [5.0.2](https://gitlab.com/gitlab-ci-utils/pa11y-ci-reporter-html/-/tags/5.0.2)

There are only 2 breaking elements in 5.0.0:
- "BREAKING: Dropped support for Node 12 and 17 since end-of-life"
  - This change is transparent in our case
- "BREAKING: Updated page reports to use [pa11y-reporter-html-plus](https://www.npmjs.com/package/pa11y-reporter-html-plus) instead of the built-in Pa11y HTML reporter. This includes enhanced support for all built-in Pa11y runners (htmlcs, axe), including links to relevant help, and the ability to filter accessibility issues by type."
  - We can see in the modified `package-lock.json` that `pa11y-reporter-html-plus` is gathered automatically as a dependency of `pa11y-ci-reporter-html` so we have nothing to do for that 

### How to test

This PR can be reviewed the same way as https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1707. I've introduced https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1712/commits/7015a3ecaebaa5e266ad9c95a09e39a46e5e1170 so that pa11y-ci fails locally and here in the CI. This commit will be reverted just before merging the PR.
- PR still failing and displays the message in the console of https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/runs/3710868362/jobs/6290756208
- Artifacts are still generated [in "Summary"](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/runs/3710868362). Not 100% sure but the HTML seems to be indeed enhanced 🤩 
- Locally, running `npm run docs-accessibility` displays errors in the console and generates `.pa11y` directory when failing.