### PR TITLE
Update color picker according to UI Kit v5

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "./dist/css/boosted.min.css",
-      "maxSize": "38.0 kB"
+      "maxSize": "38.25 kB"
     },
     {
       "path": "./dist/js/boosted.bundle.js",

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1091,7 +1091,9 @@ $input-line-height-lg:                  $h5-line-height !default; // Boosted mod
 
 $input-transition:                      border-color $transition-duration $transition-timing, $transition-focus !default;
 
-$form-color-width:                      3rem !default;
+$form-color-width:                      2.5rem !default; // Boosted mod
+$form-color-height:                     $form-color-width !default; // Boosted mod
+$form-color-padding:                    map-get($spacers, 2) !default; // Boosted mod
 // scss-docs-end form-input-variables
 
 // scss-docs-start form-check-variables

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1092,7 +1092,8 @@ $input-line-height-lg:                  $h5-line-height !default; // Boosted mod
 $input-transition:                      border-color $transition-duration $transition-timing, $transition-focus !default;
 
 $form-color-width:                      2.5rem !default; // Boosted mod
-$form-color-disabled-color:             $gray-500 !default; // Boosted mod
+$form-color-disabled-border-color:      $gray-500 !default; // Boosted mod
+$form-color-disabled-background-swatch: brightness(0) invert(1) brightness(.8) !default; // Boosted mod
 // scss-docs-end form-input-variables
 
 // scss-docs-start form-check-variables

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1091,7 +1091,7 @@ $input-line-height-lg:                  $h5-line-height !default; // Boosted mod
 
 $input-transition:                      border-color $transition-duration $transition-timing, $transition-focus !default;
 
-$form-color-width:                      2.5rem !default; // Boosted mod
+$form-color-width:                      2.5rem !default; // Boosted mod: instead of `3rem`
 $form-color-disabled-border-color:      $gray-500 !default; // Boosted mod
 $form-color-disabled-background-swatch: brightness(0) invert(1) brightness(.8) !default; // Boosted mod
 // scss-docs-end form-input-variables

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1092,7 +1092,6 @@ $input-line-height-lg:                  $h5-line-height !default; // Boosted mod
 $input-transition:                      border-color $transition-duration $transition-timing, $transition-focus !default;
 
 $form-color-width:                      2.5rem !default; // Boosted mod
-$form-color-height:                     $form-color-width !default; // Boosted mod
 $form-color-padding:                    map-get($spacers, 2) !default; // Boosted mod
 // scss-docs-end form-input-variables
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1092,7 +1092,7 @@ $input-line-height-lg:                  $h5-line-height !default; // Boosted mod
 $input-transition:                      border-color $transition-duration $transition-timing, $transition-focus !default;
 
 $form-color-width:                      2.5rem !default; // Boosted mod
-$form-color-padding:                    map-get($spacers, 2) !default; // Boosted mod
+$form-color-disabled-color:             $gray-500 !default; // Boosted mod
 // scss-docs-end form-input-variables
 
 // scss-docs-start form-check-variables

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -200,6 +200,7 @@ textarea {
   }
 
   &:disabled {
+    background-color: var(--#{$prefix}body-bg);
     border-color: $form-color-disabled-color;
 
     &::-moz-color-swatch {

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -200,8 +200,15 @@ textarea {
   }
 
   &:disabled {
-    filter: grayscale(1);
     border-color: $form-color-disabled-color;
+
+    &::-moz-color-swatch {
+      filter: brightness(0) invert(1) brightness(.8);
+    }
+
+    &::-webkit-color-swatch {
+      filter: brightness(0) invert(1) brightness(.8);
+    }
   }
   // End mod
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -31,7 +31,7 @@
   }
 
   // Customize the `:focus` state to imitate native WebKit styles.
-  &:not(.form-control-color):focus { // Boosted mod
+  &:not(.form-control-color):focus { // Boosted mod: instead of `&:focus`
     color: $input-focus-color;
     background-color: $input-focus-bg;
     border-color: $input-focus-border-color !important; // stylelint-disable-line declaration-no-important

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -31,7 +31,7 @@
   }
 
   // Customize the `:focus` state to imitate native WebKit styles.
-  &:focus {
+  &:not(.form-control-color):focus {
     color: $input-focus-color;
     background-color: $input-focus-bg;
     border-color: $input-focus-border-color !important; // stylelint-disable-line declaration-no-important
@@ -191,22 +191,17 @@ textarea {
 .form-control-color {
   width: $form-color-width;
   height: $input-height;
-  padding: $form-color-padding; // Boosted mod
-  border: 2px solid var(--#{$prefix}body-color);
+  padding: $input-padding-y;
+  border-color: var(--#{$prefix}body-color);
 
   // Boosted mod
-  &:focus {
-    &[data-focus-visible-added] {
-      background-color: $black;
-    }
-  }
-
-  &:not(:disabled):not([readonly]):hover {
+  &:not(:disabled):hover {
     background-color: var(--#{$prefix}body-color);
   }
 
   &:disabled {
     filter: grayscale(1);
+    border-color: $form-color-disabled-color;
   }
   // End mod
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -201,8 +201,12 @@ textarea {
     }
   }
 
-  &:hover {
+  &:not(:disabled):not([readonly]):hover {
     background-color: var(--#{$prefix}body-color);
+  }
+
+  &:disabled {
+    filter: grayscale(1);
   }
   // End mod
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -190,21 +190,19 @@ textarea {
 
 .form-control-color {
   width: $form-color-width;
-  height: $form-color-height; // Boosted mod
+  height: $input-height;
   padding: $form-color-padding; // Boosted mod
-  border: 0; // Boosted mod
-  box-shadow: inset 0 0 0 2px $black; // Boosted mod
+  border: 2px solid var(--#{$prefix}body-color);
 
   // Boosted mod
   &:focus {
     &[data-focus-visible-added] {
       background-color: $black;
-      box-shadow: inset 0 0 0 2px $black;
     }
   }
 
   &:hover {
-    background-color: $black;
+    background-color: var(--#{$prefix}body-color);
   }
   // End mod
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -31,7 +31,7 @@
   }
 
   // Customize the `:focus` state to imitate native WebKit styles.
-  &:not(.form-control-color):focus {
+  &:not(.form-control-color):focus { // Boosted mod
     color: $input-focus-color;
     background-color: $input-focus-bg;
     border-color: $input-focus-border-color !important; // stylelint-disable-line declaration-no-important
@@ -192,23 +192,23 @@ textarea {
   width: $form-color-width;
   height: $input-height;
   padding: $input-padding-y;
-  border-color: var(--#{$prefix}body-color);
+  border-color: var(--#{$prefix}body-color); // Boosted mod
 
   // Boosted mod
-  &:not(:disabled):hover {
+  &:hover {
     background-color: var(--#{$prefix}body-color);
   }
 
   &:disabled {
     background-color: var(--#{$prefix}body-bg);
-    border-color: $form-color-disabled-color;
+    border-color: $form-color-disabled-border-color;
 
     &::-moz-color-swatch {
-      filter: brightness(0) invert(1) brightness(.8);
+      filter: $form-color-disabled-background-swatch;
     }
 
     &::-webkit-color-swatch {
-      filter: brightness(0) invert(1) brightness(.8);
+      filter: $form-color-disabled-background-swatch;
     }
   }
   // End mod

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -190,8 +190,23 @@ textarea {
 
 .form-control-color {
   width: $form-color-width;
-  height: $input-height;
-  padding: $input-padding-y;
+  height: $form-color-height; // Boosted mod
+  padding: $form-color-padding; // Boosted mod
+  border: 0; // Boosted mod
+  box-shadow: inset 0 0 0 2px $black; // Boosted mod
+
+  // Boosted mod
+  &:focus {
+    &[data-focus-visible-added] {
+      background-color: $black;
+      box-shadow: inset 0 0 0 2px $black;
+    }
+  }
+
+  &:hover {
+    background-color: $black;
+  }
+  // End mod
 
   &:not(:disabled):not([readonly]) {
     cursor: pointer;

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -121,8 +121,8 @@ Set the `type="color"` and add `.form-control-color` to the `<input>`. We use th
 </div >
 
 <div class="mb-3">
-  <label for="exampleColorInput" class="form-label">Disabled color picker</label>
-  <input type="color" class="form-control form-control-color" id="exampleColorInput" value="#a885d8" title="Choose your color" disabled>
+  <label for="exampleDisabledColorInput" class="form-label">Disabled color picker</label>
+  <input type="color" class="form-control form-control-color" id="exampleDisabledColorInput" value="#a885d8" title="Choose your color" disabled>
 </div>
 {{< /example >}}
 

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -116,7 +116,7 @@ Set the `type="color"` and add `.form-control-color` to the `<input>`. We use th
 
 {{< example >}}
 <label for="exampleColorInput" class="form-label">Color picker</label>
-<input type="color" class="form-control form-control-color" id="exampleColorInput" value="#563d7c" title="Choose your color">
+<input type="color" class="form-control form-control-color" id="exampleColorInput" value="#a885d8" title="Choose your color">
 {{< /example >}}
 
 ## Datalists

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -120,7 +120,7 @@ Set the `type="color"` and add `.form-control-color` to the `<input>`. We use th
   <input type="color" class="form-control form-control-color" id="exampleColorInput" value="#a885d8" title="Choose your color">
 </div >
 
-<div class="mb-3">
+<div>
   <label for="exampleDisabledColorInput" class="form-label is-disabled">Disabled color picker</label>
   <input type="color" class="form-control form-control-color" id="exampleDisabledColorInput" value="#a885d8" title="Choose your color" disabled>
 </div>

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -114,6 +114,10 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 
 Set the `type="color"` and add `.form-control-color` to the `<input>`. We use the modifier class to set fixed `height`s and override some inconsistencies between browsers.
 
+{{< callout info >}}
+{{< partial "callouts/warning-color-picker.md" >}}
+{{< /callout >}}
+
 {{< example >}}
 <div class="mb-3">
   <label for="exampleColorInput" class="form-label">Color picker</label>

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -115,7 +115,7 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 Set the `type="color"` and add `.form-control-color` to the `<input>`. We use the modifier class to set fixed `height`s and override some inconsistencies between browsers.
 
 {{< callout info >}}
-{{< partial "callouts/warning-color-picker.md" >}}
+**Accessibility warning** The support among browsers/AT is not robust enough (https://a11ysupport.io/tests/tech__html__input__input-color#assertion-html-input(type-color)_element-convey_name). So, use with care and provide an alternative way of entering or choosing a color value (eg. an input text fields to enter a hexadecimal color value).
 {{< /callout >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -114,8 +114,8 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 
 Set the `type="color"` and add `.form-control-color` to the `<input>`. We use the modifier class to set fixed `height`s and override some inconsistencies between browsers.
 
-{{< callout info >}}
-**Accessibility warning** The support among browsers/AT is not robust enough (https://a11ysupport.io/tests/tech__html__input__input-color#assertion-html-input(type-color)_element-convey_name). So, use with care and provide an alternative way of entering or choosing a color value (eg. an input text fields to enter a hexadecimal color value).
+{{< callout warning >}}
+**Accessibility warning** The support among browsers/AT is not robust enough (https://a11ysupport.io/tests/tech__html__input__input-color#assertion-html-input(type-color)_element-convey_name). So, use with care and provide an alternative way of entering or choosing a color value (e.g., an input text field to enter a hexadecimal color value).
 {{< /callout >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -115,7 +115,7 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 Set the `type="color"` and add `.form-control-color` to the `<input>`. We use the modifier class to set fixed `height`s and override some inconsistencies between browsers.
 
 {{< callout warning >}}
-**Accessibility warning** The support among browsers/AT is not robust enough (https://a11ysupport.io/tests/tech__html__input__input-color#assertion-html-input(type-color)_element-convey_name). So, use with care and provide an alternative way of entering or choosing a color value (e.g., an input text field to enter a hexadecimal color value).
+Support among browsers/AT is not robust enough (https://a11ysupport.io/tests/tech__html__input__input-color#assertion-html-input(type-color)_element-convey_name). So, use with care and provide an alternative way of entering or choosing a color value (e.g., an input text field to enter a hexadecimal color value).
 {{< /callout >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -121,7 +121,7 @@ Set the `type="color"` and add `.form-control-color` to the `<input>`. We use th
 </div >
 
 <div class="mb-3">
-  <label for="exampleDisabledColorInput" class="form-label">Disabled color picker</label>
+  <label for="exampleDisabledColorInput" class="form-label is-disabled">Disabled color picker</label>
   <input type="color" class="form-control form-control-color" id="exampleDisabledColorInput" value="#a885d8" title="Choose your color" disabled>
 </div>
 {{< /example >}}

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -115,8 +115,15 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 Set the `type="color"` and add `.form-control-color` to the `<input>`. We use the modifier class to set fixed `height`s and override some inconsistencies between browsers.
 
 {{< example >}}
-<label for="exampleColorInput" class="form-label">Color picker</label>
-<input type="color" class="form-control form-control-color" id="exampleColorInput" value="#a885d8" title="Choose your color">
+<div class="mb-3">
+  <label for="exampleColorInput" class="form-label">Color picker</label>
+  <input type="color" class="form-control form-control-color" id="exampleColorInput" value="#a885d8" title="Choose your color">
+</div >
+
+<div class="mb-3">
+  <label for="exampleColorInput" class="form-label">Disabled color picker</label>
+  <input type="color" class="form-control form-control-color" id="exampleColorInput" value="#a885d8" title="Choose your color" disabled>
+</div>
 {{< /example >}}
 
 ## Datalists

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -118,8 +118,6 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
 
 - <span class="badge bg-warning">Warning</span> Form text examples have been modified to add some precisions; form text should be explicitly associated with the form control it relates to using the `aria-labelledby` (for mandatory information such as data format) or `aria-describedby` (for complementary information) attribute. Please apply this modification in your websites if needed.
 
-- `.form-control-color` component has been redesigned according to UI Kit v5.
-
 ### Helpers and utilities
 
 - <span class="badge bg-success">New</span> `.border-{color}-subtle`.

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -109,6 +109,8 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
 
 - <span class="badge bg-warning">Warning</span> Form text examples have been modified to add some precisions; form text should be explicitly associated with the form control it relates to using the `aria-labelledby` (for mandatory information such as data format) or `aria-describedby` (for complementary information) attribute. Please apply this modification in your websites if needed.
 
+- `.form-control-color` component has been redesigned according to UI Kit v5.
+
 ### Helpers and utilities
 
 - <span class="badge bg-success">New</span> `.border-{color}-subtle`.
@@ -264,6 +266,7 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-warning-bg-subtle</code></li>
       <li><code>--bs-warning-border-subtle</code></li>
       <li><code>--bs-warning-text</code></li>
+      <li><code>--bs-form-color-disabled-color</code></li>
     </ul>
   </details>
 
@@ -355,6 +358,7 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>$warning-border-subtle</code></li>
       <li><code>$warning-text-dark</code></li>
       <li><code>$warning-text</code></li>
+      <li><code>$form-color-disabled-color</code></li>
     </ul>
   </details>
 

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -230,8 +230,6 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-emphasis-color</code></li>
       <li><code>--bs-emphasis-color</code></li>
       <li><code>--bs-form-check-bg</code></li>
-      <li><code>--bs-form-color-disabled-background-swatch</code></li>
-      <li><code>--bs-form-color-disabled-border-color</code></li>
       <li><code>--bs-form-control-bg</code></li>
       <li><code>--bs-form-control-disabled-bg</code></li>
       <li><code>--bs-form-select-bg-img</code></li>

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -230,6 +230,8 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-emphasis-color</code></li>
       <li><code>--bs-emphasis-color</code></li>
       <li><code>--bs-form-check-bg</code></li>
+      <li><code>--bs-form-color-disabled-background-swatch</code></li>
+      <li><code>--bs-form-color-disabled-border-color</code></li>
       <li><code>--bs-form-control-bg</code></li>
       <li><code>--bs-form-control-disabled-bg</code></li>
       <li><code>--bs-form-select-bg-img</code></li>
@@ -266,7 +268,6 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-warning-bg-subtle</code></li>
       <li><code>--bs-warning-border-subtle</code></li>
       <li><code>--bs-warning-text</code></li>
-      <li><code>--bs-form-color-disabled-color</code></li>
     </ul>
   </details>
 
@@ -310,6 +311,8 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>$focus-visible-inner-color-inverted</code></li>
       <li><code>$focus-visible-outer-color-inverted</code></li>
       <li><code>$font-weight-medium</code></li>
+      <li><code>$form-color-disabled-background-swatch</code></li>
+      <li><code>$form-color-disabled-border-color</code></li>
       <li><code>$headings-color-dark</code></li>
       <li><code>$info-bg-subtle-dark</code></li>
       <li><code>$info-bg-subtle</code></li>
@@ -358,7 +361,6 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>$warning-border-subtle</code></li>
       <li><code>$warning-text-dark</code></li>
       <li><code>$warning-text</code></li>
-      <li><code>$form-color-disabled-color</code></li>
     </ul>
   </details>
 

--- a/site/layouts/partials/callouts/warning-color-picker.md
+++ b/site/layouts/partials/callouts/warning-color-picker.md
@@ -1,3 +1,0 @@
-##### Accessibility warning
-
-The support among browsers/AT is not robust enough (https://a11ysupport.io/tests/tech__html__input__input-color#assertion-html-input(type-color)_element-convey_name). So, use with care and provide an alternative way of entering or choosing a color value (eg. an input text fields to enter a hexadecimal color value).

--- a/site/layouts/partials/callouts/warning-color-picker.md
+++ b/site/layouts/partials/callouts/warning-color-picker.md
@@ -1,0 +1,3 @@
+##### Accessibility warning
+
+The support among browsers/AT is not robust enough (https://a11ysupport.io/tests/tech__html__input__input-color#assertion-html-input(type-color)_element-convey_name). So, use with care and provide an alternative way of entering or choosing a color value (eg. an input text fields to enter a hexadecimal color value).


### PR DESCRIPTION
### Description

Update color picker design.
Closes #1360 

### Motivation & Context

Compliance to UI Kit v5.

### Types of change

- New feature (non-breaking change which adds functionality)

### Live previews

- [https://deploy-preview-1794--boosted.netlify.app/docs/5.3/forms/form-control/#color](https://deploy-preview-1794--boosted.netlify.app/docs/5.3/forms/form-control/#color)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
- [x] My change is compatible with responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- (NA) I have added JavaScript unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] My change introduces changes to the migration guide
- (NA) My new component is added in Storybook
- (NA) My new component is compatible with RTL
- [x] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [x] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [x] Code review
- [x] Design review
- [x] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)

<!------------------------>
<!-- /!\ Core Team Only -->
<!------------------------>

<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `config.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
    - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
- [ ] if year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (eg for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] merge (on `v4-dev` or `main`)
- [ ] tag your version, and push your tag
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach zip file
  - paste CHANGELOG / Ship list in the release's description
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in NPM (with a personnal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you're releasing a pre-release, use `--tag`, eg for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch (don't forget to update Storybook as well)
  - [ ] check every `index.html` used as redirections to be redirecting to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurences
- [ ] make an announcement in Plazza :tada:
-->
