### PR TITLE
Fix quantity selector focus state

### DIFF
--- a/js/src/quantity-selector.js
+++ b/js/src/quantity-selector.js
@@ -26,7 +26,7 @@ const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 const SELECTOR_STEP_UP_BUTTON = '[data-bs-step="up"]'
 const SELECTOR_STEP_DOWN_BUTTON = '[data-bs-step="down"]'
 const SELECTOR_COUNTER_INPUT = '[data-bs-step="counter"]'
-const SELECTOR_QUANTITY_SELECTOR = '.input-group.quantity-selector'
+const SELECTOR_QUANTITY_SELECTOR = '.quantity-selector'
 
 /**
  * Class definition

--- a/js/tests/unit/quantity-selector.spec.js
+++ b/js/tests/unit/quantity-selector.spec.js
@@ -81,7 +81,7 @@ describe('QuantitySelector', () => {
 
   it('should take care of element either passed as a CSS selector or DOM element (Step Up button)', () => {
     fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
+      '<div class="quantity-selector">',
       '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
@@ -102,7 +102,7 @@ describe('QuantitySelector', () => {
 
   it('should take care of element either passed as a CSS selector or DOM element (Step Down button)', () => {
     fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
+      '<div class="quantity-selector">',
       '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
@@ -123,7 +123,7 @@ describe('QuantitySelector', () => {
 
   it('should increment by one step on click on Step Up button', () => {
     fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
+      '<div class="quantity-selector">',
       '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="9" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
@@ -150,7 +150,7 @@ describe('QuantitySelector', () => {
 
   it('should decrement by one step on click on Step Down button', () => {
     fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
+      '<div class="quantity-selector">',
       '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
@@ -177,7 +177,7 @@ describe('QuantitySelector', () => {
 
   it('should increment a decimal value by 0.5 step on click on Step Up button and round it', () => {
     fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
+      '<div class="quantity-selector">',
       '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1.25" min="0" max="10" step="0.5" data-bs-round="1" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
@@ -200,7 +200,7 @@ describe('QuantitySelector', () => {
 
   it('should decrement a decimal value by 1 step on click on Step Down button but not resulting as a negative value', () => {
     fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
+      '<div class="quantity-selector">',
       '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="1.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
@@ -225,7 +225,7 @@ describe('QuantitySelector', () => {
 
   it('should increment a decimal value by 1 step on click on Step Up button but not resulting as a negative value', () => {
     fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
+      '<div class="quantity-selector">',
       '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="8.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
@@ -250,7 +250,7 @@ describe('QuantitySelector', () => {
 
   it('should disable click on Step Down button on load to prevent a value out of range', done => {
     fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
+      '<div class="quantity-selector">',
       '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',
@@ -278,7 +278,7 @@ describe('QuantitySelector', () => {
 
   it('should disable click on Step Up button on load to prevent a value out of range', done => {
     fixtureEl.innerHTML = [
-      '<div class="input-group quantity-selector">',
+      '<div class="quantity-selector">',
       '  <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="9.5" min="0" max="10" step="1" data-bs-round="1" aria-label="Quantity selector">',
       '  <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">',
       '    <span class="visually-hidden">Step down</span>',

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -2354,7 +2354,7 @@ $sticker-content-max-width-lg:          $sticker-size-lg * .7071067812 !default;
 //// Quantity selector
 // scss-docs-start quantity-selector
 $quantity-selector-width:                 7.5rem !default;
-$quantity-selector-sm-width:              5.5rem !default;
+$quantity-selector-sm-width:              5.625rem !default;
 
 $quantity-selector-btn-padding-x:         add($btn-icon-padding-x, 2px) !default;
 $quantity-selector-btn-padding-x-sm:      add($btn-icon-padding-x-sm, 2px) !default;
@@ -2372,8 +2372,8 @@ $quantity-selector-icon-remove-sm:        $remove-icon-sm !default;
 $quantity-selector-icon-remove-height:    .125rem !default;
 $quantity-selector-icon-sm-remove-height: .125rem !default;
 
-$quantity-selector-input-max-width:       2.625rem !default;
-$quantity-selector-input-sm-max-width:    2.5rem !default;
+$quantity-selector-input-max-width:       2.5rem !default;
+$quantity-selector-input-sm-max-width:    1.875rem !default;
 // scss-docs-end quantity-selector
 
 //// Footer

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -6,8 +6,8 @@
   .form-control {
     max-width: $quantity-selector-input-max-width;
     // Add 20% security padding so the input's text isn't clipped when focused
-    padding-right: calc($input-padding-x * .8); // stylelint-disable-line function-disallowed-list
-    padding-left: calc($input-padding-x * .8); // stylelint-disable-line function-disallowed-list
+    padding-right: calc(#{$input-padding-x} * .8); // stylelint-disable-line function-disallowed-list
+    padding-left: calc(#{$input-padding-x} * .8); // stylelint-disable-line function-disallowed-list
     text-align: center;
     @include transition(none);
     appearance: textfield;

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -36,6 +36,10 @@
         border-right: none;
       }
 
+      &:focus-visible {
+        margin-right: calc(#{$input-border-width} * -1); // stylelint-disable-line function-disallowed-list
+      }
+
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
         @include button-icon($quantity-selector-icon-remove-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-remove-height, $pseudo: "after");
         padding-right: $quantity-selector-btn-padding-x-sm;
@@ -48,6 +52,11 @@
 
       &:not(:focus-visible) {
         border-left: none;
+      }
+
+      &:focus-visible {
+        // stylelint-disable-next-line declaration-no-important
+        margin-left: calc(#{$input-border-width} * -2) !important; // stylelint-disable-line function-disallowed-list
       }
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -1,5 +1,6 @@
 .quantity-selector {
   display: flex;
+  flex-wrap: wrap;
   width: $quantity-selector-width;
 
   .form-control {

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -31,13 +31,13 @@
       @include button-icon($quantity-selector-icon-remove, $size: $quantity-selector-icon-width $quantity-selector-icon-remove-height, $pseudo: "after");
       order: -1;
       padding-right: $quantity-selector-btn-padding-x;
+      border-right: none;
 
-      &:not(:focus-visible) {
-        border-right: none;
-      }
-
-      &:focus-visible {
-        margin-right: calc(#{$input-border-width} * -1); // stylelint-disable-line function-disallowed-list
+      &:focus {
+        &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
+          margin-right: calc(#{$input-border-width} * -1); // stylelint-disable-line function-disallowed-list
+          border-right: var(--#{$prefix}border-width) solid $gray-500;
+        }
       }
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
@@ -49,14 +49,14 @@
     &:last-of-type {
       @include button-icon($quantity-selector-icon-add, $size: $quantity-selector-icon-width $quantity-selector-icon-add-height, $pseudo: "after");
       padding-left: $quantity-selector-btn-padding-x;
+      border-left: none;
 
-      &:not(:focus-visible) {
-        border-left: none;
-      }
-
-      &:focus-visible {
-        // stylelint-disable-next-line declaration-no-important
-        margin-left: calc(#{$input-border-width} * -2) !important; // stylelint-disable-line function-disallowed-list
+      &:focus {
+        &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
+          // stylelint-disable-next-line declaration-no-important
+          margin-left: calc(#{$input-border-width} * -2) !important; // stylelint-disable-line function-disallowed-list
+          border-left: var(--#{$prefix}border-width) solid $gray-500;
+        }
       }
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -25,6 +25,7 @@
   }
 
   button {
+    margin-left: 0 !important; // stylelint-disable-line declaration-no-important
     border: var(--#{$prefix}border-width) solid $gray-500;
 
     &:first-of-type {

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -35,6 +35,7 @@
 
       &:focus {
         &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
+          padding-right: calc($quantity-selector-btn-padding-x - var(--#{$prefix}border-width)); // stylelint-disable-line function-disallowed-list
           margin-right: calc(#{$input-border-width} * -1); // stylelint-disable-line function-disallowed-list
           border-right-width: var(--#{$prefix}border-width);
         }
@@ -53,6 +54,7 @@
 
       &:focus {
         &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
+          padding-left: calc($quantity-selector-btn-padding-x - var(--#{$prefix}border-width)); // stylelint-disable-line function-disallowed-list
           // stylelint-disable-next-line declaration-no-important
           margin-left: calc(#{$input-border-width} * -2) !important; // stylelint-disable-line function-disallowed-list
           border-left-width: var(--#{$prefix}border-width);

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -5,6 +5,9 @@
 
   .form-control {
     max-width: $quantity-selector-input-max-width;
+    // Add 20% security padding so the input's text isn't clipped when focused
+    padding-right: calc($input-padding-x * .8); // stylelint-disable-line function-disallowed-list
+    padding-left: calc($input-padding-x * .8); // stylelint-disable-line function-disallowed-list
     text-align: center;
     @include transition(none);
     appearance: textfield;

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -31,12 +31,12 @@
       @include button-icon($quantity-selector-icon-remove, $size: $quantity-selector-icon-width $quantity-selector-icon-remove-height, $pseudo: "after");
       order: -1;
       padding-right: $quantity-selector-btn-padding-x;
-      border-right: none;
+      border-right-width: 0;
 
       &:focus {
         &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
           margin-right: calc(#{$input-border-width} * -1); // stylelint-disable-line function-disallowed-list
-          border-right: var(--#{$prefix}border-width) solid $gray-500;
+          border-right-width: var(--#{$prefix}border-width);
         }
       }
 
@@ -49,13 +49,13 @@
     &:last-of-type {
       @include button-icon($quantity-selector-icon-add, $size: $quantity-selector-icon-width $quantity-selector-icon-add-height, $pseudo: "after");
       padding-left: $quantity-selector-btn-padding-x;
-      border-left: none;
+      border-left-width: 0;
 
       &:focus {
         &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
           // stylelint-disable-next-line declaration-no-important
           margin-left: calc(#{$input-border-width} * -2) !important; // stylelint-disable-line function-disallowed-list
-          border-left: var(--#{$prefix}border-width) solid $gray-500;
+          border-left-width: var(--#{$prefix}border-width);
         }
       }
 

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -36,7 +36,6 @@
       &:focus {
         &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
           padding-right: calc(#{$quantity-selector-btn-padding-x} - var(--#{$prefix}border-width)); // stylelint-disable-line function-disallowed-list
-          margin-right: calc(#{$input-border-width} * -1); // stylelint-disable-line function-disallowed-list
           border-right-width: var(--#{$prefix}border-width);
         }
       }
@@ -55,8 +54,6 @@
       &:focus {
         &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
           padding-left: calc(#{$quantity-selector-btn-padding-x} - var(--#{$prefix}border-width)); // stylelint-disable-line function-disallowed-list
-          // stylelint-disable-next-line declaration-no-important
-          margin-left: calc(#{$input-border-width} * -2) !important; // stylelint-disable-line function-disallowed-list
           border-left-width: var(--#{$prefix}border-width);
         }
       }

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -35,7 +35,7 @@
 
       &:focus {
         &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
-          padding-right: calc(#{$quantity-selector-btn-padding-x} - var(--#{$prefix}border-width)); // stylelint-disable-line function-disallowed-list
+          padding-right: subtract(#{$quantity-selector-btn-padding-x}, var(--#{$prefix}border-width));
           border-right-width: var(--#{$prefix}border-width);
         }
       }
@@ -53,7 +53,7 @@
 
       &:focus {
         &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
-          padding-left: calc(#{$quantity-selector-btn-padding-x} - var(--#{$prefix}border-width)); // stylelint-disable-line function-disallowed-list
+          padding-left: subtract(#{$quantity-selector-btn-padding-x}, var(--#{$prefix}border-width));
           border-left-width: var(--#{$prefix}border-width);
         }
       }

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -1,4 +1,5 @@
 .quantity-selector {
+  display: flex;
   width: $quantity-selector-width;
 
   .form-control {
@@ -25,7 +26,6 @@
   }
 
   button {
-    margin-left: 0 !important; // stylelint-disable-line declaration-no-important
     border: var(--#{$prefix}border-width) solid $gray-500;
 
     &:first-of-type {

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -31,7 +31,10 @@
       @include button-icon($quantity-selector-icon-remove, $size: $quantity-selector-icon-width $quantity-selector-icon-remove-height, $pseudo: "after");
       order: -1;
       padding-right: $quantity-selector-btn-padding-x;
-      border-right: none;
+
+      &:not(:focus-visible) {
+        border-right: none;
+      }
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
         @include button-icon($quantity-selector-icon-remove-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-remove-height, $pseudo: "after");
@@ -42,7 +45,10 @@
     &:last-of-type {
       @include button-icon($quantity-selector-icon-add, $size: $quantity-selector-icon-width $quantity-selector-icon-add-height, $pseudo: "after");
       padding-left: $quantity-selector-btn-padding-x;
-      border-left: none;
+
+      &:not(:focus-visible) {
+        border-left: none;
+      }
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
         @include button-icon($quantity-selector-icon-add-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-add-height, $pseudo: "after");

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -43,6 +43,12 @@
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
         @include button-icon($quantity-selector-icon-remove-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-remove-height, $pseudo: "after");
         padding-right: $quantity-selector-btn-padding-x-sm;
+
+        &:focus {
+          &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
+            padding-right: subtract(#{$quantity-selector-btn-padding-x-sm}, var(--#{$prefix}border-width));
+          }
+        }
       }
     }
 
@@ -61,6 +67,12 @@
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
         @include button-icon($quantity-selector-icon-add-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-add-height, $pseudo: "after");
         padding-left: $quantity-selector-btn-padding-x-sm;
+
+        &:focus {
+          &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
+            padding-left: subtract(#{$quantity-selector-btn-padding-x-sm}, var(--#{$prefix}border-width));
+          }
+        }
       }
     }
   }

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -35,7 +35,7 @@
 
       &:focus {
         &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
-          padding-right: calc($quantity-selector-btn-padding-x - var(--#{$prefix}border-width)); // stylelint-disable-line function-disallowed-list
+          padding-right: calc(#{$quantity-selector-btn-padding-x} - var(--#{$prefix}border-width)); // stylelint-disable-line function-disallowed-list
           margin-right: calc(#{$input-border-width} * -1); // stylelint-disable-line function-disallowed-list
           border-right-width: var(--#{$prefix}border-width);
         }
@@ -54,7 +54,7 @@
 
       &:focus {
         &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
-          padding-left: calc($quantity-selector-btn-padding-x - var(--#{$prefix}border-width)); // stylelint-disable-line function-disallowed-list
+          padding-left: calc(#{$quantity-selector-btn-padding-x} - var(--#{$prefix}border-width)); // stylelint-disable-line function-disallowed-list
           // stylelint-disable-next-line declaration-no-important
           margin-left: calc(#{$input-border-width} * -2) !important; // stylelint-disable-line function-disallowed-list
           border-left-width: var(--#{$prefix}border-width);

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -105,13 +105,13 @@
       }
     }
 
-    // Boosted mod: Remove border on input for form element QuantitySelector
+    // Boosted mod: Change border-color when on error for form element QuantitySelector
     .quantity-selector .form-control {
       @include form-validation-state-selector($state) {
 
         // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
         & ~ button {
-          border-color: $border-color !important; // stylelint-disable-line declaration-no-important
+          border-color: $border-color;
         }
       }
     }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -108,7 +108,6 @@
     // Boosted mod: Change border-color when on error for form element QuantitySelector
     .quantity-selector .form-control {
       @include form-validation-state-selector($state) {
-
         // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
         & ~ button {
           border-color: $border-color;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -108,8 +108,6 @@
     // Boosted mod: Remove border on input for form element QuantitySelector
     .quantity-selector .form-control {
       @include form-validation-state-selector($state) {
-        border-right: none;
-        border-left: none;
 
         // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
         & ~ button {

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -111,7 +111,7 @@
 
         // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
         & ~ button {
-          border-color: $border-color;
+          border-color: $border-color !important; // stylelint-disable-line declaration-no-important
         }
       }
     }

--- a/site/content/docs/5.3/forms/quantity-selector.md
+++ b/site/content/docs/5.3/forms/quantity-selector.md
@@ -22,7 +22,7 @@ Value will vary between the values defined for the `min` and `max` attributes (n
 `step` attribute is also customizable and define the interval between values.
 
 {{< example >}}
-<div class="input-group quantity-selector">
+<div class="quantity-selector">
   <input type="number" id="inputQuantitySelector" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
   <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector" data-bs-step="down">
     <span class="visually-hidden">Step down</span>
@@ -38,7 +38,7 @@ Value will vary between the values defined for the `min` and `max` attributes (n
 Set small size using the contextual class `.quantity-selector-sm`.
 
 {{< example >}}
-<div class="input-group quantity-selector quantity-selector-sm">
+<div class="quantity-selector quantity-selector-sm">
   <input type="number" id="inputQuantitySelectorSm" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
   <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelectorSm" data-bs-step="down">
     <span class="visually-hidden">Step down</span>
@@ -54,7 +54,7 @@ Set small size using the contextual class `.quantity-selector-sm`.
 Add the `disabled` boolean attribute on quantity selector elements to give it a grayed out appearance and remove pointer events.
 
 {{< example >}}
-<div class="input-group quantity-selector">
+<div class="quantity-selector">
   <input type="number" id="inputQuantitySelectorDisabled" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector" disabled>
   <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelectorDisabled" data-bs-step="down" disabled>
     <span class="visually-hidden">Step down</span>

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -284,7 +284,7 @@ Validation styles are available for the following form controls and components:
 
   <div class="mb-3">
     <label for="inputQuantitySelector" class="form-label">Quantity selector</label>
-    <div class="input-group quantity-selector w-100">
+    <div class="quantity-selector w-100">
       <input type="number" id="inputQuantitySelector" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="11" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
       <button type="button" class="btn btn-icon btn-secondary" aria-describedby="inputQuantitySelector" data-bs-step="down">
         <span class="visually-hidden">Step down</span>

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -297,6 +297,19 @@ Validation styles are available for the following form controls and components:
   </div>
 
   <div class="mb-3">
+    <label for="inputQuantitySelector" class="form-label">Quantity selector</label>
+    <div class="quantity-selector quantity-selector-sm">
+      <input type="number" id="inputQuantitySelectorSm" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="11" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
+      <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelectorSm" data-bs-step="down">
+        <span class="visually-hidden">Step down</span>
+      </button>
+      <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelectorSm" data-bs-step="up">
+        <span class="visually-hidden">Step up</span>
+      </button>
+    </div>
+  </div>
+
+  <div class="mb-3">
     <button class="btn btn-primary mt-2" type="submit" disabled>Submit form</button>
   </div>
 </form>

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -297,19 +297,6 @@ Validation styles are available for the following form controls and components:
   </div>
 
   <div class="mb-3">
-    <label for="inputQuantitySelector" class="form-label">Quantity selector</label>
-    <div class="quantity-selector quantity-selector-sm">
-      <input type="number" id="inputQuantitySelectorSm" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="11" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
-      <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelectorSm" data-bs-step="down">
-        <span class="visually-hidden">Step down</span>
-      </button>
-      <button type="button" class="btn btn-icon btn-secondary btn-sm" aria-describedby="inputQuantitySelectorSm" data-bs-step="up">
-        <span class="visually-hidden">Step up</span>
-      </button>
-    </div>
-  </div>
-
-  <div class="mb-3">
     <button class="btn btn-primary mt-2" type="submit" disabled>Submit form</button>
   </div>
 </form>

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -27,6 +27,10 @@ If you need more details about the changes, please refer to the [v5.3.3 release]
   - <span class="badge text-bg-success">New</span> List group with badges has been added to Orange Design System specifications and can now be used in your websites.
   - <span class="badge text-bg-warning">Warning</span> List group font weight is now bold by default. Please check that it doesn't break your design.
 
+### Forms
+
+- <span class="badge text-bg-warning">Warning</span> Quantity selector has been updated to ensure a proper visible focus state and the `.input-group` class has been removed. Make sure to incorporate these changes into your websites.
+
 ### CSS and Sass variables
 
 - <details class="mb-2">


### PR DESCRIPTION
### Related issues
 
 Coming from the separation of old #1949 PR into two distinct, more comprehensible and easier to review/maintain PR.
 This PR is coming alongside with the work on the insufficient contrast in form error state (PR #2090) and was needed after the suggestions made by our design team during Spec meeting - June, 13.
 
 ### Description
 
 When on error and focused, we must keep the wole borders for the input in the middle and for the buttons.
 So we must go from this:
 ![old](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/92363071/afc61ae0-5e40-4e04-9a9c-0b6634734981)
 
 to this:
 ![new](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/92363071/873079d3-15b1-44ee-a6da-89b44ae88392)
 
 (same for buttons)
 
 ### Motivation & Context
 
 Improve a11y and design unity.
 
 ### Types of change
 
 - New feature (non-breaking change which adds functionality)
 
 ### Live previews
 
 - <https://deploy-preview-2099--boosted.netlify.app/docs/5.3/forms/quantity-selector/>
  - <https://deploy-preview-2099--boosted.netlify.app/docs/5.3/forms/validation/#supported-elements>
  
### Checklist
 
 #### Contribution
 
 - [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
 
 #### Accessibility
 
 - [x] My change follows accessibility good practices; I have at least run axe
 
 #### Design
 
 - [x] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
 - [x] My change is compatible with responsive display
 
 #### Development
 
 - [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- (NA) I have added JavaScript unit tests to cover my changes
- (NA) I have added SCSS unit tests to cover my changes
 
 #### Documentation
 
- (NA) My change introduces changes to the documentation and/or I have updated the documentation accordingly
 
 ### Checklist (for Core Team only)
 
 - (NA) My change introduces changes to the migration guide
 - (NA) My new component is added in Storybook
 - (NA) My new component is compatible with RTL
 - [x] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
 - [x] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
 - [x] Code review
 - [x] Design review
 - [x] A11y review
 
 #### After the merge
 
 - [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)
 
 <!------------------------>
 <!-- /!\ Core Team Only -->
 <!------------------------>
 
 <!-- Uncomment the following for a release DoD -->
 
 <!--
 - [ ] Run linters;
 - [ ] Run compilers;
 - [ ] Run tests;
 - [ ] Check documentation site: examples and contents;
 - [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
 - Firefox ESR
 - IE11 (v4 only)
 - Latest Edge, Chrome, Firefox, Safari
 - iOS Safari
 - Chrome & Firefox on Android
 - [ ] Including RTL mode;
 - [ ] Ask for reviews and accessibility testing;
 - [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
 - [ ] `npm run release-version $current_version $next_version` to bump version number
 - then, if bumping a minor or major version:
 - [ ] Manually change `version_short` in `package.json`
 - [ ] Add docs version to `site/data/docs-versions.yml`
 - [ ] Manually change `docs_version` in `hugo.yml` and other references to the previous version
 - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
 - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
 - [ ] Increment `site/static/docs/{version}` version
 - [ ] Increment version in `nuget/boosted.nuspec`
 - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
 - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
 - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
 - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
 - [ ] if year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities and main file) as well as in `NOTICE.txt`.
 - [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc and package the release
 - [ ] Prepare changelog:
 - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
 - run `conventional-changelog -p angular -i CHANGELOG.md -s`
 - and probably maintain [a ship list (eg for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
 - [ ] commit and push `dist` with a `chore(release)` commit message
 - [ ] Manually run BrowserStack test
 - [ ] Manually run Percy test
 - [ ] merge (on `v4-dev` or `main`)
 - [ ] tag your version, and push your tag
 - [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
 - attach zip file
 - paste CHANGELOG / Ship list in the release's description
 - [ ] Pack and publish
 - `npm pack`
 - if you are already logged in NPM (with a personnal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
 - Publish:
 - if you're releasing a pre-release, use `--tag`, eg for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
 - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
 - (v5 only) `npm publish`
 - [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
 - [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
 - [ ] publish documentation on `gh-pages`:
 - [ ] copy `../_site` to the `gh-pages` branch (don't forget to update Storybook as well)
 - [ ] check every `index.html` used as redirections to be redirecting to the new release
 - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
 - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurences
 - [ ] make an announcement in Plazza :tada:
 -->
