### PR TITLE
chore(deps): fix coverallsapp/github-action to v2

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm run js-test
 
       - name: Run Coveralls
-        uses: coverallsapp/github-action@v2.1.2
+        uses: coverallsapp/github-action@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           path-to-lcov: "./js/coverage/lcov.info"


### PR DESCRIPTION
Supersedes #2082 by fixing the version to v2 like it is done upstream: https://github.com/twbs/bootstrap/blob/bb92ec707aa607fa4a43f49e75d69ebd67132e2e/.github/workflows/js.yml#L48