### PR TITLE
chore(deps-dev): bump tarteaucitronjs from 1.9.9 to 1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "sirv-cli": "^2.0.2",
         "stylelint": "^14.15.0",
         "stylelint-config-twbs-bootstrap": "^7.0.0",
-        "tarteaucitronjs": "^1.9.9",
+        "tarteaucitronjs": "^1.10.0",
         "terser": "^5.15.1",
         "vnu-jar": "^22.9.29"
       },
@@ -22883,9 +22883,9 @@
       }
     },
     "node_modules/tarteaucitronjs": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.9.9.tgz",
-      "integrity": "sha512-0KQWbMab+5tB6Jm9cRCoW+GBsVnJRtY6ZhslygXOYoJZt2tI4O918kc/+ImeSkB0m+yLcwPLFO/w8N4Hzg4EfA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.10.0.tgz",
+      "integrity": "sha512-+DcPWPA9VsoT+vGGegcxu9fFrCOdFPtvzmO1P6OXFiF8ngNG1SsCWpxn+05XY0I3B0hNaVJgkSOoGm9cZUMjKA==",
       "dev": true
     },
     "node_modules/telejson": {
@@ -42649,9 +42649,9 @@
       }
     },
     "tarteaucitronjs": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.9.9.tgz",
-      "integrity": "sha512-0KQWbMab+5tB6Jm9cRCoW+GBsVnJRtY6ZhslygXOYoJZt2tI4O918kc/+ImeSkB0m+yLcwPLFO/w8N4Hzg4EfA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.10.0.tgz",
+      "integrity": "sha512-+DcPWPA9VsoT+vGGegcxu9fFrCOdFPtvzmO1P6OXFiF8ngNG1SsCWpxn+05XY0I3B0hNaVJgkSOoGm9cZUMjKA==",
       "dev": true
     },
     "telejson": {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "sirv-cli": "^2.0.2",
     "stylelint": "^14.15.0",
     "stylelint-config-twbs-bootstrap": "^7.0.0",
-    "tarteaucitronjs": "^1.9.9",
+    "tarteaucitronjs": "^1.10.0",
     "terser": "^5.15.1",
     "vnu-jar": "^22.9.29"
   },


### PR DESCRIPTION
Please double-check that there is no regression with this new version of tarteaucitronjs.