### PR TITLE
chore(deps): bump tarteaucitronjs from 1.11.0 to 1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "sirv-cli": "^2.0.2",
         "stylelint": "^15.6.2",
         "stylelint-config-twbs-bootstrap": "^10.0.0",
-        "tarteaucitronjs": "^1.11.0",
+        "tarteaucitronjs": "^1.12.0",
         "terser": "5.16.0",
         "vnu-jar": "^23.4.11"
       },
@@ -23176,9 +23176,9 @@
       }
     },
     "node_modules/tarteaucitronjs": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.11.0.tgz",
-      "integrity": "sha512-kfzrzK5fgn3NaGrLK874wf+JmEOxFsY/FAZfOhb26QAvF46f5nJDN2yQvsa5nuEiAAd/mtZ+giiz4KyONc4Ftg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.12.0.tgz",
+      "integrity": "sha512-iS+gxawPM8rS+6irOR4BCuTVaXU7eLb0bvm/CTkisj98eraaFlUMUktKFu4yL1kn/tY1lYmcz97hL6MmSBLOlw==",
       "dev": true
     },
     "node_modules/telejson": {
@@ -43035,9 +43035,9 @@
       }
     },
     "tarteaucitronjs": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.11.0.tgz",
-      "integrity": "sha512-kfzrzK5fgn3NaGrLK874wf+JmEOxFsY/FAZfOhb26QAvF46f5nJDN2yQvsa5nuEiAAd/mtZ+giiz4KyONc4Ftg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.12.0.tgz",
+      "integrity": "sha512-iS+gxawPM8rS+6irOR4BCuTVaXU7eLb0bvm/CTkisj98eraaFlUMUktKFu4yL1kn/tY1lYmcz97hL6MmSBLOlw==",
       "dev": true
     },
     "telejson": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "sirv-cli": "^2.0.2",
     "stylelint": "^15.6.2",
     "stylelint-config-twbs-bootstrap": "^10.0.0",
-    "tarteaucitronjs": "^1.11.0",
+    "tarteaucitronjs": "^1.12.0",
     "terser": "5.16.0",
     "vnu-jar": "^23.4.11"
   },


### PR DESCRIPTION
This PR bumps tarteaucitronjs dependency from 1.11.0 to 1.12.0.
 
 The [content of this new release](https://github.com/AmauriC/tarteaucitron.js/compare/v1.11.0...v1.12.0) seems to be transparent for us.
 
 Please double-check there's no regression.
 
 ## [Live preview](https://deploy-preview-2061--boosted.netlify.app/)