### PR TITLE
chore(deps): bump tarteaucitronjs from 1.10.0 to 1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "sirv-cli": "^2.0.2",
         "stylelint": "^14.16.1",
         "stylelint-config-twbs-bootstrap": "^7.0.0",
-        "tarteaucitronjs": "^1.10.0",
+        "tarteaucitronjs": "^1.11.0",
         "terser": "5.16.0",
         "vnu-jar": "^22.9.29"
       },
@@ -22909,9 +22909,9 @@
       }
     },
     "node_modules/tarteaucitronjs": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.10.0.tgz",
-      "integrity": "sha512-+DcPWPA9VsoT+vGGegcxu9fFrCOdFPtvzmO1P6OXFiF8ngNG1SsCWpxn+05XY0I3B0hNaVJgkSOoGm9cZUMjKA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.11.0.tgz",
+      "integrity": "sha512-kfzrzK5fgn3NaGrLK874wf+JmEOxFsY/FAZfOhb26QAvF46f5nJDN2yQvsa5nuEiAAd/mtZ+giiz4KyONc4Ftg==",
       "dev": true
     },
     "node_modules/telejson": {
@@ -42623,9 +42623,9 @@
       }
     },
     "tarteaucitronjs": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.10.0.tgz",
-      "integrity": "sha512-+DcPWPA9VsoT+vGGegcxu9fFrCOdFPtvzmO1P6OXFiF8ngNG1SsCWpxn+05XY0I3B0hNaVJgkSOoGm9cZUMjKA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.11.0.tgz",
+      "integrity": "sha512-kfzrzK5fgn3NaGrLK874wf+JmEOxFsY/FAZfOhb26QAvF46f5nJDN2yQvsa5nuEiAAd/mtZ+giiz4KyONc4Ftg==",
       "dev": true
     },
     "telejson": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "sirv-cli": "^2.0.2",
     "stylelint": "^14.16.1",
     "stylelint-config-twbs-bootstrap": "^7.0.0",
-    "tarteaucitronjs": "^1.10.0",
+    "tarteaucitronjs": "^1.11.0",
     "terser": "5.16.0",
     "vnu-jar": "^22.9.29"
   },


### PR DESCRIPTION
### Description

New tarteaucitronjs release: https://github.com/AmauriC/tarteaucitron.js/releases/tag/v1.11.0.

Here is the complete diff: https://github.com/AmauriC/tarteaucitron.js/compare/v1.10.0...v1.11.0.

I haven't spotted any breaking changes in this comparison and the basic tests done on the deployed branch were OK. I let the reviewer double-check everything.

### Motivation & Context

Dependencies must be up-to-date!

### Types of change

- Chore (non-breaking change)

### Live previews

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>
