### PR TITLE
 Workflows: Add automation for github project to pass a PR being reviewed directly in good column

### DIFF
--- a/.github/workflows/update-pr-review-in-progress.yml
+++ b/.github/workflows/update-pr-review-in-progress.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   move_card_to_dev_review_in_progress:
-    if: github.event.pull_request.draft == false && github.event.review.state != 'approved' && github.event.review.user != 'julien-deramond' && github.event.review.user != 'Aniort'
+    if: github.event.pull_request.draft == false && github.event.review.state != 'approved' && github.event.review.user != ${{ vars.LEAD_DEV_GH_USERNAME }} && github.event.review.user != ${{ vars.A11Y_REVIEWER_GH_USERNAME }}
     runs-on: ubuntu-latest
     steps:
       - name: Get Project Data
@@ -14,8 +14,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BOOSTED_MOD_PERSONAL_TOKEN_CLASSIC }}
           ORGANIZATION: ${{ github.repository_owner }}
           PR_ID: ${{ github.event.pull_request.node_id }}
-          PROJECT_NUMBER: 12
-          PROJECT_TARGET_COL: "Dev Review In Progress"
+          PROJECT_NUMBER: ${{ vars.PR_BOARD_PROJECT_NUMBER }}
+          PROJECT_TARGET_COL: ${{ vars.PR_BOARD_DEV_REVIEW_IN_PROGRESS_COL_NAME }}
         run: |
           gh api graphql -f query='
             query($org: String!, $number: Int!) {

--- a/.github/workflows/update-pr-review-in-progress.yml
+++ b/.github/workflows/update-pr-review-in-progress.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   move_card_to_dev_review_in_progress:
-    if: github.event.review.state != 'approved' && github.event.review.user != 'julien-deramond' && github.event.review.user != 'Aniort'
+    if: github.event.pull_request.draft == false && github.event.review.state != 'approved' && github.event.review.user != 'julien-deramond' && github.event.review.user != 'Aniort'
     runs-on: ubuntu-latest
     steps:
       - name: Get Project Data

--- a/.github/workflows/update-pr-review-in-progress.yml
+++ b/.github/workflows/update-pr-review-in-progress.yml
@@ -1,0 +1,85 @@
+name: Dev review in progress move PR in the right column
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  project-move-card:
+    if: github.event.review.state != 'approved' && github.event.review.user != 'julien-deramond' && github.event.review.user != 'Aniort'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Project Data
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOOSTED_MOD_PERSONAL_TOKEN_CLASSIC }}
+          ORGANIZATION: ${{ github.repository_owner }}
+          PR_ID: ${{ github.event.pull_request.node_id }}
+          PROJECT_NUMBER: 12
+          PROJECT_TARGET_COL: "Dev Review In Progress"
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectV2(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                  items(first:20) {
+                    nodes {
+                      id
+                      content {
+                        ... on PullRequest {
+                          id
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+
+          # echo `cat project_data.json`
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'TARGET_COL_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="${{ env.PROJECT_TARGET_COL }}") |.id' project_data.json) >> $GITHUB_ENV
+          echo 'ITEM_ID='$(jq '.data.organization.projectV2.items.nodes[] | select(.content.id=="${{ env.PR_ID }}") |.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Move to Dev Review in Progress Column
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOOSTED_MOD_PERSONAL_TOKEN_CLASSIC }}
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              set_status: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: {
+                  singleSelectOptionId: $status_value
+                  }
+              }) {
+                projectV2Item {
+                  id
+                  }
+              }
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.TARGET_COL_ID }} --silent

--- a/.github/workflows/update-pr-review-in-progress.yml
+++ b/.github/workflows/update-pr-review-in-progress.yml
@@ -1,11 +1,11 @@
-name: Dev review in progress move PR in the right column
+name: Move card to Dev Review in Progess column
 on:
   pull_request_review:
     types:
       - submitted
 
 jobs:
-  project-move-card:
+  move_card_to_dev_review_in_progress:
     if: github.event.review.state != 'approved' && github.event.review.user != 'julien-deramond' && github.event.review.user != 'Aniort'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_
 
 ### Related issues
 
 NA
 
 ### Description
 
 When a PR is reviewed but not approved while not being already approved once, the associated card should move in the Dev Review in Progress column.

⚠️ The actual solution is far from ideal but we can't check either the card column or get all the card's id in one column yet. I tried to check the codeowners but it seems that it's not feasible at the moment so this workflow might need an update later on.
 
 ### Motivation & Context
 
 Automate our processes.
 
 ### Types of change
 
 <!-- What types of changes does you code introduce? -->
 <!-- Please remove the unused items in the list -->
 
 - New feature (non-breaking change which adds functionality)
 
