### PR TITLE
fix(badge): better rendering for positioned badge focus state

### DIFF
--- a/site/content/docs/5.2/components/badge.md
+++ b/site/content/docs/5.2/components/badge.md
@@ -58,12 +58,12 @@ Please refer to our Boosted [Navbars]({{< docsref "/examples/navbars" >}}) examp
 {{< /ods-incompatibility-alert >}}
 
 {{< example >}}
-<a href="#" class="position-relative">
+<a href="#" class="position-relative d-inline-block">
   <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
     <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#buy"/>
   </svg>
   <span class="visually-hidden">Shopping basket</span>
-  <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-info text-white">
+  <span class="position-absolute top-0 badge rounded-pill bg-info text-white mt-1 start-50 translate-middle-y">
     99+
     <span class="visually-hidden">shopping basket items</span>
   </span>


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Linked to https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1437.

### Modification

Linked to https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1437/files where the rendering of the focus state is not great for the positioned badge.
In order to have a nice focus ring, the `<a>` must be inline block which implies some other class modifications.

Note: is it possible to modify the global headers as well to have this same kind of dynamic rendering?

### Types of change

- Fix

### Live previews

* https://deploy-preview-1747--boosted.netlify.app/

### Checklist

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [ ] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
- (NA) My change is compatible with responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- (NA) I have added JavaScript unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- (NA) My new component is added in Storybook
- (NA) My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- (NA) A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)

