### PR TITLE
chore(template): change last release step in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -132,5 +132,5 @@ _Note: Please transform `- [ ]` into `- (NA)` in the description when things are
   - [ ] check every `index.html` used as redirections to be redirecting to the new release
   - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
   - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurences
-- [ ] make an announcement in Plazza :tada:
+- [ ] make an announcement in [GitHub Discussions](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/discussions/categories/announcements) and internal communication channels :tada:
 -->


### PR DESCRIPTION
Just a minor change in the last step mentioned in the PR template. Needs to be merged after the v5.3.0 release. No need for a review.