### PR TITLE
Popover tour: prototype for an example

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -18,7 +18,7 @@ import TemplateFactory from './util/template-factory.js'
  */
 
 const NAME = 'tooltip'
-const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
+const DISALLOWED_ATTRIBUTES = new Set(['allowList', 'sanitizeFn'])
 
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_MODAL = 'modal'
@@ -211,6 +211,8 @@ class Tooltip extends BaseComponent {
       EventHandler.trigger(this._element, this.constructor.eventName(EVENT_INSERTED))
     }
 
+    // eslint-disable-next-line no-console
+    console.log(tip)
     this._popper = this._createPopper(tip)
 
     tip.classList.add(CLASS_NAME_SHOW)

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -211,8 +211,6 @@ class Tooltip extends BaseComponent {
       EventHandler.trigger(this._element, this.constructor.eventName(EVENT_INSERTED))
     }
 
-    // eslint-disable-next-line no-console
-    console.log(tip)
     this._popper = this._createPopper(tip)
 
     tip.classList.add(CLASS_NAME_SHOW)

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1808,7 +1808,7 @@ $popover-header-color:              $headings-color !default;
 $popover-header-padding-top:        $popover-padding-y !default; // Boosted mod
 $popover-header-padding-bottom:     map-get($spacers, 2) !default; // Boosted mod
 $popover-header-padding-y:          initial !default; // Boosted mod: instead of `.5rem`
-$popover-header-padding-x:          $spacer * .9 !default; // Boosted mod: instead of `$spacer`
+$popover-header-padding-x:          $spacer !default; // Boosted mod: instead of `$spacer`
 
 $popover-body-color:                var(--#{$prefix}body-color) !default;
 $popover-body-padding-top:          0 !default; // Boosted mod

--- a/site/content/docs/5.3/examples/popover-tour-backdrop/index.html
+++ b/site/content/docs/5.3/examples/popover-tour-backdrop/index.html
@@ -21,7 +21,7 @@ aliases:
   </symbol>
 </svg>
 
-<header class="">
+<header>
   <nav class="navbar navbar-dark navbar-expand-lg bg-dark supra" aria-label="Supra navigation - Popover tour example">
     <div class="container-xxl">
       <ul class="navbar-nav me-auto">
@@ -51,11 +51,11 @@ aliases:
           <li class="nav-item"><a class="nav-link" href="#">Services</a></li>
           <li class="nav-item"><a class="nav-link" href="#">Entertainment</a></li>
           <li class="nav-item"><a class="nav-link" href="#">News</a></li>
-          <li class="nav-item position-relative" style="z-index: 2000;">
+          <li class="nav-item position-relative">
             <a class="nav-link" href="#">Support</a>
 
             <div id="popover-tour-1" class="position-absolute top-100 start-50 translate-middle-x d-flex" data-bs-theme="light">
-              <button type="button" class="btn border-0" data-bs-container="#popover-tour-1" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-offset="0,0" data-bs-custom-class="popover-width"
+              <button type="button" tabindex="-1" class="popover-trigger visually-hidden" data-bs-container="#popover-tour-1" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-custom-class="popover-width"
                       data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;' data-bs-toggle='tooltip' data-bs-placement='bottom' data-bs-title='Close' data-bs-dismiss='popover' data-bs-container='.popover-header'><span class='visually-hidden'>Close</span></button>"
                       data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
                                        <div class='d-flex justify-content-between align-items-end pt-1'>
@@ -119,7 +119,7 @@ aliases:
     <div class="container-xxl">
       <h1 class="display-1">Title</h1>
       <div class="d-flex ms-auto">
-        <div class="position-relative bg-body" style="z-index:2000;">
+        <div class="position-relative bg-body">
           <a href="#">
             <svg xmlns="http://www.w3.org/2000/svg" width="1.875rem" height="1.875rem" focusable="false" aria-hidden="true">
               <use xlink:href="#notification-alert"/>
@@ -128,7 +128,7 @@ aliases:
           </a>
 
           <div id="popover-tour-2" class="position-absolute top-100 start-50 translate-middle-x d-flex">
-            <button type="button" class="btn border-0" data-bs-container="#popover-tour-2" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-offset="0,0" data-bs-custom-class="popover-width"
+            <button type="button" tabindex="-1" class="popover-trigger visually-hidden" data-bs-container="#popover-tour-2" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-custom-class="popover-width"
                     data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;' data-bs-toggle='tooltip' data-bs-placement='bottom' data-bs-title='Close' data-bs-dismiss='popover' data-bs-container='.popover-header'><span class='visually-hidden'>Close</span></button>"
                     data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
                                      <div class='d-flex justify-content-between align-items-end pt-1'>
@@ -162,11 +162,11 @@ aliases:
   <div class="border-bottom border-1 border-light custom-local-nav">
     <div class="container-xxl">
       <ul class="navbar-nav flex-row gap-3 py-2">
-        <li class="nav-item position-relative py-1 bg-body" style="z-index: 2000;">
+        <li class="nav-item position-relative py-1 bg-body">
           <a class="nav-link" href="#">Label</a>
 
           <div id="popover-tour-3" class="position-absolute top-100 start-50 translate-middle-x d-flex">
-            <button type="button" class="btn border-0" data-bs-container="#popover-tour-3" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-offset="0,0" data-bs-custom-class="popover-width"
+            <button type="button" tabindex="-1" class="popover-trigger visually-hidden" data-bs-container="#popover-tour-3" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-custom-class="popover-width"
                     data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;' data-bs-toggle='tooltip' data-bs-placement='bottom' data-bs-title='Close' data-bs-dismiss='popover' data-bs-container='.popover-header'><span class='visually-hidden'>Close</span></button>"
                     data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
                                      <div class='d-flex justify-content-between align-items-end pt-1'>

--- a/site/content/docs/5.3/examples/popover-tour-backdrop/index.html
+++ b/site/content/docs/5.3/examples/popover-tour-backdrop/index.html
@@ -21,7 +21,7 @@ aliases:
   </symbol>
 </svg>
 
-<header class="sticky-top">
+<header class="">
   <nav class="navbar navbar-dark navbar-expand-lg bg-dark supra" aria-label="Supra navigation - Popover tour example">
     <div class="container-xxl">
       <ul class="navbar-nav me-auto">
@@ -51,13 +51,22 @@ aliases:
           <li class="nav-item"><a class="nav-link" href="#">Services</a></li>
           <li class="nav-item"><a class="nav-link" href="#">Entertainment</a></li>
           <li class="nav-item"><a class="nav-link" href="#">News</a></li>
-          <li class="nav-item position-relative">
+          <li class="nav-item position-relative" style="z-index: 2000;">
             <a class="nav-link" href="#">Support</a>
 
             <div id="popover-tour-1" class="position-absolute top-100 start-50 translate-middle-x d-flex" data-bs-theme="light">
-              <button type="button" class="popover-trigger" data-bs-container="#popover-tour-1" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-offset="0,20" data-bs-custom-class="popover-width"
+              <button type="button" class="btn border-0" data-bs-container="#popover-tour-1" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-offset="0,0" data-bs-custom-class="popover-width"
                       data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;' data-bs-toggle='tooltip' data-bs-placement='bottom' data-bs-title='Close' data-bs-dismiss='popover' data-bs-container='.popover-header'><span class='visually-hidden'>Close</span></button>"
-                      data-bs-content="<p class='mb-0'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>">
+                      data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
+                                       <div class='d-flex justify-content-between align-items-end pt-1'>
+                                         <p class=' mb-0 fw-bold'>1 of 5</p>
+                                         <nav aria-label='Popover navigation'>
+                                           <ul class='pagination m-0'>
+                                             <li class='page-item disabled'><a class='page-link' aria-label='Previous'></a></li>
+                                             <li class='page-item'><a href='#' class='page-link' aria-label='Next'></a></li>
+                                           </ul>
+                                         </nav>
+                                       </div>">
                 <span class="visually-hidden">Popover tour for alerts</span>
               </button>
             </div>
@@ -110,7 +119,7 @@ aliases:
     <div class="container-xxl">
       <h1 class="display-1">Title</h1>
       <div class="d-flex ms-auto">
-        <div class="position-relative">
+        <div class="position-relative bg-body" style="z-index:2000;">
           <a href="#">
             <svg xmlns="http://www.w3.org/2000/svg" width="1.875rem" height="1.875rem" focusable="false" aria-hidden="true">
               <use xlink:href="#notification-alert"/>
@@ -119,9 +128,18 @@ aliases:
           </a>
 
           <div id="popover-tour-2" class="position-absolute top-100 start-50 translate-middle-x d-flex">
-            <button type="button" class="popover-trigger" data-bs-container="#popover-tour-2" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-offset="0,20" data-bs-custom-class="popover-width"
+            <button type="button" class="btn border-0" data-bs-container="#popover-tour-2" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-offset="0,0" data-bs-custom-class="popover-width"
                     data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;' data-bs-toggle='tooltip' data-bs-placement='bottom' data-bs-title='Close' data-bs-dismiss='popover' data-bs-container='.popover-header'><span class='visually-hidden'>Close</span></button>"
-                    data-bs-content="<p class='mb-0'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>">
+                    data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
+                                     <div class='d-flex justify-content-between align-items-end pt-1'>
+                                       <p class=' mb-0 fw-bold'>1 of 5</p>
+                                       <nav aria-label='Popover navigation'>
+                                         <ul class='pagination m-0'>
+                                           <li class='page-item disabled'><a class='page-link' aria-label='Previous'></a></li>
+                                           <li class='page-item'><a href='#' class='page-link' aria-label='Next'></a></li>
+                                         </ul>
+                                       </nav>
+                                     </div>">
               <span class="visually-hidden">Popover tour for alerts</span>
             </button>
           </div>
@@ -144,13 +162,22 @@ aliases:
   <div class="border-bottom border-1 border-light custom-local-nav">
     <div class="container-xxl">
       <ul class="navbar-nav flex-row gap-3 py-2">
-        <li class="nav-item position-relative py-1">
+        <li class="nav-item position-relative py-1 bg-body" style="z-index: 2000;">
           <a class="nav-link" href="#">Label</a>
 
           <div id="popover-tour-3" class="position-absolute top-100 start-50 translate-middle-x d-flex">
-            <button type="button" class="popover-trigger" data-bs-container="#popover-tour-3" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-offset="0,20" data-bs-custom-class="popover-width"
+            <button type="button" class="btn border-0" data-bs-container="#popover-tour-3" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-offset="0,0" data-bs-custom-class="popover-width"
                     data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;' data-bs-toggle='tooltip' data-bs-placement='bottom' data-bs-title='Close' data-bs-dismiss='popover' data-bs-container='.popover-header'><span class='visually-hidden'>Close</span></button>"
-                    data-bs-content="<p class='mb-0'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>">
+                    data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
+                                     <div class='d-flex justify-content-between align-items-end pt-1'>
+                                       <p class=' mb-0 fw-bold'>1 of 5</p>
+                                       <nav aria-label='Popover navigation'>
+                                         <ul class='pagination m-0'>
+                                           <li class='page-item disabled'><a class='page-link' aria-label='Previous'></a></li>
+                                           <li class='page-item'><a href='#' class='page-link' aria-label='Next'></a></li>
+                                         </ul>
+                                       </nav>
+                                     </div>">
               <span class="visually-hidden">Popover tour for alerts</span>
             </button>
           </div>

--- a/site/content/docs/5.3/examples/popover-tour-backdrop/index.html
+++ b/site/content/docs/5.3/examples/popover-tour-backdrop/index.html
@@ -6,7 +6,7 @@ extra_css:
 extra_js:
   - src: "popover-tour.js"
 aliases:
-  - "/docs/examples/popover-tour"
+  - "/docs/examples/popover-tour-backdrop"
 ---
 
 <svg xmlns="http://www.w3.org/2000/svg" class="d-none">

--- a/site/content/docs/5.3/examples/popover-tour-backdrop/index.html
+++ b/site/content/docs/5.3/examples/popover-tour-backdrop/index.html
@@ -59,11 +59,11 @@ aliases:
                       data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;' data-bs-toggle='tooltip' data-bs-placement='bottom' data-bs-title='Close' data-bs-dismiss='popover' data-bs-container='.popover-header'><span class='visually-hidden'>Close</span></button>"
                       data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
                                        <div class='d-flex justify-content-between align-items-end pt-1'>
-                                         <p class=' mb-0 fw-bold'>1 of 5</p>
+                                         <p class=' mb-0 fw-bold'>1 of 3</p>
                                          <nav aria-label='Popover navigation'>
                                            <ul class='pagination m-0'>
                                              <li class='page-item disabled'><a class='page-link' aria-label='Previous'></a></li>
-                                             <li class='page-item'><a href='#' class='page-link' aria-label='Next'></a></li>
+                                             <li class='page-item'><a href='#popover-tour-2' class='page-link' aria-label='Next'></a></li>
                                            </ul>
                                          </nav>
                                        </div>">
@@ -132,11 +132,11 @@ aliases:
                     data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;' data-bs-toggle='tooltip' data-bs-placement='bottom' data-bs-title='Close' data-bs-dismiss='popover' data-bs-container='.popover-header'><span class='visually-hidden'>Close</span></button>"
                     data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
                                      <div class='d-flex justify-content-between align-items-end pt-1'>
-                                       <p class=' mb-0 fw-bold'>1 of 5</p>
+                                       <p class=' mb-0 fw-bold'>2 of 3</p>
                                        <nav aria-label='Popover navigation'>
                                          <ul class='pagination m-0'>
-                                           <li class='page-item disabled'><a class='page-link' aria-label='Previous'></a></li>
-                                           <li class='page-item'><a href='#' class='page-link' aria-label='Next'></a></li>
+                                           <li class='page-item'><a href='#popover-tour-1' class='page-link' aria-label='Previous'></a></li>
+                                           <li class='page-item'><a href='#popover-tour-3' class='page-link' aria-label='Next'></a></li>
                                          </ul>
                                        </nav>
                                      </div>">
@@ -170,11 +170,11 @@ aliases:
                     data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;' data-bs-toggle='tooltip' data-bs-placement='bottom' data-bs-title='Close' data-bs-dismiss='popover' data-bs-container='.popover-header'><span class='visually-hidden'>Close</span></button>"
                     data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
                                      <div class='d-flex justify-content-between align-items-end pt-1'>
-                                       <p class=' mb-0 fw-bold'>1 of 5</p>
+                                       <p class=' mb-0 fw-bold'>3 of 3</p>
                                        <nav aria-label='Popover navigation'>
                                          <ul class='pagination m-0'>
-                                           <li class='page-item disabled'><a class='page-link' aria-label='Previous'></a></li>
-                                           <li class='page-item'><a href='#' class='page-link' aria-label='Next'></a></li>
+                                           <li class='page-item'><a href='#popover-tour-2' class='page-link' aria-label='Previous'></a></li>
+                                           <li class='page-item disabled'><a class='page-link' aria-label='Next'></a></li>
                                          </ul>
                                        </nav>
                                      </div>">

--- a/site/content/docs/5.3/examples/popover-tour-backdrop/popover-tour.css
+++ b/site/content/docs/5.3/examples/popover-tour-backdrop/popover-tour.css
@@ -1,0 +1,51 @@
+html,
+body {
+  height: 100%;
+}
+
+.title-bar h1 + * {
+  padding: .666666em 0 .333333em;
+  margin-right: -1.25rem;
+}
+
+.title-bar svg {
+  width: 1.875rem;
+  height: 1.875rem;
+  margin: 0 1.25rem;
+}
+
+.custom-local-nav {
+  height: 50px;
+}
+
+.popover-width {
+  width: 23.75rem;
+}
+
+.popover-trigger {
+  position: relative;
+  width: 1.25rem;
+  height: 1.25rem;
+  background-color: #527edb;
+  border: 0;
+  border-radius: 50rem;
+  /* stylelint-disable-next-line declaration-no-important */
+  box-shadow: 0 0 0 0 #527ebd88 !important;
+  transition: box-shadow .3s ease;
+}
+
+.popover-trigger::after {
+  position: absolute;
+  top: -.625rem;
+  right: -.625rem;
+  bottom: -.625rem;
+  left: -.625rem;
+  content: "";
+  border-radius: 1.25rem;
+}
+
+.popover-trigger:hover,
+.popover-trigger[aria-describedby] {
+  /* stylelint-disable-next-line declaration-no-important */
+  box-shadow: 0 0 0 10px #527ebd88 !important;
+}

--- a/site/content/docs/5.3/examples/popover-tour-backdrop/popover-tour.js
+++ b/site/content/docs/5.3/examples/popover-tour-backdrop/popover-tour.js
@@ -22,4 +22,6 @@
       })
     })
   })
+
+  boosted.Modal.getOrCreateInstance('body')._initializeBackDrop().show()
 })()

--- a/site/content/docs/5.3/examples/popover-tour-backdrop/popover-tour.js
+++ b/site/content/docs/5.3/examples/popover-tour-backdrop/popover-tour.js
@@ -13,15 +13,42 @@
       new boosted.Tooltip(tooltip)
     })
 
+  // Handling backdrop
+  const backdrop = document.createElement('div')
+  backdrop.classList.add('modal-backdrop', 'fade', 'show')
+  document.body.append(backdrop)
+  // backdrop.addEventListener('click', () => {
+  //   document.querySelectorAll('[data-bs-toggle="popover"]').forEach(popover => {
+  //     boosted.Popover.getOrCreateInstance(popover).hide()
+  //     popover.parentElement.remove()
+  //   })
+  //   backdrop.remove()
+  // })
+
+  // Show tooltips and hide popover on close button click
   document.addEventListener('shown.bs.popover', event => {
     const element = event.target
     element.parentElement.querySelectorAll('.btn-close').forEach(closeBtn => {
       boosted.Tooltip.getOrCreateInstance(closeBtn)
       closeBtn.addEventListener('click', () => {
         boosted.Popover.getOrCreateInstance(element).hide()
+        backdrop.remove()
+        document.querySelectorAll('[data-bs-toggle="popover"]').forEach(popover => {
+          boosted.Popover.getOrCreateInstance(popover).hide()
+          popover.parentElement.remove()
+        })
       })
+    })
+    element.parentElement.querySelectorAll('[href]').forEach(link => {
+      if (link.getAttribute('href').startsWith('#')) {
+        link.addEventListener('click', () => {
+          document.querySelector(`${link.getAttribute('href')} [data-bs-toggle="popover"]`).click()
+          boosted.Popover.getOrCreateInstance(element).hide()
+        })
+      }
     })
   })
 
-  boosted.Modal.getOrCreateInstance('body')._initializeBackDrop().show()
+  // Show first popover
+  boosted.Popover.getOrCreateInstance(document.querySelector('[data-bs-toggle="popover"]')).show()
 })()

--- a/site/content/docs/5.3/examples/popover-tour-backdrop/popover-tour.js
+++ b/site/content/docs/5.3/examples/popover-tour-backdrop/popover-tour.js
@@ -44,7 +44,7 @@
     element.parentElement.querySelectorAll('[href]').forEach(link => {
       if (link.getAttribute('href').startsWith('#')) {
         link.addEventListener('click', () => {
-          document.querySelector(`${link.getAttribute('href')} [data-bs-toggle="popover"]`).click()
+          boosted.Popover.getOrCreateInstance(document.querySelector(`${link.getAttribute('href')} [data-bs-toggle="popover"]`)).show()
           boosted.Popover.getOrCreateInstance(element).hide()
           element.parentElement.parentElement.style.zIndex = null
         })

--- a/site/content/docs/5.3/examples/popover-tour-backdrop/popover-tour.js
+++ b/site/content/docs/5.3/examples/popover-tour-backdrop/popover-tour.js
@@ -8,11 +8,6 @@
     new boosted.Popover(popover)
   })
 
-  document.querySelectorAll('[data-bs-toggle="tooltip"]')
-    .forEach(tooltip => {
-      new boosted.Tooltip(tooltip)
-    })
-
   // Handling backdrop
   const backdrop = document.createElement('div')
   backdrop.classList.add('modal-backdrop', 'fade', 'show')
@@ -28,27 +23,74 @@
   // Show tooltips and hide popover on close button click
   document.addEventListener('shown.bs.popover', event => {
     const element = event.target
+    element.parentElement.parentElement.style.zIndex = '2000'
+    focusTrap(element.parentElement.parentElement)
+
     element.parentElement.querySelectorAll('.btn-close').forEach(closeBtn => {
       boosted.Tooltip.getOrCreateInstance(closeBtn)
+
       closeBtn.addEventListener('click', () => {
+        element.parentElement.parentElement.style.zIndex = null
         boosted.Popover.getOrCreateInstance(element).hide()
         backdrop.remove()
+
         document.querySelectorAll('[data-bs-toggle="popover"]').forEach(popover => {
           boosted.Popover.getOrCreateInstance(popover).hide()
           popover.parentElement.remove()
         })
       })
     })
+
     element.parentElement.querySelectorAll('[href]').forEach(link => {
       if (link.getAttribute('href').startsWith('#')) {
         link.addEventListener('click', () => {
           document.querySelector(`${link.getAttribute('href')} [data-bs-toggle="popover"]`).click()
           boosted.Popover.getOrCreateInstance(element).hide()
+          element.parentElement.parentElement.style.zIndex = null
         })
       }
     })
   })
 
+  const focusTrap = element => {
+    const focusableEls = element.querySelectorAll('a[href]:not([disabled]), button:not([disabled])')
+    const firstFocusableEl = focusableEls[0]
+    const lastFocusableEl = focusableEls[focusableEls.length - 1]
+    firstFocusableEl.focus()
+
+    const keydownHandler = e => {
+      const isTabPressed = (e.key === 'Tab')
+
+      if (!isTabPressed) {
+        return
+      }
+
+      if (element.contains(document.activeElement)) {
+        if (e.shiftKey) /* shift + tab */ {
+          if (document.activeElement === firstFocusableEl) {
+            lastFocusableEl.focus()
+            e.preventDefault()
+          }
+        } else if (document.activeElement === lastFocusableEl) {
+          firstFocusableEl.focus()
+          e.preventDefault()
+        }
+      } else {
+        document.removeEventListener('keydown', keydownHandler)
+      }
+    }
+
+    document.addEventListener('keydown', keydownHandler)
+
+    document.addEventListener('click', e => {
+      if (!element.contains(e.target)) {
+        firstFocusableEl.focus()
+      }
+    })
+  }
+
   // Show first popover
   boosted.Popover.getOrCreateInstance(document.querySelector('[data-bs-toggle="popover"]')).show()
+  document.querySelector('[data-bs-toggle="popover"]').parentElement.parentElement.style.zIndex = '2000'
+  focusTrap(document.querySelector('[data-bs-toggle="popover"]').parentElement.parentElement)
 })()

--- a/site/content/docs/5.3/examples/popover-tour/index.html
+++ b/site/content/docs/5.3/examples/popover-tour/index.html
@@ -1,0 +1,92 @@
+---
+layout: examples
+title: Popover tour
+extra_css:
+  - "popover-tour.css"
+extra_js:
+  - src: "popover-tour.js"
+aliases:
+  - "/docs/examples/popover-tour"
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" class="d-none">
+  <symbol fill="currentColor" viewBox="0 0 24 24" id="notification-alert">
+    <path d="M12 22.2a2.4 2.4 0 0 0 2.4-2.4H9.6a2.4 2.4 0 0 0 2.4 2.4Zm8.458-3.909L19.2 16.2v-5.952c0-3.348-2.3-6.203-5.4-7.016V3a1.8 1.8 0 0 0-3.6 0v.227A7.201 7.201 0 0 0 4.8 10.2v6l-1.258 2.091a.6.6 0 0 0 .515.909h15.886a.6.6 0 0 0 .515-.909Z"/>
+  </symbol>
+  <symbol fill="currentColor" viewBox="0 0 24 24" id="reload">
+    <path d="M18.789 5.212a9.6 9.6 0 1 0 0 13.576l-2.546-2.545a6 6 0 1 1 0-8.486v.001L13.802 10.2H19.8A1.2 1.2 0 0 0 21 9V3l-2.211 2.212Z"/>
+  </symbol>
+  <symbol fill="currentColor" viewBox="0 0 24 24" id="settings">
+    <path d="M19.862 12.012c0-2.655 2.897-.646 1.548-3.902-1.35-3.257-1.977.211-3.855-1.666-1.877-1.877 1.592-2.504-1.664-3.853-3.257-1.349-1.249 1.547-3.903 1.547-2.655 0-.646-2.896-3.902-1.547-3.257 1.349.211 1.976-1.666 3.853-1.877 1.877-2.505-1.59-3.854 1.666-1.35 3.256 1.548 1.247 1.548 3.902 0 2.655-2.897.646-1.548 3.902 1.35 3.257 1.977-.211 3.854 1.665 1.877 1.877-1.591 2.505 1.666 3.854 3.256 1.349 1.247-1.547 3.902-1.547 2.654 0 .646 2.896 3.903 1.547 3.256-1.349-.213-1.977 1.664-3.854 1.878-1.876 2.505 1.592 3.855-1.665 1.349-3.256-1.548-1.247-1.548-3.902ZM12 7.224a4.8 4.8 0 1 1 0 9.6 4.8 4.8 0 0 1 0-9.6Z"/>
+  </symbol>
+</svg>
+
+<header class="sticky-top">
+  {{< orange-supra aria_label="Supra navigation - Popover tour example" >}}
+  {{< /orange-supra >}}
+
+  {{< orange-global-headers id="global-header-1" mode="actions" supra=true aria_label="Global navigation - Popover tour example" >}}
+  {{< /orange-global-headers >}}
+</header>
+
+<main>
+  <div class="bg-body title-bar">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+      <div class="d-flex ms-auto">
+        <div class="position-relative">
+          <a href="#">
+            <svg xmlns="http://www.w3.org/2000/svg" width="1.875rem" height="1.875rem" focusable="false" aria-hidden="true">
+              <use xlink:href="#notification-alert"/>
+            </svg>
+            <span class="visually-hidden">Alerts</span>
+          </a>
+
+          <div class="position-absolute top-100 start-50 translate-middle">
+            <button type="button" class="popover-trigger" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false"
+                    data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;'><span class='visually-hidden' data-bs-dismiss='popover'>Close</span></button>"
+                    data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
+                                     <div class='d-flex justify-content-between align-items-end pt-1'>
+                                       <p class=' mb-0 fw-bold'>1 of 5</p>
+                                       <nav aria-label='Popover navigation'>
+                                         <ul class='pagination m-0'>
+                                           <li class='page-item disabled'><a class='page-link' aria-label='Previous'></a></li>
+                                           <li class='page-item'><a href='#' class='page-link' aria-label='Next'></a></li>
+                                         </ul>
+                                       </nav>
+                                     </div>">
+              <span class="visually-hidden">Popover on bottom</span>
+            </button>
+          </div>
+        </div>
+        <a href="#">
+          <svg xmlns="http://www.w3.org/2000/svg" width="1.875rem" height="1.875rem" focusable="false" aria-hidden="true">
+            <use xlink:href="#reload"/>
+          </svg>
+          <span class="visually-hidden">Reload</span>
+        </a>
+        <a href="#">
+          <svg xmlns="http://www.w3.org/2000/svg" width="1.875rem" height="1.875rem" focusable="false" aria-hidden="true">
+            <use xlink:href="#settings"/>
+          </svg>
+          <span class="visually-hidden">Settings</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div class="border-bottom border-1 border-light custom-local-nav"></div>
+</main>
+
+<footer class="footer bg-dark navbar-dark position-sticky top-100">
+  <h2 class="visually-hidden">Sitemap & information</h2>
+  <div class="container-xxl footer-terms">
+    <ul class="navbar-nav gap-md-3">
+      <li class="fw-bold">© Orange {{< year >}}</li>
+      <li><a class="nav-link" href="https://system.design.orange.com/0c1af118d/p/0127c5-the-orange-design-system/b/135b17" target="_blank" rel="noopener">Terms and conditions</a></li>
+      <li><a class="nav-link" href="https://system.design.orange.com/" target="_blank" rel="noopener">Orange Design System website</a></li>
+      <li><a class="nav-link" href="https://boosted.orange.com/">Boosted</a></li>
+      <li><a class="nav-link" href="https://brand.orange.com/" target="_blank" rel="noopener">Orange Brand website</a></li>
+      <li><a class="nav-link" href="https://developer.orange.com/" target="_blank" rel="noopener">Orange developer website</a></li>
+    </ul>
+  </div>
+</footer>

--- a/site/content/docs/5.3/examples/popover-tour/index.html
+++ b/site/content/docs/5.3/examples/popover-tour/index.html
@@ -42,8 +42,8 @@ aliases:
             <span class="visually-hidden">Alerts</span>
           </a>
 
-          <div class="position-absolute top-100 start-50 translate-middle">
-            <button type="button" class="popover-trigger" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false"
+          <div id="test2" class="position-absolute top-100 start-50 translate-middle h-auto">
+            <button type="button" class="popover-trigger" data-bs-container="#test2" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-sanitize="false" data-bs-offset="0,20" data-bs-custom-class="popover-width"
                     data-bs-title="Popover header<button class='btn-close float-end' style='margin: -10px;'><span class='visually-hidden' data-bs-dismiss='popover'>Close</span></button>"
                     data-bs-content="<p class='mb-3'>Purus sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus dolor purus non enim praesent elementum facilisis.</p>
                                      <div class='d-flex justify-content-between align-items-end pt-1'>
@@ -55,7 +55,7 @@ aliases:
                                          </ul>
                                        </nav>
                                      </div>">
-              <span class="visually-hidden">Popover on bottom</span>
+              <span class="visually-hidden">Popover tour for alerts</span>
             </button>
           </div>
         </div>

--- a/site/content/docs/5.3/examples/popover-tour/popover-tour.css
+++ b/site/content/docs/5.3/examples/popover-tour/popover-tour.css
@@ -1,0 +1,47 @@
+html,
+body {
+  height: 100%;
+}
+
+.title-bar .d-flex {
+  padding: .666666em 0 .333333em;
+  margin-right: -1.25rem;
+}
+
+.title-bar svg {
+  width: 1.875rem;
+  height: 1.875rem;
+  margin: 0 1.25rem;
+}
+
+.custom-local-nav {
+  height: 50px;
+}
+
+.popover-trigger {
+  position: relative;
+  width: 1.25rem;
+  height: 1.25rem;
+  background-color: #527edb;
+  border: 0;
+  border-radius: 50rem;
+  /* stylelint-disable-next-line declaration-no-important */
+  box-shadow: 0 0 0 0 #527ebd88 !important;
+  transition: box-shadow .3s ease;
+}
+
+.popover-trigger::after {
+  position: absolute;
+  top: -.625rem;
+  right: -.625rem;
+  bottom: -.625rem;
+  left: -.625rem;
+  content: "";
+  border-radius: 1.25rem;
+}
+
+.popover-trigger:hover,
+.popover-trigger[aria-describedby] {
+  /* stylelint-disable-next-line declaration-no-important */
+  box-shadow: 0 0 0 10px #527ebd88 !important;
+}

--- a/site/content/docs/5.3/examples/popover-tour/popover-tour.css
+++ b/site/content/docs/5.3/examples/popover-tour/popover-tour.css
@@ -3,7 +3,7 @@ body {
   height: 100%;
 }
 
-.title-bar .d-flex {
+.title-bar h1 + * {
   padding: .666666em 0 .333333em;
   margin-right: -1.25rem;
 }
@@ -16,6 +16,10 @@ body {
 
 .custom-local-nav {
   height: 50px;
+}
+
+.popover-width {
+  width: 23.75rem;
 }
 
 .popover-trigger {

--- a/site/content/docs/5.3/examples/popover-tour/popover-tour.js
+++ b/site/content/docs/5.3/examples/popover-tour/popover-tour.js
@@ -1,0 +1,15 @@
+/* global boosted: false */
+
+(() => {
+  'use strict'
+
+  document.querySelectorAll('[data-bs-toggle="popover"]')
+  .forEach(popover => {
+    new boosted.Popover(popover)
+  })
+
+  document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    .forEach(tooltip => {
+      new boosted.Tooltip(tooltip)
+    })
+})()

--- a/site/content/docs/5.3/examples/popover-tour/popover-tour.js
+++ b/site/content/docs/5.3/examples/popover-tour/popover-tour.js
@@ -12,4 +12,13 @@
     .forEach(tooltip => {
       new boosted.Tooltip(tooltip)
     })
+
+  document.addEventListener('shown.bs.popover', event => {
+    const element = event.target
+    element.parentElement.querySelectorAll('.btn-close').forEach(closeBtn => {
+      closeBtn.addEventListener('click', () => {
+        boosted.Popover.getOrCreateInstance(element).hide()
+      })
+    })
+  })
 })()


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Tried a different approach from #607.

### Description

Trying a way to develop the popover tour using Popovers.
It's missing much a11y and design features, this PR is just to show a draft and see the contraints on this implementation compared to modals.
Some things might be hardly homemade for time reasons.
Some basic things seems to be missing from the bundle such as focustrap and backdrop.

This solution looks far from ideal because:
- Reusability: Should we implement a component ?
- Refreshing the page leads to regenerate all the mechanism: Should we introduce a localStorage or a way to deactivate it when not needed ?
- Uses much js: 3 steps need ~100lines of js
- More ...

### Motivation & Context

See if the tour is feasible using only Popovers.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2190--boosted.netlify.app/docs/examples/popover-tour>
- <https://deploy-preview-2190--boosted.netlify.app/docs/examples/popover-tour-backdrop>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- (NA) I have added JavaScript unit tests to cover my changes
- (NA) I have added SCSS unit tests to cover my changes

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-2190--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)

<!------------------------>
<!-- /!\ Core Team Only -->
<!------------------------>

<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `hugo.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
    - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
- [ ] if the year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities, and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc, and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (e.g. for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] merge (on `v4-dev` or `main`)
- [ ] tag your version, and push your tag
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach the zip file
  - paste the CHANGELOG / Ship list in the release's description
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in to NPM (with a personal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you're releasing a pre-release, use `--tag`, e.g. for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch (don't forget to update Storybook as well)
  - [ ] check every `index.html` used as redirections to redirect to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurrences
- [ ] make an announcement in [GitHub Discussions](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/discussions/categories/announcements) (+ pin the new GH Discussion) and internal communication channels :tada:
-->