### PR TITLE
chore(deps-dev): bump tarteaucitronjs from 1.12.0 to 1.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "sirv-cli": "^2.0.2",
         "stylelint": "^15.6.2",
         "stylelint-config-twbs-bootstrap": "^10.0.0",
-        "tarteaucitronjs": "^1.12.0",
+        "tarteaucitronjs": "^1.13.0",
         "terser": "5.16.0",
         "vnu-jar": "^23.4.11"
       },
@@ -23215,9 +23215,9 @@
       }
     },
     "node_modules/tarteaucitronjs": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.12.0.tgz",
-      "integrity": "sha512-iS+gxawPM8rS+6irOR4BCuTVaXU7eLb0bvm/CTkisj98eraaFlUMUktKFu4yL1kn/tY1lYmcz97hL6MmSBLOlw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.13.0.tgz",
+      "integrity": "sha512-9oDLdNoax0zVeio3Ps7YtURtRgpLXIsTno1hqZGAIx38nCxWdfuB8ancC5PUyjKYwbPCDGkc1fKFvoHxUZ1HDw==",
       "dev": true
     },
     "node_modules/telejson": {
@@ -43104,9 +43104,9 @@
       }
     },
     "tarteaucitronjs": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.12.0.tgz",
-      "integrity": "sha512-iS+gxawPM8rS+6irOR4BCuTVaXU7eLb0bvm/CTkisj98eraaFlUMUktKFu4yL1kn/tY1lYmcz97hL6MmSBLOlw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.13.0.tgz",
+      "integrity": "sha512-9oDLdNoax0zVeio3Ps7YtURtRgpLXIsTno1hqZGAIx38nCxWdfuB8ancC5PUyjKYwbPCDGkc1fKFvoHxUZ1HDw==",
       "dev": true
     },
     "telejson": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "sirv-cli": "^2.0.2",
     "stylelint": "^15.6.2",
     "stylelint-config-twbs-bootstrap": "^10.0.0",
-    "tarteaucitronjs": "^1.12.0",
+    "tarteaucitronjs": "^1.13.0",
     "terser": "5.16.0",
     "vnu-jar": "^23.4.11"
   },


### PR DESCRIPTION
### Description

This PR bumps `tarteaucitronjs` from 1.12.0 to 1.13.0.
[Diff between the two versions](https://github.com/AmauriC/tarteaucitron.js/compare/v1.12.0...v1.13.0) doesn't seem to be impactful for Boosted.

Please double-check that everything's still working as expected during the code review.