### PR TITLE
fix(docs): Solaris icons URL

### DIFF
--- a/hugo.yml
+++ b/hugo.yml
@@ -68,7 +68,7 @@ params:
   repo:                             "https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap"
   twitter:                          "getbootstrap"
   blog:                             "https://blog.getbootstrap.com/"
-  icons:                            "https://system.design.orange.com/0c1af118d/p/847054-solaris-icons/b/84c5ca"
+  icons:                            "https://system.design.orange.com/0c1af118d/p/65c68d-solaris-icon-library"
   bootstrap:                        "https://getbootstrap.com"
   ods:
     web:                            "https://system.design.orange.com/0c1af118d/n/76065f"


### PR DESCRIPTION
### Description
 
 This PR modifies the URL displayed in the documentation to download Solaris icons from the Design System Manager. The previous one was obsolete.
 
 ### Live preview

- https://deploy-preview-2112--boosted.netlify.app/docs/5.3/extend/icons/#solaris