### PR TITLE
Chore merge 13th of Feb

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/boosted.css",
-      "maxSize": "41.0 kB"
+      "maxSize": "41.25 kB"
     },
     {
       "path": "./dist/css/boosted.min.css",

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -116,19 +116,6 @@
   }
 }
 
-// Boosted mod
-.nav-tabs-light {
-  // scss-docs-start nav-tabs-light-css-vars
-  --#{$prefix}nav-tabs-border-width: #{calc($nav-tabs-border-width * .5)};
-  --#{$prefix}nav-tabs-border-color: #{$gray-500};
-  --#{$prefix}nav-tabs-link-hover-color: #{$accessible-orange};
-  --#{$prefix}nav-tabs-link-border-width: 0 0 calc(var(--#{$prefix}nav-tabs-border-width) * 4); // stylelint-disable-line function-disallowed-list
-  --#{$prefix}nav-tabs-link-hover-border-color: transparent;
-  --#{$prefix}nav-tabs-link-active-border-color: #{$accessible-orange};
-  // scss-docs-end nav-tabs-light-css-vars
-}
-// End mod
-
 //
 // Pills
 //
@@ -164,6 +151,68 @@
   // Boosted mod
   .nav-item + .nav-item {
     margin-left: calc(var(--#{$prefix}nav-link-padding-y) * .5); /* stylelint-disable-line function-disallowed-list */
+  }
+  // End mod
+}
+
+//
+// Underline
+//
+
+.nav-underline {
+  // scss-docs-start nav-underline-css-vars
+  --#{$prefix}nav-underline-gap: #{$nav-underline-gap};
+  --#{$prefix}nav-underline-border-width: #{$nav-underline-border-width};
+  --#{$prefix}nav-underline-border-color: #{$gray-500}; // Boosted mod
+  --#{$prefix}nav-underline-border-radius: #{$nav-tabs-border-radius}; // Boosted mod
+  --#{$prefix}nav-underline-link-padding-x: #{$nav-tabs-link-padding-x}; // Boosted mod
+  --#{$prefix}nav-underline-link-hover-color: #{$accessible-orange}; // Boosted mod
+  --#{$prefix}nav-underline-link-hover-bg: var(--#{$prefix}nav-underline-link-hover-border-color); // Boosted mod
+  --#{$prefix}nav-underline-link-border-width: 0 0 calc(var(--#{$prefix}nav-underline-border-width) * 4);  /* stylelint-disable-line function-disallowed-list */ // Boosted mod
+  --#{$prefix}nav-underline-link-hover-border-color: transparent; // Boosted mod
+  --#{$prefix}nav-underline-link-active-color: #{$nav-underline-link-active-color};
+  --#{$prefix}nav-underline-link-active-bg: #{$nav-tabs-link-active-bg}; // Boosted mod
+  --#{$prefix}nav-underline-link-active-border-color: #{$accessible-orange}; // Boosted mod
+  // scss-docs-end nav-underline-css-vars
+
+  gap: var(--#{$prefix}nav-underline-gap);
+  border-bottom: var(--#{$prefix}nav-underline-border-width) solid var(--#{$prefix}nav-underline-border-color); // Boosted mod
+
+  // Boosted mod
+  // Bigger gap between elements form lg breakpoint
+  @include media-breakpoint-up(lg) {
+    --#{$prefix}nav-underline-gap: var(--#{$prefix}nav-link-padding-y);
+  }
+
+  .nav-link {
+    padding: subtract(1rem, var(--#{$prefix}nav-underline-border-width)) subtract(var(--#{$prefix}nav-underline-link-padding-x), var(--#{$prefix}nav-underline-border-width)); // Boosted mod
+    margin-bottom: calc(-1 * var(--#{$prefix}nav-underline-border-width)); // stylelint-disable-line function-disallowed-list
+    background: none;
+    border: var(--#{$prefix}nav-underline-border-width) solid transparent;
+    border-width: var(--#{$prefix}nav-underline-link-border-width);
+    @include border-top-radius(var(--#{$prefix}nav-underline-border-radius));
+
+    &:hover {
+      color: var(--#{$prefix}nav-underline-link-hover-color);
+      background-color: var(--#{$prefix}nav-underline-link-hover-bg);
+      // Prevents active .nav-link tab overlapping focus outline of previous/next .nav-link
+      isolation: isolate;
+      border-color: var(--#{$prefix}nav-underline-link-hover-border-color);
+    }
+
+    &.disabled,
+    &:disabled {
+      color: var(--#{$prefix}nav-link-disabled-color);
+      background-color: transparent;
+      border-color: transparent;
+    }
+  }
+
+  .nav-link.active,
+  .nav-item.show .nav-link {
+    color: var(--#{$prefix}nav-underline-link-active-color);
+    background-color: var(--#{$prefix}nav-underline-link-active-bg);
+    border-color: var(--#{$prefix}nav-underline-link-active-border-color);
   }
   // End mod
 }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -178,7 +178,7 @@
   // Boosted mod
   // Bigger gap between elements from lg breakpoint
   @include media-breakpoint-up(lg) {
-    --#{$prefix}nav-underline-gap: var(--#{$prefix}nav-link-padding-y);
+    --#{$prefix}nav-underline-gap: #{$nav-underline-gap-lg};
   }
 
   .nav-link {

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -179,7 +179,7 @@
   border-bottom: var(--#{$prefix}nav-underline-border-width) solid var(--#{$prefix}nav-underline-border-color); // Boosted mod
 
   // Boosted mod
-  // Bigger gap between elements form lg breakpoint
+  // Bigger gap between elements from lg breakpoint
   @include media-breakpoint-up(lg) {
     --#{$prefix}nav-underline-gap: var(--#{$prefix}nav-link-padding-y);
   }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -163,16 +163,16 @@
   // scss-docs-start nav-underline-css-vars
   --#{$prefix}nav-underline-gap: #{$nav-underline-gap};
   --#{$prefix}nav-underline-border-width: #{$nav-underline-border-width};
-  --#{$prefix}nav-underline-border-color: #{$gray-500}; // Boosted mod
-  --#{$prefix}nav-underline-border-radius: #{$nav-tabs-border-radius}; // Boosted mod
-  --#{$prefix}nav-underline-link-padding-x: #{$nav-tabs-link-padding-x}; // Boosted mod
-  --#{$prefix}nav-underline-link-hover-color: #{$accessible-orange}; // Boosted mod
-  --#{$prefix}nav-underline-link-hover-bg: var(--#{$prefix}nav-underline-link-hover-border-color); // Boosted mod
-  --#{$prefix}nav-underline-link-border-width: 0 0 calc(var(--#{$prefix}nav-underline-border-width) * 4);  /* stylelint-disable-line function-disallowed-list */ // Boosted mod
+  --#{$prefix}nav-underline-border-color: #{$nav-underline-border-color}; // Boosted mod
+  --#{$prefix}nav-underline-border-radius: #{$nav-underline-border-radius}; // Boosted mod
+  --#{$prefix}nav-underline-link-padding-x: #{$nav-underline-link-padding-x}; // Boosted mod
+  --#{$prefix}nav-underline-link-hover-color: #{$nav-underline-link-hover-color}; // Boosted mod
+  --#{$prefix}nav-underline-link-hover-bg: transparent; // Boosted mod
+  --#{$prefix}nav-underline-link-border-width: #{$nav-underline-link-border-width}; // Boosted mod
   --#{$prefix}nav-underline-link-hover-border-color: transparent; // Boosted mod
   --#{$prefix}nav-underline-link-active-color: #{$nav-underline-link-active-color};
-  --#{$prefix}nav-underline-link-active-bg: #{$nav-tabs-link-active-bg}; // Boosted mod
-  --#{$prefix}nav-underline-link-active-border-color: #{$accessible-orange}; // Boosted mod
+  --#{$prefix}nav-underline-link-active-bg: #{$nav-underline-link-active-bg}; // Boosted mod
+  --#{$prefix}nav-underline-link-active-border-color: #{$nav-underline-link-active-border-color}; // Boosted mod
   // scss-docs-end nav-underline-css-vars
 
   gap: var(--#{$prefix}nav-underline-gap);

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -184,7 +184,6 @@
   .nav-link {
     padding: subtract(1rem, var(--#{$prefix}nav-underline-border-width)) subtract(var(--#{$prefix}nav-underline-link-padding-x), var(--#{$prefix}nav-underline-border-width)); // Boosted mod
     margin-bottom: calc(-1 * var(--#{$prefix}nav-underline-border-width)); // stylelint-disable-line function-disallowed-list
-    background: none;
     border: var(--#{$prefix}nav-underline-border-width) solid transparent;
     border-width: var(--#{$prefix}nav-underline-link-border-width);
     @include border-top-radius(var(--#{$prefix}nav-underline-border-radius));

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -79,7 +79,6 @@
   .nav-link {
     padding: subtract(1rem, var(--#{$prefix}nav-tabs-border-width)) subtract(var(--#{$prefix}nav-tabs-link-padding-x), var(--#{$prefix}nav-tabs-border-width)); // Boosted mod
     margin-bottom: calc(-1 * var(--#{$prefix}nav-tabs-border-width)); // stylelint-disable-line function-disallowed-list
-    background: none;
     border: var(--#{$prefix}nav-tabs-border-width) solid transparent;
     border-width: var(--#{$prefix}nav-tabs-link-border-width); // Boosted mod
     @include border-top-radius(var(--#{$prefix}nav-tabs-border-radius));
@@ -131,8 +130,6 @@
   .nav-link {
     padding-right: var(--#{$prefix}nav-pills-padding-x); // Boosted mod
     padding-left: var(--#{$prefix}nav-pills-padding-x); // Boosted mod
-    background: none;
-    border: 0;
     @include border-radius(var(--#{$prefix}nav-pills-border-radius));
 
     &:disabled {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1348,6 +1348,7 @@ $nav-pills-link-active-color:       $component-active-color !default;
 $nav-pills-link-active-bg:          $component-active-bg !default;
 
 $nav-underline-gap:                       0 !default; // Boosted mod: instead of 1rem
+$nav-underline-gap-lg:                    var(--#{$prefix}nav-link-padding-y) !default; // Boosted mod
 $nav-underline-border-width:              calc(var(--#{$prefix}border-width) * .5) !default; /* stylelint-disable-line function-disallowed-list */ // Boosted mod: instead of .125rem
 $nav-underline-border-color:              $gray-500 !default; // Boosted mod
 $nav-underline-border-radius:             var(--#{$prefix}border-radius) !default; // Boosted mod

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1348,7 +1348,7 @@ $nav-pills-link-active-color:       $component-active-color !default;
 $nav-pills-link-active-bg:          $component-active-bg !default;
 
 $nav-underline-gap:                       0 !default; // Boosted mod: instead of 1rem
-$nav-underline-border-width:              #{calc($nav-tabs-border-width * .5)} !default; // Boosted mod: instead of .125rem
+$nav-underline-border-width:              calc(var(--#{$prefix}border-width) * .5) !default; /* stylelint-disable-line function-disallowed-list */ // Boosted mod: instead of .125rem
 $nav-underline-border-color:              $gray-500 !default; // Boosted mod
 $nav-underline-border-radius:             var(--#{$prefix}border-radius) !default; // Boosted mod
 $nav-underline-link-active-color:         var(--#{$prefix}emphasis-color) !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1347,9 +1347,16 @@ $nav-pills-border-radius:           $border-radius !default;
 $nav-pills-link-active-color:       $component-active-color !default;
 $nav-pills-link-active-bg:          $component-active-bg !default;
 
-$nav-underline-gap:                 0 !default; // Boosted mod: instead of 1rem
-$nav-underline-border-width:        #{calc($nav-tabs-border-width * .5)} !default; // Boosted mod: instead of .125rem
-$nav-underline-link-active-color:   var(--#{$prefix}emphasis-color) !default;
+$nav-underline-gap:                       0 !default; // Boosted mod: instead of 1rem
+$nav-underline-border-width:              #{calc($nav-tabs-border-width * .5)} !default; // Boosted mod: instead of .125rem
+$nav-underline-border-color:              $gray-500 !default; // Boosted mod
+$nav-underline-border-radius:             var(--#{$prefix}border-radius) !default; // Boosted mod
+$nav-underline-link-active-color:         var(--#{$prefix}emphasis-color) !default;
+$nav-underline-link-padding-x:            $nav-tabs-link-padding-x !default; // Boosted mod
+$nav-underline-link-hover-color:          $accessible-orange !default; // Boosted mod
+$nav-underline-link-border-width:         0 0 calc(var(--#{$prefix}nav-underline-border-width) * 4) !default;  /* stylelint-disable-line function-disallowed-list */ // Boosted mod
+$nav-underline-link-active-bg:            var(--#{$prefix}body-bg) !default; // Boosted mod
+$nav-underline-link-active-border-color:  $accessible-orange !default; // Boosted mod
 // scss-docs-end nav-variables
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1346,6 +1346,10 @@ $nav-pills-padding-x:               $nav-tabs-link-padding-x !default; // Booste
 $nav-pills-border-radius:           $border-radius !default;
 $nav-pills-link-active-color:       $component-active-color !default;
 $nav-pills-link-active-bg:          $component-active-bg !default;
+
+$nav-underline-gap:                 0 !default; // Boosted mod: instead of 1rem
+$nav-underline-border-width:        #{calc($nav-tabs-border-width * .5)} !default; // Boosted mod: instead of .125rem
+$nav-underline-link-active-color:   var(--#{$prefix}emphasis-color) !default;
 // scss-docs-end nav-variables
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1342,18 +1342,18 @@ $nav-tabs-link-active-color:        var(--#{$prefix}emphasis-color) !default;
 $nav-tabs-link-active-bg:           var(--#{$prefix}body-bg) !default;
 $nav-tabs-link-active-border-color: $nav-tabs-link-active-color !default; // Boosted mod: instead of `var(--#{$prefix}border-color) var(--#{$prefix}border-color) $nav-tabs-link-active-bg`
 
-$nav-pills-padding-x:               $nav-tabs-link-padding-x !default; // Boosted mod
+$nav-pills-padding-x:               1.8125rem !default; // Boosted mod
 $nav-pills-border-radius:           $border-radius !default;
 $nav-pills-link-active-color:       $component-active-color !default;
 $nav-pills-link-active-bg:          $component-active-bg !default;
 
 $nav-underline-gap:                       0 !default; // Boosted mod: instead of 1rem
-$nav-underline-gap-lg:                    var(--#{$prefix}nav-link-padding-y) !default; // Boosted mod
+$nav-underline-gap-lg:                    $spacer * .5 !default; // Boosted mod
 $nav-underline-border-width:              calc(var(--#{$prefix}border-width) * .5) !default; /* stylelint-disable-line function-disallowed-list */ // Boosted mod: instead of .125rem
 $nav-underline-border-color:              $gray-500 !default; // Boosted mod
 $nav-underline-border-radius:             var(--#{$prefix}border-radius) !default; // Boosted mod
 $nav-underline-link-active-color:         var(--#{$prefix}emphasis-color) !default;
-$nav-underline-link-padding-x:            $nav-tabs-link-padding-x !default; // Boosted mod
+$nav-underline-link-padding-x:            1.8125rem !default; // Boosted mod
 $nav-underline-link-hover-color:          $accessible-orange !default; // Boosted mod
 $nav-underline-link-border-width:         0 0 calc(var(--#{$prefix}nav-underline-border-width) * 4) !default;  /* stylelint-disable-line function-disallowed-list */ // Boosted mod
 $nav-underline-link-active-bg:            var(--#{$prefix}body-bg) !default; // Boosted mod

--- a/site/content/docs/5.3/components/navs-tabs.md
+++ b/site/content/docs/5.3/components/navs-tabs.md
@@ -151,81 +151,6 @@ Takes the basic nav from above and adds the `.nav-tabs` class to generate a tabb
 </ul>
 {{< /example >}}
 
-<!-- Boosted mod -->
-### Tabs light
-
-Nav tabs light only differ visually, with a full width bottom border and a different active state.
-
-{{< example >}}
-<ul class="nav nav-tabs nav-tabs-light">
-  <li class="nav-item">
-    <a class="nav-link active" href="#" aria-current="page">Active</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" href="#">Link</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" href="#">Link</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link disabled">Disabled</a>
-  </li>
-</ul>
-{{< /example >}}
-
-### Nested tabs
-
-{{< added-in "5.2.0" >}}
-
-Nav tabs light is nested in a tab for adding a level of depth in information organization.
-
-{{< example >}}
-<ul role="tablist" aria-owns="nav-tab1 nav-tab2 nav-tab3 nav-tab4" class="nav nav-tabs" id="nav-tab-with-nested-tabs">
-  <li class="nav-item" role="presentation">
-    <a class="nav-link active" aria-current="page" id="nav-tab1" href="#tab1-content" data-bs-toggle="tab" data-bs-target="#tab1-content" role="tab" aria-controls="tab1-content" aria-selected="true">Tab 1</a>
-  </li>
-  <li class="nav-item" role="presentation">
-    <a class="nav-link" id="nav-tab2" data-bs-toggle="tab" href="#tab2-content" data-bs-target="#tab2-content" role="tab" aria-controls="tab2-content" aria-selected="false">Tab 2</a>
-  </li>
-  <li class="nav-item" role="presentation">
-    <a class="nav-link" id="nav-tab3" data-bs-toggle="tab" href="#tab3-content" data-bs-target="#tab3-content" role="tab" aria-controls="tab3-content" aria-selected="false">Tab 3</a>
-  </li>
-  <li class="nav-item" role="presentation">
-    <a class="nav-link disabled" id="nav-tab4" data-bs-toggle="tab" data-bs-target="#tab4-content" role="tab" aria-controls="tab4-content" aria-selected="false">Tab 4</a>
-  </li>
-</ul>
-
-<div class="tab-content" id="nav-tabs-content">
-  <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tabpanel" aria-labelledby="nav-tab1">
-    <ul role="tablist" aria-owns="nav-linkA nav-linkB nav-linkC nav-linkD" class="nav nav-tabs nav-tabs-light mt-0">
-      <li class="nav-item" role="presentation">
-        <a class="nav-link active" id="nav-linkA" href="#linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page">Link A</a>
-      </li>
-      <li class="nav-item" role="presentation">
-        <a class="nav-link" id="nav-linkB" href="#linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tab">Link B</a>
-      </li>
-      <li class="nav-item" role="presentation">
-        <a class="nav-link" id="nav-linkC" href="#linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tab">Link C</a>
-      </li>
-      <li class="nav-item" role="presentation">
-        <a class="nav-link disabled" id="nav-linkD" data-bs-toggle="tab" data-bs-target="#linkD" role="tab">Link D</a>
-      </li>
-    </ul>
-    <div class="tab-content border-0" id="nav-tabs-light-content">
-      <div class="tab-pane fade show active" id="linkA" role="tabpanel" aria-labelledby="nav-linkA">Content of Link A</div>
-      <div class="tab-pane" id="linkB" role="tabpanel" aria-labelledby="nav-linkB">Content of Link B</div>
-      <div class="tab-pane" id="linkC" role="tabpanel" aria-labelledby="nav-linkC">Content of Link C</div>
-      <div class="tab-pane" id="linkD" role="tabpanel" aria-labelledby="nav-linkD">Content of Link D</div>
-    </div>
-  </div>
-  <div class="tab-pane" id="tab2-content" role="tabpanel" aria-labelledby="nav-tab2">Content of Tab 2</div>
-  <div class="tab-pane" id="tab3-content" role="tabpanel" aria-labelledby="nav-tab3">Content of Tab 3</div>
-  <div class="tab-pane" id="tab4-content" role="tabpanel" aria-labelledby="nav-tab4">Content of Tab 4</div>
-</div>
-{{< /example >}}
-
-<!-- End mod -->
-
 ### Pills
 
 Take that same HTML, but use `.nav-pills` instead:
@@ -250,6 +175,80 @@ This variant should not be used because it is a button component in the Orange D
   </li>
 </ul>
 {{< /example >}}
+
+### Underline
+
+Take that same HTML, but use `.nav-underline` instead:
+
+{{< example >}}
+<ul class="nav nav-underline">
+  <li class="nav-item">
+    <a class="nav-link active" aria-current="page" href="#">Active</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Link</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+  </li>
+</ul>
+{{< /example >}}
+
+<!-- Boosted mod -->
+### Nested tabs
+
+{{< added-in "5.2.0" >}}
+
+Nav tabs light is nested in a tab for adding a level of depth in information organization.
+
+{{< example >}}
+<ul role="tablist" aria-owns="nav-tab1 nav-tab2 nav-tab3 nav-tab4" class="nav nav-tabs" id="nav-tab-with-nested-tabs">
+  <li class="nav-item" role="presentation">
+    <a class="nav-link active" aria-current="page" id="nav-tab1" href="#tab1-content" data-bs-toggle="tab" data-bs-target="#tab1-content" role="tab" aria-controls="tab1-content" aria-selected="true">Tab 1</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link" id="nav-tab2" data-bs-toggle="tab" href="#tab2-content" data-bs-target="#tab2-content" role="tab" aria-controls="tab2-content" aria-selected="false">Tab 2</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link" id="nav-tab3" data-bs-toggle="tab" href="#tab3-content" data-bs-target="#tab3-content" role="tab" aria-controls="tab3-content" aria-selected="false">Tab 3</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link disabled" id="nav-tab4" data-bs-toggle="tab" data-bs-target="#tab4-content" role="tab" aria-controls="tab4-content" aria-selected="false">Tab 4</a>
+  </li>
+</ul>
+
+<div class="tab-content" id="nav-tabs-content">
+  <div class="tab-pane-with-nested-tab fade show active" id="tab1-content" role="tabpanel" aria-labelledby="nav-tab1">
+    <ul role="tablist" aria-owns="nav-linkA nav-linkB nav-linkC nav-linkD" class="nav nav-underline mt-0">
+      <li class="nav-item" role="presentation">
+        <a class="nav-link active" id="nav-linkA" href="#linkA" data-bs-toggle="tab" data-bs-target="#linkA" role="tab" aria-current="page">Link A</a>
+      </li>
+      <li class="nav-item" role="presentation">
+        <a class="nav-link" id="nav-linkB" href="#linkB" data-bs-toggle="tab" data-bs-target="#linkB" role="tab">Link B</a>
+      </li>
+      <li class="nav-item" role="presentation">
+        <a class="nav-link" id="nav-linkC" href="#linkC" data-bs-toggle="tab" data-bs-target="#linkC" role="tab">Link C</a>
+      </li>
+      <li class="nav-item" role="presentation">
+        <a class="nav-link disabled" id="nav-linkD" data-bs-toggle="tab" data-bs-target="#linkD" role="tab">Link D</a>
+      </li>
+    </ul>
+    <div class="tab-content border-0">
+      <div class="tab-pane fade show active" id="linkA" role="tabpanel" aria-labelledby="nav-linkA">Content of Link A</div>
+      <div class="tab-pane" id="linkB" role="tabpanel" aria-labelledby="nav-linkB">Content of Link B</div>
+      <div class="tab-pane" id="linkC" role="tabpanel" aria-labelledby="nav-linkC">Content of Link C</div>
+      <div class="tab-pane" id="linkD" role="tabpanel" aria-labelledby="nav-linkD">Content of Link D</div>
+    </div>
+  </div>
+  <div class="tab-pane" id="tab2-content" role="tabpanel" aria-labelledby="nav-tab2">Content of Tab 2</div>
+  <div class="tab-pane" id="tab3-content" role="tabpanel" aria-labelledby="nav-tab3">Content of Tab 3</div>
+  <div class="tab-pane" id="tab4-content" role="tabpanel" aria-labelledby="nav-tab4">Content of Tab 4</div>
+</div>
+{{< /example >}}
+<!-- End mod -->
 
 ### Fill and justify
 
@@ -398,7 +397,7 @@ This variant should not be used because it is a button component in the Orange D
 
 {{< added-in "5.2.0" >}}
 
-As part of Boosted's evolving CSS variables approach, navs now use local CSS variables on `.nav`, `.nav-tabs`, `.nav-tabs-light` and `.nav-pills` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+As part of Boosted's evolving CSS variables approach, navs now use local CSS variables on `.nav`, `.nav-tabs`, and `.nav-pills` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
 
 On the `.nav` base class:
 
@@ -408,10 +407,6 @@ On the `.nav-tabs` modifier class:
 
 {{< scss-docs name="nav-tabs-css-vars" file="scss/_nav.scss" >}}
 
-On the `.nav-tabs-light` modifier class:
-
-{{< scss-docs name="nav-tabs-light-css-vars" file="scss/_nav.scss" >}}
-
 On the `.nav-pills` modifier class:
 
 {{< scss-docs name="nav-pills-css-vars" file="scss/_nav.scss" >}}
@@ -419,6 +414,12 @@ On the `.nav-pills` modifier class:
 On the `.tab-content` modifier class:
 
 {{< scss-docs name="tab-content-css-vars" file="scss/_nav.scss" >}}
+
+{{< added-in "5.3.0" >}}
+
+On the `.nav-underline` modifier class:
+
+{{< scss-docs name="nav-underline-css-vars" file="scss/_nav.scss" >}}
 
 ### Sass variables
 

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -59,8 +59,17 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
 
   - <span class="badge text-warning-emphasis bg-warning">Deprecated</span> The `.list-group-variant()` mixin is now deprecated. We now [use the Sass loop]({{< docsref "/components/list-group#sass-loop" >}}) directly to modify the component's default CSS variables for each variant.
 
-- **Progress bars**
+- **Navs and tabs**
+  - <span class="badge bg-danger">Breaking</span> Based on Bootstrap, we've replaced "Tabs light" variant by "Underline" variant. It means that `.nav-tabs-light` is deprecated and doesn't exist anymore and so that the following modification must be done in your websites:
 
+    ```diff
+    - <ul class="nav nav-tabs nav-tabs-light">
+    + <ul class="nav nav-underline">
+    ```
+
+    It also means that the "Nested tabs" variant has been slightly modified to use this new class rather than `.nav-tabs` combined to `.nav-tabs-light`.
+
+- **Progress bars**
   - The markup for [progress bars]({{< docsref "/components/progress" >}}) has been updated in v5.3.0. Due to the placement of `role` and various `aria-` attributes on the inner `.progress-bar` element, **some screen readers were not announcing zero value progress bars**. Now, `role="progressbar"` and the relevant `aria-*` attributes are on the outer `.progress` element, leaving the `.progress-bar` purely for the visual presentation of the bar and optional label.
 
     While we recommend adopting the new markup for improved compatibility with all screen readers, note that the legacy progress bar structure will continue to work as before.
@@ -243,6 +252,18 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-link-decoration</code></li>
       <li><code>--bs-link-hover-color-rgb</code></li>
       <li><code>--bs-link-hover-decoration</code></li>
+      <li><code>--bs-nav-underline-border-color</code></li>
+      <li><code>--bs-nav-underline-border-radius</code></li>
+      <li><code>--bs-nav-underline-border-width</code></li>
+      <li><code>--bs-nav-underline-gap</code></li>
+      <li><code>--bs-nav-underline-link-active-bg</code></li>
+      <li><code>--bs-nav-underline-link-active-border-color</code></li>
+      <li><code>--bs-nav-underline-link-active-color</code></li>
+      <li><code>--bs-nav-underline-link-border-width</code></li>
+      <li><code>--bs-nav-underline-link-hover-border-color</code></li>
+      <li><code>--bs-nav-underline-link-hover-bg</code></li>
+      <li><code>--bs-nav-underline-link-hover-color</code></li>
+      <li><code>--bs-nav-underline-link-padding-x</code></li>
       <li><code>--bs-offcanvas-transition</code></li>
       <li><code>--bs-primary-bg-subtle</code></li>
       <li><code>--bs-primary-border-subtle</code></li>
@@ -329,6 +350,9 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>$list-group-hover-bg</code></li>
       <li><code>$mark-bg-inverted</code></li>
       <li><code>$mark-color-inverted</code></li>
+      <li><code>$nav-underline-gap</code></li>
+      <li><code>$nav-underline-border-width</code></li>
+      <li><code>$nav-underline-link-active-color</code></li>
       <li><code>$pre-color-inverted</code></li>
       <li><code>$primary-bg-subtle-dark</code></li>
       <li><code>$primary-bg-subtle</code></li>

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -351,8 +351,15 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>$mark-bg-inverted</code></li>
       <li><code>$mark-color-inverted</code></li>
       <li><code>$nav-underline-gap</code></li>
+      <li><code>$nav-underline-border-color</code></li>
+      <li><code>$nav-underline-border-radius</code></li>
       <li><code>$nav-underline-border-width</code></li>
+      <li><code>$nav-underline-link-active-bg</code></li>
+      <li><code>$nav-underline-link-active-border-color</code></li>
       <li><code>$nav-underline-link-active-color</code></li>
+      <li><code>$nav-underline-link-border-width</code></li>
+      <li><code>$nav-underline-link-hover-color</code></li>
+      <li><code>$nav-underline-link-padding-x</code></li>
       <li><code>$pre-color-inverted</code></li>
       <li><code>$primary-bg-subtle-dark</code></li>
       <li><code>$primary-bg-subtle</code></li>

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -350,10 +350,11 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>$list-group-hover-bg</code></li>
       <li><code>$mark-bg-inverted</code></li>
       <li><code>$mark-color-inverted</code></li>
-      <li><code>$nav-underline-gap</code></li>
       <li><code>$nav-underline-border-color</code></li>
       <li><code>$nav-underline-border-radius</code></li>
       <li><code>$nav-underline-border-width</code></li>
+      <li><code>$nav-underline-gap</code></li>
+      <li><code>$nav-underline-gap-lg</code></li>
       <li><code>$nav-underline-link-active-bg</code></li>
       <li><code>$nav-underline-link-active-border-color</code></li>
       <li><code>$nav-underline-link-active-color</code></li>


### PR DESCRIPTION
The following commit coming from Bootstrap has been isolated in this PR because of the complexity of the review: https://github.com/twbs/bootstrap/commit/7d9aa9d71602ff6856c02ee9b9d2bacf2ee3d2f4.

The principle here is that "Tabs light" nav is replaced by the variant coming from Bootstrap: "Underline".

"Tabs light" were built based on `--bs-nav-tabs-*` CSS vars. Since we don't use `.nav-tabs` in combination of `.nav-underline` a big part of the content of `.nav-tabs` CSS vars and rules has been copied into `.nav-underline`. I'm not sure I can do better here, but if you have any ideas don't hesitate.

This change also implies a breaking change for the Nested Tabs second row which now uses "Underline" nav.

I wanted to redirect the URLs with anchors between v5.2 and v5.3 but that's not going to be possible.

### Live previews
- [Navs and tabs > Underline](https://deploy-preview-1829--boosted.netlify.app/docs/5.3/components/navs-tabs/#underline)
- [Navs and tabs > Nested tabs](https://deploy-preview-1829--boosted.netlify.app/docs/5.3/components/navs-tabs/#nested-tabs)
- [Navs and tabs > CSS variables](https://deploy-preview-1829--boosted.netlify.app/docs/5.3/components/navs-tabs/#variables)