### PR TITLE
feat(utilities): add `.border-4` and `.border-5`

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -618,7 +618,9 @@ $border-width:                .125rem !default;
 $border-widths: (
   1: $border-width * .5,
   2: $border-width,
-  3: $border-width * 1.5
+  3: $border-width * 1.5,
+  4: $border-width * 2,
+  5: $border-width * 2.5
 ) !default;
 $border-style:                solid !default;
 $border-color:                $black !default; // Boosted mod

--- a/site/content/docs/5.3/utilities/borders.md
+++ b/site/content/docs/5.3/utilities/borders.md
@@ -127,6 +127,8 @@ Or, choose from any of the `.border-opacity` utilities:
 <span class="border border-1"></span>
 <span class="border border-2"></span>
 <span class="border border-3"></span>
+<span class="border border-4"></span>
+<span class="border border-5"></span>
 {{< /example >}}
 
 ## Radius


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2064#discussion_r1252683331

### Description

This PR reintegrates `.border-4` and `.border-5` from Bootstrap (see https://twbs-bootstrap.netlify.app/docs/5.3/utilities/borders/#width).

This is not mentioned in the migration guide since it's not to be used for Orange developers.

### Motivation & Context

Alignment between Boosted and Bootstrap.

### Types of change

- New feature (non-breaking change which adds functionality)

### Live previews

- <https://deploy-preview-2127--boosted.netlify.app/docs/5.3/utilities/borders/#width>

### Checklist

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
