### PR TITLE
fix(docs): use `current_version` data in Getting Started > Download

### DIFF
--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -67,7 +67,7 @@ Pull in Boosted's **source files** into nearly any project with some of the most
 Install Boosted in your Node.js powered apps with [the npm package](https://www.npmjs.com/package/boosted):
 
 ```sh
-npm install boosted@v5.3.0-alpha2
+npm install boosted@{{< param "current_version" >}}
 ```
 
 `const boosted = require('boosted')` or `import boosted from 'boosted'` will load all of Boosted's plugins onto a `boosted` object.
@@ -87,7 +87,7 @@ Boosted's `package.json` contains some additional metadata under the following k
 Install Boosted in your Node.js powered apps with [the yarn package](https://yarnpkg.com/en/package/boosted):
 
 ```sh
-yarn add boosted@v5.3.0-alpha2
+yarn add boosted@{{< param "current_version" >}}
 ```
 
 ### Composer


### PR DESCRIPTION
### Description

As mentioned in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1924#discussion_r1149265079, we forgot somehow to gather a modification from Bootstrap which now use de `current_version` param in the "Getting Started > Download" page. (see https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/getting-started/download.md?plain=1)

This PR gathers this same modification.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

- https://deploy-preview-1926--boosted.netlify.app/docs/5.3/getting-started/download/#npm
- https://deploy-preview-1926--boosted.netlify.app/docs/5.3/getting-started/download/#yarn