### PR TITLE
SCSS: remove `$boosted-prefix` in favor of `$prefix`

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -72,7 +72,7 @@ const SELECTOR_CAROUSEL_PAUSE_TEXT = 'data-bs-pause-text' // Boosted mod
 const SELECTOR_CAROUSEL_DEFAULT_PLAY_TEXT = 'Play Carousel' // Boosted mod
 const SELECTOR_CAROUSEL_DEFAULT_PAUSE_TEXT = 'Pause Carousel' // Boosted mod
 
-const PREFIX_CUSTOM_PROPS = 'o-' // Boosted mod: should match `$boosted-prefix` in scss/_variables.scss
+const PREFIX_CUSTOM_PROPS = 'bs-' // Boosted mod: should match `$prefix` in scss/_variables.scss
 
 const KEY_TO_DIRECTION = {
   [ARROW_LEFT_KEY]: DIRECTION_RIGHT,

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -1619,7 +1619,7 @@ describe('Carousel', () => {
     })
 
     // Boosted mod
-    it('should set --o-carousel-interval custom property on indicator if data-bs-interval is provided', () => {
+    it('should set --bs-carousel-interval custom property on indicator if data-bs-interval is provided', () => {
       fixtureEl.innerHTML = [
         '<div id="myCarousel" class="carousel slide">',
         '  <ol class="carousel-indicators">',
@@ -1642,12 +1642,12 @@ describe('Carousel', () => {
       const carousel = new Carousel(carouselEl)
       carousel.cycle()
 
-      expect(firstIndicator.style.getPropertyValue('--o-carousel-interval')).toEqual('7ms')
+      expect(firstIndicator.style.getPropertyValue('--bs-carousel-interval')).toEqual('7ms')
 
       carousel._activeElement = secondItemEl
       carousel.cycle()
 
-      expect(secondIndicator.style.getPropertyValue('--o-carousel-interval')).toEqual('9385ms')
+      expect(secondIndicator.style.getPropertyValue('--bs-carousel-interval')).toEqual('9385ms')
     })
     // End mod
   })

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -141,7 +141,7 @@
   --#{$prefix}alert-icon-size: #{$alert-icon-size-sm};
   --#{$prefix}alert-btn-close-offset: #{$alert-btn-close-offset-sm};
   // scss-docs-end alert-sm-css-vars
-  --#{$boosted-prefix}icon-spacing: #{$btn-close-padding-sm};
+  --#{$prefix}icon-spacing: #{$btn-close-padding-sm};
 
   .alert-icon {
     margin: var(--#{$prefix}alert-icon-margin-y) 0;

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -20,7 +20,7 @@
   --#{$prefix}btn-box-shadow: #{$btn-box-shadow};
   --#{$prefix}btn-disabled-opacity: #{$btn-disabled-opacity};
   --#{$prefix}btn-focus-box-shadow: 0 0 0 #{$btn-focus-width} var(--#{$prefix}btn-focus-shadow-rgb); // Boosted mod
-  --#{$boosted-prefix}icon-spacing: #{$btn-icon-padding-x}; // Boosted mod
+  --#{$prefix}icon-spacing: #{$btn-icon-padding-x}; // Boosted mod
   // scss-docs-end btn-css-vars
 
   display: inline-flex; // Boosted mod
@@ -222,7 +222,7 @@
 
 // Boosted mod: icon button
 .btn-icon {
-  padding: var(--#{$boosted-prefix}icon-spacing);
+  padding: var(--#{$prefix}icon-spacing);
 }
 // End mod
 
@@ -230,15 +230,15 @@
 .btn-social {
   --#{$prefix}btn-border-color: currentcolor;
   --#{$prefix}btn-hover-color: #{$white};
-  --#{$prefix}btn-hover-bg: var(--#{$boosted-prefix}network-color, #{$black});
-  --#{$prefix}btn-hover-border-color: var(--#{$boosted-prefix}network-color, #{$black});
+  --#{$prefix}btn-hover-bg: var(--#{$prefix}network-color, #{$black});
+  --#{$prefix}btn-hover-border-color: var(--#{$prefix}network-color, #{$black});
   --#{$prefix}btn-active-color: #{$white};
   --#{$prefix}btn-active-bg: #{$black};
   --#{$prefix}btn-active-border-color: #{$black};
   --#{$prefix}btn-disabled-color: #{$gray-500};
   --#{$prefix}btn-disabled-bg: transparent;
   @include border-radius(50%, 50%);
-  @include button-icon(var(--#{$boosted-prefix}network-logo));
+  @include button-icon(var(--#{$prefix}network-logo));
 
   &.btn-inverse {
     --#{$prefix}btn-color: #{$white};
@@ -253,8 +253,8 @@
   $network: map-get($btn-social-networks, $name);
 
   .btn-#{$name} {
-    --#{$boosted-prefix}network-color: #{map-get($network, "color")};
-    --#{$boosted-prefix}network-logo: #{escape-svg(url("data:image/svg+xml,#{map-get($network, "icon")}"))};
+    --#{$prefix}network-color: #{map-get($network, "color")};
+    --#{$prefix}network-logo: #{escape-svg(url("data:image/svg+xml,#{map-get($network, "icon")}"))};
 
     &::before {
       mask-size: if(map-has-key($network, "size"), map-get($network, "size"), null);

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -86,7 +86,7 @@
 
 .carousel-control-prev,
 .carousel-control-next {
-  --#{$boosted-prefix}control-bg: #{rgba($carousel-indicator-active-bg, .5)}; // Boosted mod
+  --#{$prefix}control-bg: #{rgba($carousel-indicator-active-bg, .5)}; // Boosted mod
   position: absolute;
   top: 0;
   bottom: 0;
@@ -108,7 +108,7 @@
 
   // Hover state - Boosted mod: no focus state
   &:hover {
-    --#{$boosted-prefix}control-bg: #{color-contrast($carousel-indicator-active-bg)}; // Boosted mod
+    --#{$prefix}control-bg: #{color-contrast($carousel-indicator-active-bg)}; // Boosted mod
     color: color-contrast($carousel-control-color);
     text-decoration: none;
     opacity: $carousel-control-hover-opacity;
@@ -122,7 +122,7 @@
   }
 
   &:active {
-    --#{$boosted-prefix}control-bg: #{$carousel-control-icon-active-bg};
+    --#{$prefix}control-bg: #{$carousel-control-icon-active-bg};
     color: $carousel-control-color;
   }
 
@@ -151,7 +151,7 @@
 .carousel-control-prev-icon,
 .carousel-control-next-icon {
   display: inline-block;
-  background-color: var(--#{$boosted-prefix}control-bg); // Boosted mod
+  background-color: var(--#{$prefix}control-bg); // Boosted mod
   @include button-icon($carousel-control-icon-bg, $carousel-control-icon-width, $size: $carousel-control-icon-size, $position: subtract(50%, $spacer * .1) 50%); // Boosted mod
   @include border-radius(50%, 50%);
 }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -40,7 +40,7 @@
 
   // Boosted mod
   @each $icon, $svg in $svg-as-custom-props {
-    --#{$boosted-prefix}#{$icon}-icon: #{escape-svg($svg)};
+    --#{$prefix}#{$icon}-icon: #{escape-svg($svg)};
   }
   // End mod
 
@@ -151,13 +151,13 @@
   --#{$prefix}link-hover-color-rgb: #{to-rgb($link-hover-color-inverted)};
   --#{$prefix}focus-visible-inner-color: #{$focus-visible-inner-color-inverted};
   --#{$prefix}focus-visible-outer-color: #{$focus-visible-outer-color-inverted};
-  --#{$boosted-prefix}caption-color: #{$table-caption-color-inverted};
+  --#{$prefix}caption-color: #{$table-caption-color-inverted};
   --#{$prefix}code-color: #{$code-color-inverted};
   --#{$prefix}highlight-color: #{$mark-color-inverted};
   --#{$prefix}highlight-bg: #{$mark-bg-inverted};
-  --#{$boosted-prefix}kbd-color: #{$kbd-color-inverted};
-  --#{$boosted-prefix}kbd-bg: #{$kbd-bg-inverted};
-  --#{$boosted-prefix}pre-color: #{$pre-color-inverted};
+  --#{$prefix}kbd-color: #{$kbd-color-inverted};
+  --#{$prefix}kbd-bg: #{$kbd-bg-inverted};
+  --#{$prefix}pre-color: #{$pre-color-inverted};
 
   // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
   [class*="bg-"]:not(&):not(.bg-transparent) {
@@ -168,13 +168,13 @@
     --#{$prefix}link-hover-color-rgb: #{to-rgb($link-hover-color)};
     --#{$prefix}focus-visible-inner-color: #{$focus-visible-inner-color};
     --#{$prefix}focus-visible-outer-color: #{$focus-visible-outer-color};
-    --#{$boosted-prefix}caption-color: #{$table-caption-color};
+    --#{$prefix}caption-color: #{$table-caption-color};
     --#{$prefix}code-color: #{$code-color};
     --#{$prefix}highlight-color: #{$mark-color};
     --#{$prefix}highlight-bg: #{$mark-bg};
-    --#{$boosted-prefix}kbd-color: #{$kbd-color};
-    --#{$boosted-prefix}kbd-bg: #{$kbd-bg};
-    --#{$boosted-prefix}pre-color: #{$pre-color};
+    --#{$prefix}kbd-color: #{$kbd-color};
+    --#{$prefix}kbd-bg: #{$kbd-bg};
+    --#{$prefix}pre-color: #{$pre-color};
   }
 }
 // End mod

--- a/scss/_tags.scss
+++ b/scss/_tags.scss
@@ -69,8 +69,8 @@
       min-height: subtract(var(--#{$prefix}tag-close-size), .625rem);
       content: "";
       background-color: currentcolor;
-      -webkit-mask: escape-svg(var(--#{$boosted-prefix}close-icon)) no-repeat 50% / subtract(var(--#{$prefix}tag-close-size), .625rem); // stylelint-disable-line property-no-vendor-prefix
-      mask: escape-svg(var(--#{$boosted-prefix}close-icon)) no-repeat 50% / subtract(var(--#{$prefix}tag-close-size), .625rem);
+      -webkit-mask: escape-svg(var(--#{$prefix}close-icon)) no-repeat 50% / subtract(var(--#{$prefix}tag-close-size), .625rem); // stylelint-disable-line property-no-vendor-prefix
+      mask: escape-svg(var(--#{$prefix}close-icon)) no-repeat 50% / subtract(var(--#{$prefix}tag-close-size), .625rem);
     }
 
     &:hover,

--- a/scss/_tags.scss
+++ b/scss/_tags.scss
@@ -69,7 +69,6 @@
       min-height: subtract(var(--#{$prefix}tag-close-size), .625rem);
       content: "";
       background-color: currentcolor;
-      -webkit-mask: escape-svg(var(--#{$prefix}close-icon)) no-repeat 50% / subtract(var(--#{$prefix}tag-close-size), .625rem); // stylelint-disable-line property-no-vendor-prefix
       mask: escape-svg(var(--#{$prefix}close-icon)) no-repeat 50% / subtract(var(--#{$prefix}tag-close-size), .625rem);
     }
 

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -62,7 +62,7 @@
   @include border-top-radius(calc(var(--#{$prefix}toast-border-radius) - var(--#{$prefix}toast-border-width)));
 
   .btn-close {
-    --#{$boosted-prefix}icon-spacing: #{$btn-close-padding-sm}; // Boosted mod
+    --#{$prefix}icon-spacing: #{$btn-close-padding-sm}; // Boosted mod
     margin-right: calc(-.5 * var(--#{$prefix}toast-padding-x)); // stylelint-disable-line function-disallowed-list
     margin-left: var(--#{$prefix}toast-padding-x);
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -447,8 +447,10 @@ $color-mode-type:             data !default; // `data` or `media-query`
 
 $variable-prefix:             bs- !default; // Deprecated in v5.2.0 for the shorter `$prefix`
 $prefix:                      $variable-prefix !default;
+// fusv-disable
 $boosted-variable-prefix:     o- !default; // Deprecated in v5.2.0 for the shorter `$prefix`
-$prefix:              $boosted-variable-prefix !default;
+$boosted-prefix:              $boosted-variable-prefix !default; // Deprecated in v6.0.0
+// fusv-enable
 
 // Gradient
 //

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -447,8 +447,8 @@ $color-mode-type:             data !default; // `data` or `media-query`
 
 $variable-prefix:             bs- !default; // Deprecated in v5.2.0 for the shorter `$prefix`
 $prefix:                      $variable-prefix !default;
-$boosted-variable-prefix:     o- !default; // Deprecated in v5.2.0 for the shorter `$boosted-prefix`
-$boosted-prefix:              $boosted-variable-prefix !default;
+$boosted-variable-prefix:     o- !default; // Deprecated in v5.2.0 for the shorter `$prefix`
+$prefix:              $boosted-variable-prefix !default;
 
 // Gradient
 //
@@ -909,7 +909,7 @@ $table-striped-columns-order:           even !default;
 
 $table-group-separator-color:           currentcolor !default;
 
-$table-caption-color:                   var(--#{$boosted-prefix}caption-color, var(--#{$prefix}emphasis-color)) !default; // Boosted mod: instead of `var(--#{$prefix}secondary-color)`
+$table-caption-color:                   var(--#{$prefix}caption-color, var(--#{$prefix}emphasis-color)) !default; // Boosted mod: instead of `var(--#{$prefix}secondary-color)`
 $table-caption-color-inverted:          var(--#{$prefix}body-bg) !default; // Boosted mod
 $table-caption-padding-y:               .75rem !default; // Boosted mod
 
@@ -1156,7 +1156,7 @@ $form-check-input-focus-box-shadow:       $focus-ring-box-shadow !default;
 $form-check-input-checked-color:          $component-active-color !default;
 $form-check-input-checked-bg-color:       $component-active-bg !default;
 $form-check-input-checked-border-color:   $form-check-input-checked-bg-color !default;
-$form-check-input-checked-bg-image:       var(--#{$boosted-prefix}check-icon) !default;
+$form-check-input-checked-bg-image:       var(--#{$prefix}check-icon) !default;
 $form-check-input-disabled-color:         $gray-900 !default; // Boosted mod
 $form-check-radio-checked-bg-image:       url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#{$form-check-input-checked-color}'/></svg>") !default;
 
@@ -1190,7 +1190,7 @@ $form-star-focus-box-shadow:      $input-btn-focus-box-shadow !default; // Depre
 // Boosted mod: no $form-switch-color
 $form-switch-width:               $spacer * 3 !default; // Boosted mod
 $form-switch-padding-start:       $form-switch-width + .625rem !default; // Boosted mod
-$form-switch-bg-image:            var(--#{$boosted-prefix}close-icon) !default;  // Boosted mod
+$form-switch-bg-image:            var(--#{$prefix}close-icon) !default;  // Boosted mod
 $form-switch-bg-position:         right .5rem top 50% !default;  // Boosted mod
 $form-switch-bg-size:             .75rem !default;  // Boosted mod
 $form-switch-bg-square-size:      add(1rem, $spacer * .5) !default;  // Boosted mod
@@ -1303,8 +1303,8 @@ $form-feedback-valid-color:         $success !default; // Boosted mod: deprecate
 $form-feedback-invalid-color:       $danger !default; // Boosted mod: deprecated in v5.3.0
 // fusv-enable
 
-$form-feedback-icon-valid:          var(--#{$boosted-prefix}success-icon) !default;
-$form-feedback-icon-invalid:        var(--#{$boosted-prefix}error-icon) !default;
+$form-feedback-icon-valid:          var(--#{$prefix}success-icon) !default;
+$form-feedback-icon-invalid:        var(--#{$prefix}error-icon) !default;
 $form-feedback-icon-size:           add($spacer * .25, $spacer * .5) !default; // Boosted mod
 $form-feedback-line-height:         $line-height-sm !default; // Boosted mod
 // scss-docs-end form-feedback-variables
@@ -1606,7 +1606,7 @@ $pagination-transition:             $transition-focus !default;
 
 // Boosted mod
 $pagination-padding-end:            1.125rem !default;
-$pagination-icon:                   var(--#{$boosted-prefix}chevron-icon) !default;
+$pagination-icon:                   var(--#{$prefix}chevron-icon) !default;
 $pagination-icon-size:              subtract($spacer * 2, calc(var(--#{$prefix}border-width) * 2)) !default; // stylelint-disable-line function-disallowed-list
 $pagination-icon-width:             add(.5rem, 1px) !default;
 $pagination-icon-height:            subtract(1rem, 1px) !default;
@@ -1925,10 +1925,10 @@ $alert-border-width:                var(--#{$prefix}border-width) !default;
 // Boosted mod
 $alert-padding-sm:                  $spacer * .5 !default;
 $alert-icons: (
-  "success": var(--#{$boosted-prefix}success-icon),
+  "success": var(--#{$prefix}success-icon),
   "info":    escape-svg($info-icon),
   "warning": escape-svg($warning-icon),
-  "danger":  var(--#{$boosted-prefix}error-icon)
+  "danger":  var(--#{$prefix}error-icon)
 ) !default;
 $alert-logo-size:                   add($spacer * .5, 1rem) !default;
 $alert-logo-size-sm:                add(1rem, 1px) !default;
@@ -2110,7 +2110,7 @@ $carousel-caption-spacer:            $spacer * 3 !default;
 $carousel-control-icon-width:        2.5rem !default;
 // Boosted mod
 $carousel-control-icon-size:         1rem 1.5rem !default;
-$carousel-control-icon-bg:           var(--#{$boosted-prefix}chevron-icon) !default;
+$carousel-control-icon-bg:           var(--#{$prefix}chevron-icon) !default;
 $carousel-control-icon-active-bg:    $component-active-bg !default;
 
 $carousel-control-pause-indicators-spacing: 10px !default;
@@ -2154,11 +2154,11 @@ $spinner-border-width-lg: calc(var(--#{$prefix}border-width) * 4) !default; // B
 // scss-docs-start close-variables
 $btn-close-width:               $spacer !default; // Boosted mod
 $btn-close-height:              $btn-close-width !default;
-$btn-close-padding:             var(--#{$boosted-prefix}icon-spacing, #{$btn-icon-padding-x}) !default; // Boosted mod
+$btn-close-padding:             var(--#{$prefix}icon-spacing, #{$btn-icon-padding-x}) !default; // Boosted mod
 $btn-close-border-width:        var(--#{$prefix}border-width) !default; // Boosted mod
 $btn-close-border-color:        transparent !default; // Boosted mod
 $btn-close-color:               var(--#{$prefix}emphasis-color) !default;
-$btn-close-bg:                  var(--#{$boosted-prefix}close-icon) !default; // Boosted mod
+$btn-close-bg:                  var(--#{$prefix}close-icon) !default; // Boosted mod
 // Boosted mod
 // fusv-disable
 $btn-close-focus-shadow:        $btn-focus-box-shadow !default; // Deprecated in v5.3.0
@@ -2215,13 +2215,13 @@ $code-color-inverted:               $gray-600 !default;
 $kbd-padding-y:                     $spacer * .05 !default;
 $kbd-padding-x:                     $spacer * .05 !default;
 $kbd-font-size:                     $code-font-size !default;
-$kbd-color:                         var(--#{$boosted-prefix}kbd-color, $black) !default;
+$kbd-color:                         var(--#{$prefix}kbd-color, $black) !default;
 $kbd-color-inverted:                $white !default;
-$kbd-bg:                            var(--#{$boosted-prefix}kbd-bg, $gray-300) !default;
+$kbd-bg:                            var(--#{$prefix}kbd-bg, $gray-300) !default;
 $kbd-bg-inverted:                   $gray-900 !default;
 $nested-kbd-font-weight:            null !default; // Deprecated in v5.2.0, removing in v6
 
-$pre-color:                         var(--#{$boosted-prefix}pre-color, $gray-900) !default;
+$pre-color:                         var(--#{$prefix}pre-color, $gray-900) !default;
 $pre-color-inverted:                $gray-300 !default;
 $pre-line-height:                   1.25 !default;
 // End mod
@@ -2246,7 +2246,7 @@ $back-to-top-link-offset-top-xl: subtract(100vh, $spacer * 5) !default;
 $back-to-top-title-offset-right: add(100%, var(--#{$prefix}border-width)) !default;
 $back-to-top-title-padding:      subtract($btn-padding-y, 1px) $btn-padding-x add($btn-padding-y, 1px) !default;
 $back-to-top-title-bg-color:     $white !default;
-$back-to-top-icon:               var(--#{$boosted-prefix}chevron-icon) !default;
+$back-to-top-icon:               var(--#{$prefix}chevron-icon) !default;
 $back-to-top-icon-width:         add(.5rem, 1px) !default;
 $back-to-top-icon-height:        subtract(1rem, 1px) !default;
 // scss-docs-end back-to-top

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -449,7 +449,7 @@ $variable-prefix:             bs- !default; // Deprecated in v5.2.0 for the shor
 $prefix:                      $variable-prefix !default;
 // fusv-disable
 $boosted-variable-prefix:     o- !default; // Deprecated in v5.2.0 for the shorter `$prefix`
-$boosted-prefix:              $boosted-variable-prefix !default; // Deprecated in v6.0.0
+$boosted-prefix:              $boosted-variable-prefix !default; // Deprecated in v5.3.0 for the shorter `$prefix`
 // fusv-enable
 
 // Gradient

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -153,7 +153,7 @@
 
 .form-switch {
   // Boosted mod
-  --#{$boosted-prefix}switch-gradient: #{linear-gradient(to right, $black $form-switch-bg-square-size, transparent)};
+  --#{$prefix}switch-gradient: #{linear-gradient(to right, $black $form-switch-bg-square-size, transparent)};
 
   min-height: $form-switch-width * .5;
   padding-left: $form-switch-padding-start;
@@ -166,7 +166,7 @@
     height: $form-switch-width * .5;
     margin-left: $form-switch-padding-start * -1;
     background-color: $white; // Boosted mod
-    background-image: var(--#{$prefix}form-switch-bg), var(--#{$boosted-prefix}switch-gradient); // Boosted mod: extra param `var(--#{$boosted-prefix}switch-gradient)`
+    background-image: var(--#{$prefix}form-switch-bg), var(--#{$prefix}switch-gradient); // Boosted mod: extra param `var(--#{$prefix}switch-gradient)`
     filter: $invert-filter; // Boosted mod
     background-position: $form-switch-bg-position, 0 0;
     background-size: $form-switch-bg-size, $form-switch-bg-square-size 100%; // Get a 1px separation
@@ -202,7 +202,7 @@
       }
 
       &:not(:disabled) {
-        --#{$boosted-prefix}switch-gradient: #{linear-gradient(to right, $white $form-switch-bg-square-size, transparent)};
+        --#{$prefix}switch-gradient: #{linear-gradient(to right, $white $form-switch-bg-square-size, transparent)};
       }
     }
 

--- a/scss/helpers/_chevron-link.scss
+++ b/scss/helpers/_chevron-link.scss
@@ -10,7 +10,7 @@
     margin-left: $linked-chevron-margin-left;
     vertical-align: middle;
     content: "";
-    background-image: var(--#{$boosted-prefix}chevron-icon);
+    background-image: var(--#{$prefix}chevron-icon);
     background-repeat: no-repeat;
     transform: $linked-chevron-transform;
   }

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -73,7 +73,6 @@
       min-height: inherit;
       content: "";
       background-color: currentcolor;
-      -webkit-mask: #{$icon} no-repeat #{$position} / #{$size}; // stylelint-disable-line property-no-vendor-prefix
       mask: #{$icon} no-repeat #{$position} / #{$size};
     }
   }

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -42,7 +42,7 @@
 
 // scss-docs-start btn-size-mixin
 @mixin button-size($padding-y, $padding-x, $font-size, $border-radius, $line-height: null, $icon-spacing: $btn-icon-padding-x, $letter-spacing: $letter-spacing-base) {
-  --#{$boosted-prefix}icon-spacing: #{$icon-spacing}; // Boosted mod: used for icons
+  --#{$prefix}icon-spacing: #{$icon-spacing}; // Boosted mod: used for icons
   --#{$prefix}btn-padding-y: #{$padding-y};
   --#{$prefix}btn-padding-x: #{$padding-x};
   @include rfs($font-size, --#{$prefix}btn-font-size);

--- a/site/content/docs/5.3/components/carousel.md
+++ b/site/content/docs/5.3/components/carousel.md
@@ -60,7 +60,7 @@ You can add indicators to the carousel, alongside the previous/next controls. Th
 
 <!-- Boosted mod -->
 
-Indicators are animated to show the active slide progress, based on its interval. It adapts to [any interval you set](#individual-carousel-item-interval) thanks to the `--o-carousel-interval` CSS custom property.
+Indicators are animated to show the active slide progress, based on its interval. It adapts to [any interval you set](#individual-carousel-item-interval) thanks to the `--bs-carousel-interval` CSS custom property.
 Carousel progress indicator is paused under multiple conditions:
 
 * when the `prefers-reduced-motion` media query equals `reduce` [to improve accessibility]({{< docsref "/getting-started/accessibility#reduced-motion" >}}).

--- a/site/content/docs/5.3/customize/css-variables.md
+++ b/site/content/docs/5.3/customize/css-variables.md
@@ -78,15 +78,15 @@ Boosted uses [embedded SVGs as data URIs]({{< docsref "/customize/overview" >}}#
 
 ```css
 :root {
-  --o-chevron-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'%3e%3cpath d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/%3e%3c/svg%3e");
+  --bs-chevron-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 14'%3e%3cpath d='M9 2L7 0 0 7l7 7 2-2-5-5 5-5z'/%3e%3c/svg%3e");
 }
 
 .back-to-top-link::after {
-  background-image: var(--o-chevron-icon);
+  background-image: var(--bs-chevron-icon);
 }
 
 .pagination-item:first-child .page-link::before {
-  background-image: var(--o-chevron-icon);
+  background-image: var(--bs-chevron-icon);
 }
 ```
 <!-- End mod -->

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -259,7 +259,7 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
 - `@mixin caret()` has a new interface including a new optional parameters.
 
 - <details class="mb-2">
-  <summary><span class="badge bg-danger">Breaking</span> Remove <code>$boosted-prefix</code> in favor of <code>$prefix</code>. Please check and replace all occurrences in your code.</summary>
+  <summary><span class="badge bg-danger">Breaking</span> Remove <code>$boosted-prefix</code> in favor of <code>$prefix</code>. Please check and replace all occurrences of `$boosted-prefix` or `--o-` and replace them respectively by `$prefix` or `--bs-` in your code.</summary>
 
     ```diff
     - $boosted-prefix // or `o-`
@@ -289,12 +289,27 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
     <ul>
       <li><code>--bs-border-radius-2xl</code></li>
       <li><code>--bs-offcanvas-transition-duration</code></li>
+      <li><code>--o-caption-color</code></li>
+      <li><code>--o-check-icon</code></li>
+      <li><code>--o-chevron-icon</code></li>
+      <li><code>--o-close-icon</code></li>
+      <li><code>--o-control-bg</code></li>
+      <li><code>--o-error-icon</code></li>
+      <li><code>--o-icon-spacing</code></li>
+      <li><code>--o-kbd-bg</code></li>
+      <li><code>--o-kbd-color</code></li>
+      <li><code>--o-network-color</code></li>
+      <li><code>--o-network-logo</code></li>
+      <li><code>--o-pre-color</code></li>
+      <li><code>--o-success-icon</code></li>
+      <li><code>--o-switch-gradient</code></li>
     </ul>
   </details>
 
 - <details class="mb-2">
     <summary><span class="badge bg-danger">Breaking</span> Deprecated Sass variables:</summary>
     <ul>
+      <li><code>$boosted-prefix</code></li>
       <li><code>$border-radius-2xl</code></li>
       <li><code>$code-color-dark</code></li>
       <li><code>$focus-visible-inner-color-dark</code></li>
@@ -325,8 +340,13 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-breakpoint-xl</code></li>
       <li><code>--bs-breakpoint-xs</code></li>
       <li><code>--bs-breakpoint-xxl</code></li>
+      <li><code>--bs-caption-color</code></li>
       <li><code>--bs-card-subtitle-color</code></li>
       <li><code>--bs-card-title-color</code></li>
+      <li><code>--bs-check-icon</code></li>
+      <li><code>--bs-chevron-icon</code></li>
+      <li><code>--bs-close-icon</code></li>
+      <li><code>--bs-control-bg</code></li>
       <li><code>--bs-danger-bg-subtle</code></li>
       <li><code>--bs-danger-border-subtle</code></li>
       <li><code>--bs-danger-text-emphasis</code></li>
@@ -336,6 +356,7 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-emphasis-color-rgb</code></li>
       <li><code>--bs-emphasis-color</code></li>
       <li><code>--bs-emphasis-color</code></li>
+      <li><code>--bs-error-icon</code></li>
       <li><code>--bs-focus-ring-box-shadow</code></li>
       <li><code>--bs-focus-ring-color</code></li>
       <li><code>--bs-focus-ring-opacity</code></li>
@@ -350,9 +371,12 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-form-valid-border-color</code></li>
       <li><code>--bs-form-valid-color</code></li>
       <li><code>--bs-heading-color</code></li>
+      <li><code>--bs-icon-spacing</code></li>
       <li><code>--bs-info-bg-subtle</code></li>
       <li><code>--bs-info-border-subtle</code></li>
       <li><code>--bs-info-text-emphasis</code></li>
+      <li><code>--bs-kbd-bg</code></li>
+      <li><code>--bs-kbd-color</code></li>
       <li><code>--bs-light-bg-subtle</code></li>
       <li><code>--bs-light-border-subtle</code></li>
       <li><code>--bs-light-text-emphasis</code></li>
@@ -360,6 +384,7 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-link-decoration</code></li>
       <li><code>--bs-link-hover-color-rgb</code></li>
       <li><code>--bs-link-hover-decoration</code></li>
+      <li><code>--bs-modal-footer-margin-top</code></li>
       <li><code>--bs-nav-underline-border-color</code></li>
       <li><code>--bs-nav-underline-border-radius</code></li>
       <li><code>--bs-nav-underline-border-width</code></li>
@@ -372,7 +397,8 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-nav-underline-link-hover-bg</code></li>
       <li><code>--bs-nav-underline-link-hover-color</code></li>
       <li><code>--bs-nav-underline-link-padding-x</code></li>
-      <li><code>--bs-modal-footer-margin-top</code></li>
+      <li><code>--bs-network-color</code></li>
+      <li><code>--bs-network-logo</code></li>
       <li><code>--bs-offcanvas-transition</code></li>
       <li><code>--bs-popover-body-padding-bottom</code></li>
       <li><code>--bs-popover-body-padding-top</code></li>
@@ -380,6 +406,7 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-popover-header-padding-bottom</code></li>
       <li><code>--bs-popover-header-padding-top</code></li>
       <li><code>--bs-popover-line-height</code></li>
+      <li><code>--bs-pre-color</code></li>
       <li><code>--bs-primary-bg-subtle</code></li>
       <li><code>--bs-primary-border-subtle</code></li>
       <li><code>--bs-primary-text-emphasis</code></li>
@@ -392,7 +419,9 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-secondary-text-emphasis</code></li>
       <li><code>--bs-success-bg-subtle</code></li>
       <li><code>--bs-success-border-subtle</code></li>
+      <li><code>--bs-success-icon</code></li>
       <li><code>--bs-success-text-emphasis</code></li>
+      <li><code>--bs-switch-gradient</code></li>
       <li><code>--bs-table-bg-state</code></li>
       <li><code>--bs-table-bg-type</code></li>
       <li><code>--bs-table-color-state</code></li>

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -260,11 +260,11 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
 - `@mixin caret()` has a new interface including a new optional parameters.
 
 - <details class="mb-2">
-  <summary><span class="badge bg-danger">Breaking</span> Remove <code>$boosted-prefix</code> in favor of <code>$prefix</code>. Please check and replace all occurrences of `$boosted-prefix` or `--o-` and replace them respectively by `$prefix` or `--bs-` in your code.</summary>
+  <summary><span class="badge bg-danger">Breaking</span> Deprecated <code>$boosted-prefix</code> in favor of <code>$prefix</code>. Please check and replace all occurrences of <code>$boosted-prefix</code> or <code>--o-</code> and replace them respectively by <code>$prefix</code> or <code>--bs-</code> in your code.</summary>
 
     ```diff
-    - $boosted-prefix // or `o-`
-    + $prefix // or `bs-`
+    - $boosted-prefix // or `--o-`
+    + $prefix // or `--bs-`
     ```
   </details>
 
@@ -291,6 +291,7 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-border-radius-2xl</code></li>
       <li><code>--bs-offcanvas-transition-duration</code></li>
       <li><code>--o-caption-color</code></li>
+      <li><code>--o-carousel-interval</code></li>
       <li><code>--o-check-icon</code></li>
       <li><code>--o-chevron-icon</code></li>
       <li><code>--o-close-icon</code></li>
@@ -344,6 +345,7 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
       <li><code>--bs-caption-color</code></li>
       <li><code>--bs-card-subtitle-color</code></li>
       <li><code>--bs-card-title-color</code></li>
+      <li><code>--bs-carousel-interval</code></li>
       <li><code>--bs-check-icon</code></li>
       <li><code>--bs-chevron-icon</code></li>
       <li><code>--bs-close-icon</code></li>

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -259,6 +259,15 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
 - `@mixin caret()` has a new interface including a new optional parameters.
 
 - <details class="mb-2">
+  <summary><span class="badge bg-danger">Breaking</span> Remove <code>$boosted-prefix</code> in favor of <code>$prefix</code>. Please check and replace all occurrences in your code.</summary>
+
+    ```diff
+    - $boosted-prefix // or `o-`
+    + $prefix // or `bs-`
+    ```
+  </details>
+
+- <details class="mb-2">
   <summary><span class="badge bg-danger">Breaking</span> Because of the dark mode we've renamed our dark variant Sass variables; <code>$*-dark</code> in <code>$*-inverted</code></summary>
     <ul>
       <li><code>$code-color-dark</code> → <code>$code-color-inverted</code></li>


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_  ### Related issues  Closes #1553.  ### Description  Change all `$boosted-prefix` in favor of `$prefix` to harmonize our framework. Might be merged for v6 only maybe ?  ### Motivation & Context  End user will only have one prefix and not being forced to switch beside two of them.  ### Types of change  <!-- What types of changes does you code introduce? --> <!-- Please remove the unused items in the list -->  - Breaking change (fix or feature that would change existing functionality)  ### Live previews  <!-- Please add direct links where your modifications can be seen in the documentation -->  - <https://deploy-preview-2129--boosted.netlify.app/>  ### Checklist  <!-- Go over all the following points, and put an `x` in all the boxes that apply. --> <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->  #### Contribution  - [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)  #### Accessibility  - [x] My change follows accessibility good practices; I have at least run axe  #### Design  - [x] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web) - [x] My change is compatible with responsive display  #### Development  - [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide) - (NA) I have added JavaScript unit tests to cover my changes - (NA) I have added SCSS unit tests to cover my changes  #### Documentation  - [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly  ### Checklist (for Core Team only)  - [ ] My change introduces changes to the migration guide - (NA) My new component is added in Storybook - (NA) My new component is compatible with RTL - [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml) - [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android) - [ ] Code review - [ ] Design review - [ ] A11y review  #### After the merge  - [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)  <!------------------------> <!-- /!\ Core Team Only --> <!------------------------>  <!-- Uncomment the following for a release DoD -->  <!-- - [ ] Run linters; - [ ] Run compilers; - [ ] Run tests; - [ ] Check documentation site: examples and contents; - [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/): - Firefox ESR - IE11 (v4 only) - Latest Edge, Chrome, Firefox, Safari - iOS Safari - Chrome & Firefox on Android - [ ] Including RTL mode; - [ ] Ask for reviews and accessibility testing; - [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it; - [ ] `npm run release-version $current_version $next_version` to bump version number - then, if bumping a minor or major version: - [ ] Manually change `version_short` in `package.json` - [ ] Add docs version to `site/data/docs-versions.yml` - [ ] Manually change `docs_version` in `hugo.yml` and other references to the previous version - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?) - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1` - [ ] Increment `site/static/docs/{version}` version - [ ] Increment version in `nuget/boosted.nuspec` - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec` - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md` - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed! - :warning: `site/content/docs/5.1/**/*.md` should not always be modified - [ ] if year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities and main file) as well as in `NOTICE.txt`. - [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc and package the release - [ ] Prepare changelog: - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally - run `conventional-changelog -p angular -i CHANGELOG.md -s` - and probably maintain [a ship list (eg for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226) - [ ] commit and push `dist` with a `chore(release)` commit message - [ ] Manually run BrowserStack test - [ ] Manually run Percy test - [ ] merge (on `v4-dev` or `main`) - [ ] tag your version, and push your tag - [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new): - attach zip file - paste CHANGELOG / Ship list in the release's description - [ ] Pack and publish - `npm pack` - if you are already logged in NPM (with a personnal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally) - Publish: - if you're releasing a pre-release, use `--tag`, eg for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next` - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it) - (v5 only) `npm publish` - [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages) - [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)… - [ ] publish documentation on `gh-pages`: - [ ] copy `../_site` to the `gh-pages` branch (don't forget to update Storybook as well) - [ ] check every `index.html` used as redirections to be redirecting to the new release - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurences - [ ] make an announcement in Plazza :tada: -->