### PR TITLE
docs: fix Composer command with the right version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Several quick start options are available:
 - Clone the repo: `git clone https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap.git`
 - Install with [npm](https://www.npmjs.com/): `npm install boosted@v5.2.3`
 - Install with [yarn](https://yarnpkg.com/): `yarn add boosted@v5.2.3`
-- Install with [Composer](https://getcomposer.org/): `composer require Orange-OpenSource/Orange-Boosted-Bootstrap:5.2.3`
+- Install with [Composer](https://getcomposer.org/): `composer require Orange-OpenSource/Orange-Boosted-Bootstrap:v5.2.3`
 - Install with [NuGet](https://www.nuget.org/): CSS: `Install-Package boosted` Sass: `Install-Package boosted.sass`
 
 Read the [Getting started page](https://boosted.orange.com/docs/getting-started/introduction/) for information on the framework contents, templates, examples, and more.

--- a/site/content/docs/5.2/getting-started/download.md
+++ b/site/content/docs/5.2/getting-started/download.md
@@ -95,7 +95,7 @@ yarn add boosted@v5.2.3
 You can also install and manage Boosted's Sass and JavaScript using [Composer](https://getcomposer.org/):
 
 ```sh
-composer require orange-opensource/orange-boosted-bootstrap:{{< param current_version >}}
+composer require orange-opensource/orange-boosted-bootstrap:v{{< param current_version >}}
 ```
 
 ### NuGet


### PR DESCRIPTION
> **Warning**
> Before merging, wait until Bootstrap corresponding PR is merged to confirm

Using Composer with Boosted is described like this in our doc: https://boosted.orange.com/docs/5.2/getting-started/download/#composer.

The issue is that `5.2.3` (without the "v" before) didn't exist since we now tag our versions with this prefix.

I've reuploaded all versions: 5.2.0, 5.2.1, 5.2.2 and 5.2.3 (check https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap#5.2.0).

So it means that for the following 5.3 version, we will continue to tag it `v5.3.0` so our doc must be updated so that the command works!

/cc @Lausselloic 

### [Live preview](https://deploy-preview-1777--boosted.netlify.app/docs/5.2/getting-started/download/#composer)