### PR TITLE
Forms>Validation : Add a link to "Terms and conditions" checkboxes

### DIFF
--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -135,8 +135,8 @@
   // Boosted mod: required symbol
   &:required {
     ~ .form-check-label::after {
+      margin-left: $form-label-required-margin-left;
       color: $accessible-orange;
-      // Boosted mod: no margin-left
       content: "*";
     }
   }

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -135,7 +135,6 @@
   // Boosted mod: required symbol
   &:required {
     ~ .form-check-label::after {
-      margin-left: $form-label-required-margin-left;
       color: $accessible-orange;
       content: "*";
     }

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -136,6 +136,7 @@
   &:required {
     ~ .form-check-label::after {
       color: $accessible-orange;
+      // Boosted mod: no margin-left
       content: "*";
     }
   }

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -89,10 +89,8 @@ Custom feedback styles apply custom colors, borders, focus styles, and backgroun
   <div class="col-12">
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="invalidCheck" required>
-      <label class="form-check-label" for="invalidCheck">
-        By checking this box, I agree to the
-        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a>
-      </label>
+      <!-- Keep this <label> written on one single line to avoid browsers adding an extra and unwanted space between the end of the label ("conditions") and the asterisk meaning the field is required -->
+      <label class="form-check-label" for="invalidCheck">By checking this box, I agree to the <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a></label>
       <div class="invalid-feedback">
         You must agree before submitting.
       </div>
@@ -151,10 +149,8 @@ While these feedback styles cannot be styled with CSS, you can still customize t
   <div class="col-12">
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="invalidCheck2" required>
-       <label class="form-check-label" for="invalidCheck2">
-        By checking this box, I agree to the
-        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a>
-      </label>
+      <!-- Keep this <label> written on one single line to avoid browsers adding an extra and unwanted space between the end of the label ("conditions") and the asterisk meaning the field is required -->
+      <label class="form-check-label" for="invalidCheck2">By checking this box, I agree to the <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a></label>
     </div>
   </div>
   <div class="col-12">
@@ -224,10 +220,8 @@ To fix [issues with border radius](https://github.com/twbs/bootstrap/issues/2511
   <div class="col-12">
     <div class="form-check">
       <input class="form-check-input is-invalid" type="checkbox" value="" id="invalidCheck3" aria-describedby="invalidCheck3Feedback" required>
-         <label class="form-check-label" for="invalidCheck3">
-        By checking this box, I agree to the
-        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a>
-      </label>
+      <!-- Keep this <label> written on one single line to avoid browsers adding an extra and unwanted space between the end of the label ("conditions") and the asterisk meaning the field is required -->
+      <label class="form-check-label" for="invalidCheck3">By checking this box, I agree to the <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a></label>
       <div id="invalidCheck3Feedback" class="invalid-feedback">
         You must agree before submitting.
       </div>

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -90,7 +90,7 @@ Custom feedback styles apply custom colors, borders, focus styles, and backgroun
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="invalidCheck" required>
       <label class="form-check-label" for="invalidCheck">
-        Agree to terms and conditions
+        <a href="" target="_blank">Agree to terms and conditions</a>
       </label>
       <div class="invalid-feedback">
         You must agree before submitting.
@@ -151,7 +151,7 @@ While these feedback styles cannot be styled with CSS, you can still customize t
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="invalidCheck2" required>
       <label class="form-check-label" for="invalidCheck2">
-        Agree to terms and conditions
+        <a href="" target="_blank">Agree to terms and conditions</a>
       </label>
     </div>
   </div>
@@ -223,7 +223,7 @@ To fix [issues with border radius](https://github.com/twbs/bootstrap/issues/2511
     <div class="form-check">
       <input class="form-check-input is-invalid" type="checkbox" value="" id="invalidCheck3" aria-describedby="invalidCheck3Feedback" required>
       <label class="form-check-label" for="invalidCheck3">
-        Agree to terms and conditions
+        <a href="" target="_blank">Agree to terms and conditions</a>
       </label>
       <div id="invalidCheck3Feedback" class="invalid-feedback">
         You must agree before submitting.

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -90,7 +90,7 @@ Custom feedback styles apply custom colors, borders, focus styles, and backgroun
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="invalidCheck" required>
       <label class="form-check-label" for="invalidCheck">
-        <a href="" target="_blank">Agree to terms and conditions</a>
+        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)">Agree to terms and conditions</a>
       </label>
       <div class="invalid-feedback">
         You must agree before submitting.
@@ -151,7 +151,7 @@ While these feedback styles cannot be styled with CSS, you can still customize t
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="invalidCheck2" required>
       <label class="form-check-label" for="invalidCheck2">
-        <a href="" target="_blank">Agree to terms and conditions</a>
+        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)">Agree to terms and conditions</a>
       </label>
     </div>
   </div>
@@ -223,7 +223,7 @@ To fix [issues with border radius](https://github.com/twbs/bootstrap/issues/2511
     <div class="form-check">
       <input class="form-check-input is-invalid" type="checkbox" value="" id="invalidCheck3" aria-describedby="invalidCheck3Feedback" required>
       <label class="form-check-label" for="invalidCheck3">
-        <a href="" target="_blank">Agree to terms and conditions</a>
+        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)">Agree to terms and conditions</a>
       </label>
       <div id="invalidCheck3Feedback" class="invalid-feedback">
         You must agree before submitting.

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -90,7 +90,8 @@ Custom feedback styles apply custom colors, borders, focus styles, and backgroun
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="invalidCheck" required>
       <label class="form-check-label" for="invalidCheck">
-        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)">Agree to terms and conditions</a>
+        By checking this box, I agree to the
+        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a>
       </label>
       <div class="invalid-feedback">
         You must agree before submitting.
@@ -150,8 +151,9 @@ While these feedback styles cannot be styled with CSS, you can still customize t
   <div class="col-12">
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="invalidCheck2" required>
-      <label class="form-check-label" for="invalidCheck2">
-        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)">Agree to terms and conditions</a>
+       <label class="form-check-label" for="invalidCheck2">
+        By checking this box, I agree to the
+        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a>
       </label>
     </div>
   </div>
@@ -222,8 +224,9 @@ To fix [issues with border radius](https://github.com/twbs/bootstrap/issues/2511
   <div class="col-12">
     <div class="form-check">
       <input class="form-check-input is-invalid" type="checkbox" value="" id="invalidCheck3" aria-describedby="invalidCheck3Feedback" required>
-      <label class="form-check-label" for="invalidCheck3">
-        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)">Agree to terms and conditions</a>
+         <label class="form-check-label" for="invalidCheck3">
+        By checking this box, I agree to the
+        <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a>
       </label>
       <div id="invalidCheck3Feedback" class="invalid-feedback">
         You must agree before submitting.

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -90,7 +90,7 @@ Custom feedback styles apply custom colors, borders, focus styles, and backgroun
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="invalidCheck" required>
       <!-- Keep this <label> written on one single line to avoid browsers adding an extra and unwanted space between the end of the label ("conditions") and the asterisk meaning the field is required -->
-      <label class="form-check-label" for="invalidCheck">By checking this box, I agree to the <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a></label>
+      <label class="form-check-label" for="invalidCheck">By checking this box, I agree to the <a href="" target="_blank" aria-label="Terms and conditions (opens new window)">terms and conditions</a></label>
       <div class="invalid-feedback">
         You must agree before submitting.
       </div>
@@ -150,7 +150,7 @@ While these feedback styles cannot be styled with CSS, you can still customize t
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="invalidCheck2" required>
       <!-- Keep this <label> written on one single line to avoid browsers adding an extra and unwanted space between the end of the label ("conditions") and the asterisk meaning the field is required -->
-      <label class="form-check-label" for="invalidCheck2">By checking this box, I agree to the <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a></label>
+      <label class="form-check-label" for="invalidCheck2">By checking this box, I agree to the <a href="" target="_blank" aria-label="Terms and conditions (opens new window)">terms and conditions</a></label>
     </div>
   </div>
   <div class="col-12">
@@ -221,7 +221,7 @@ To fix [issues with border radius](https://github.com/twbs/bootstrap/issues/2511
     <div class="form-check">
       <input class="form-check-input is-invalid" type="checkbox" value="" id="invalidCheck3" aria-describedby="invalidCheck3Feedback" required>
       <!-- Keep this <label> written on one single line to avoid browsers adding an extra and unwanted space between the end of the label ("conditions") and the asterisk meaning the field is required -->
-      <label class="form-check-label" for="invalidCheck3">By checking this box, I agree to the <a href="" target="_blank" aria-label="Terms and conditions (opens new window)"> terms and conditions</a></label>
+      <label class="form-check-label" for="invalidCheck3">By checking this box, I agree to the <a href="" target="_blank" aria-label="Terms and conditions (opens new window)">terms and conditions</a></label>
       <div id="invalidCheck3Feedback" class="invalid-feedback">
         You must agree before submitting.
       </div>


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_
 
 ### Related issues
 
 [#1715](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/1715)
 
 ### Description
 
 Designers said that the checkbox label "Agree Terms and Conditions" should be a link towards a "Terms and Conditions" page that the user is supposed to read before checking the box.
 
 As no design specification is available yet, a design review is to be asked.
 
 ### Motivation & Context
 
 This changed was required by designers.
 
 ### Types of change
 
 - New feature (non-breaking change which adds functionality)
 
 ### Live previews
 
 - <https://deploy-preview-2002--boosted.netlify.app/docs/5.3/forms/validation/#custom-styles>
 
 ### Checklist
 
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 
 #### Contribution
 
 - [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
 
 #### Accessibility
 
 - [ ] My change follows accessibility good practices; I have at least run axe
 
 #### Design
 
 - [x] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
 - [x] My change is compatible with responsive display
 
 #### Development
 
 - [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
 - [ ] I have added JavaScript unit tests to cover my changes
 - [ ] I have added SCSS unit tests to cover my changes
 
 #### Documentation
 
 - [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly
 
 ### Checklist (for Core Team only)
 
 - [ ] My change introduces changes to the migration guide
 - [ ] My new component is added in Storybook
 - [ ] My new component is compatible with RTL
 - [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
 - [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
 - [ ] Code review
 - [ ] Design review
 - [ ] A11y review
 
 #### After the merge
 
 - [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)
 
 <!------------------------>
 <!-- /!\ Core Team Only -->
 <!------------------------>
 
 <!-- Uncomment the following for a release DoD -->
 
 <!--
 - [ ] Run linters;
 - [ ] Run compilers;
 - [ ] Run tests;
 - [ ] Check documentation site: examples and contents;
 - [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
 - Firefox ESR
 - IE11 (v4 only)
 - Latest Edge, Chrome, Firefox, Safari
 - iOS Safari
 - Chrome & Firefox on Android
 - [ ] Including RTL mode;
 - [ ] Ask for reviews and accessibility testing;
 - [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
 - [ ] `npm run release-version $current_version $next_version` to bump version number
 - then, if bumping a minor or major version:
 - [ ] Manually change `version_short` in `package.json`
 - [ ] Add docs version to `site/data/docs-versions.yml`
 - [ ] Manually change `docs_version` in `config.yml` and other references to the previous version
 - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
 - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
 - [ ] Increment `site/static/docs/{version}` version
 - [ ] Increment version in `nuget/boosted.nuspec`
 - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
 - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
 - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
 - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
 - [ ] if year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities and main file) as well as in `NOTICE.txt`.
 - [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc and package the release
 - [ ] Prepare changelog:
 - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
 - run `conventional-changelog -p angular -i CHANGELOG.md -s`
 - and probably maintain [a ship list (eg for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
 - [ ] commit and push `dist` with a `chore(release)` commit message
 - [ ] Manually run BrowserStack test
 - [ ] Manually run Percy test
 - [ ] merge (on `v4-dev` or `main`)
 - [ ] tag your version, and push your tag
 - [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
 - attach zip file
 - paste CHANGELOG / Ship list in the release's description
 - [ ] Pack and publish
 - `npm pack`
 - if you are already logged in NPM (with a personnal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
 - Publish:
 - if you're releasing a pre-release, use `--tag`, eg for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
 - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
 - (v5 only) `npm publish`
 - [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
 - [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
 - [ ] publish documentation on `gh-pages`:
 - [ ] copy `../_site` to the `gh-pages` branch (don't forget to update Storybook as well)
 - [ ] check every `index.html` used as redirections to be redirecting to the new release
 - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
 - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurences
 - [ ] make an announcement in Plazza :tada:
 -->
