### PR TITLE
docs: enhance rendering of `scss-docs` in Customize > Color section

### DIFF
--- a/site/content/docs/5.2/customize/color.md
+++ b/site/content/docs/5.2/customize/color.md
@@ -136,11 +136,11 @@ Boosted core uses Bootstrap's naming for maintenance ease, but **you're encourag
 <div class="row row-cols-1 row-cols-lg-2 mt-4">
     <div class="col">
         <h4>Orange color tokens</h4>
-        {{< scss-docs name="brand-colors" file="scss/_variables.scss" >}}
+{{< scss-docs name="brand-colors" file="scss/_variables.scss" >}}
     </div>
     <div class="col">
         <h4>Bootstrap core variables</h4>
-        {{< scss-docs name="color-variables" file="scss/_variables.scss" >}}
+{{< scss-docs name="color-variables" file="scss/_variables.scss" >}}
     </div>
 </div>
 <!-- End mod -->


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Description

This PR fixes the alignment of the "Orange color tokens" and "Bootstrap core variables" sections.

Before:

![Screenshot 2022-12-26 at 11 53 09](https://user-images.githubusercontent.com/17381666/209540845-c440ffb7-12d4-42e0-9b66-b964605209c5.png)

### Types of change

- Bug fix (non-breaking which fixes an issues)

### Live previews

* https://deploy-preview-1731--boosted.netlify.app/docs/5.2/customize/color/#usage
