### PR TITLE
Improve a11y in form example

### DIFF
--- a/site/content/docs/5.3/examples/form/form.js
+++ b/site/content/docs/5.3/examples/form/form.js
@@ -16,6 +16,16 @@
         // Focus on first error
         const invalidItems = form.querySelectorAll(':invalid')
         invalidItems[0].focus()
+        // Add the id of the corresponding invalid message to each invalid field
+        invalidItems.forEach(element => {
+          let valuesArray = [element.id + 'Label', element.id + 'Feedback'].join(' ')
+          element.setAttribute('aria-labelledby', valuesArray)
+        })
+        // Remove the id of the corresponding invalid message to each valid field
+        const validItems = form.querySelectorAll(':valid')
+        validItems.forEach(element => {
+          element.setAttribute('aria-labelledby', element.id + 'Label')
+        })
       }
 
       form.classList.add('was-validated')

--- a/site/content/docs/5.3/examples/form/index.html
+++ b/site/content/docs/5.3/examples/form/index.html
@@ -94,7 +94,7 @@ aliases:
             </div>
             <div class="col-sm-4 col-md-6 mb-3">
               <label for="selectTitle" id="selectTitleLabel" class="form-label is-required">Title</label>
-              <select class="form-select" id="selectTitle" aria-labelledby="selectTitleLabel selectTitleFeedback" autocomplete="sex" required>
+              <select class="form-select" id="selectTitle" aria-labelledby="selectTitleLabel" autocomplete="sex" required>
                 <option selected disabled value="" aria-hidden="true">Select a title</option>
                 <option value="1">Miss</option>
                 <option value="2">Mr.</option>
@@ -112,7 +112,7 @@ aliases:
             <div class="col-12">
               <div class="mb-3">
                 <label for="firstName" id="firstNameLabel" class="form-label is-required">First name</label>
-                <input type="text" class="form-control" id="firstName" aria-labelledby="firstNameLabel firstNameFeedback" autocomplete="given-name" required>
+                <input type="text" class="form-control" id="firstName" aria-labelledby="firstNameLabel" autocomplete="given-name" required>
                 <div class="valid-feedback">
                   Looks good!
                 </div>
@@ -122,7 +122,7 @@ aliases:
               </div>
               <div class="mb-3">
                 <label for="lastName" id="lastNameLabel" class="form-label is-required">Last name</label>
-                <input type="text" class="form-control" id="lastName" aria-labelledby="lastNameLabel lastNameFeedback" autocomplete="family-name" required>
+                <input type="text" class="form-control" id="lastName" aria-labelledby="lastNameLabel" autocomplete="family-name" required>
                 <div class="valid-feedback">
                   Looks good!
                 </div>
@@ -132,7 +132,7 @@ aliases:
               </div>
               <div class="mb-3">
                 <label for="email" id="emailLabel" class="form-label is-required">Email</label>
-                <input type="email" class="form-control" id="email" aria-labelledby="emailLabel emailFeedback" autocomplete="email" required>
+                <input type="email" class="form-control" id="email" aria-labelledby="emailLabel" autocomplete="email" required>
                 <div class="valid-feedback">
                   Looks good!
                 </div>
@@ -142,7 +142,7 @@ aliases:
               </div>
               <div class="mb-3">
                 <label for="country" id="countryLabel" class="form-label is-required">Country</label>
-                <select class="form-select" id="country" aria-labelledby="countryLabel countryFeedback" autocomplete="country-name" required>
+                <select class="form-select" id="country" aria-labelledby="countryLabel" autocomplete="country-name" required>
                   <option selected disabled value="" aria-hidden="true">Select a country</option>
                   <option value="1">Australia</option>
                   <option value="2">Canada</option>
@@ -158,7 +158,7 @@ aliases:
               </div>
               <div class="mb-3">
                 <label for="company" id="companyLabel" class="form-label is-required">Name of company</label>
-                <input type="text" class="form-control" id="company" aria-labelledby="companyLabel companyFeedback" required>
+                <input type="text" class="form-control" id="company" aria-labelledby="companyLabel" required>
                 <div class="valid-feedback">
                   Looks good!
                 </div>
@@ -168,7 +168,7 @@ aliases:
               </div>
               <div class="mb-3">
                 <label for="business" id="businessLabel" class="form-label is-required">Business type</label>
-                <select class="form-select" id="business" aria-labelledby="businessLabel businessFeedback" required>
+                <select class="form-select" id="business" aria-labelledby="businessLabel" required>
                   <option selected disabled value="" aria-hidden="true">Select a type</option>
                   <option value="1">Corporation</option>
                   <option value="2">Limited liability company</option>
@@ -184,7 +184,7 @@ aliases:
               </div>
               <div class="mb-3">
                 <label for="website" id="websiteLabel" class="form-label">Website</label>
-                <input type="text" class="form-control" id="website" aria-labelledby="websiteLabel websiteFeedback">
+                <input type="text" class="form-control" id="website" aria-labelledby="websiteLabel">
                 <div class="valid-feedback">
                   Looks good!
                 </div>
@@ -197,7 +197,7 @@ aliases:
                 <button type="button" class="form-helper" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Help for text area">
                   <span class="visually-hidden">Helper for text area</span>
                 </button>
-                <textarea class="form-control" id="message" rows="5" placeholder="Describe your business and your motivation in becoming an Orange reseller" aria-labelledby="messageLabel messageFeedback" required></textarea>
+                <textarea class="form-control" id="message" rows="5" placeholder="Describe your business and your motivation in becoming an Orange reseller" aria-labelledby="messageLabel" required></textarea>
                 <div class="valid-feedback">
                   Looks good!
                 </div>


### PR DESCRIPTION
### Related issues

Closes #1599 

### Description

Improve accessibility by removing the `id` of the invalid message feedback in the `aria-labelledby` attribute of each `input `and `select`.
This id is added on submit for invalid fields and remove when fields become valid.

### Motivation & Context

Improve a11y for screen reader users.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>

### Checklist

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices; I have at least run axe

#### Design

- [ ] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
- [ ] My change is compatible with responsive display

#### Development

- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is added in Storybook
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)

<!------------------------>
<!-- /!\ Core Team Only -->
<!------------------------>

<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `config.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
    - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
- [ ] if year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (eg for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] merge (on `v4-dev` or `main`)
- [ ] tag your version, and push your tag
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach zip file
  - paste CHANGELOG / Ship list in the release's description
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in NPM (with a personnal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you're releasing a pre-release, use `--tag`, eg for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch (don't forget to update Storybook as well)
  - [ ] check every `index.html` used as redirections to be redirecting to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurences
- [ ] make an announcement in Plazza :tada:
-->
