### PR TITLE
chore(workflows): drop skip:ci and skip:pa11y

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -15,7 +15,7 @@ jobs:
   browserstack:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: "!(contains(github.event.*.labels.*.name, 'skip:ci') || github.actor == 'dependabot[bot]')"
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Clone repository

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -7,7 +7,7 @@ on:
       - 'js/**'
       - 'scss/**'
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 env:
@@ -20,7 +20,7 @@ permissions:
 jobs:
   bundlewatch:
     runs-on: ubuntu-latest
-    if: "!(contains(github.event.*.labels.*.name, 'skip:ci') || github.actor == 'dependabot[bot]')"
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Clone repository

--- a/.github/workflows/cspell.yml
+++ b/.github/workflows/cspell.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 env:
@@ -21,7 +21,7 @@ jobs:
       contents: read
       pull-requests: read
     runs-on: ubuntu-latest
-    if: "!(contains(github.event.*.labels.*.name, 'skip:ci') || github.actor == 'dependabot[bot]')"
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Clone repository

--- a/.github/workflows/css.yml
+++ b/.github/workflows/css.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - "scss/**"
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 env:
@@ -19,7 +19,7 @@ permissions:
 jobs:
   css:
     runs-on: ubuntu-latest
-    if: "!(contains(github.event.*.labels.*.name, 'skip:ci') || github.actor == 'dependabot[bot]') || github.event_name == 'workflow_dispatch'"
+    if: github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Clone repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
       - 'scss/**'
       - 'site/**'
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 env:
@@ -21,7 +21,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: "!(contains(github.event.*.labels.*.name, 'skip:ci') || github.actor == 'dependabot[bot]')"
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Clone repository

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'js/**'
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 env:
@@ -24,7 +24,7 @@ jobs:
       contents: read
     name: JS Tests
     runs-on: ubuntu-latest
-    if: "!(contains(github.event.*.labels.*.name, 'skip:ci') || github.actor == 'dependabot[bot]')"
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Clone repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
       - 'js/**'
       - 'scss/**'
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 env:
@@ -20,7 +20,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    if: "!(contains(github.event.*.labels.*.name, 'skip:ci') || github.actor == 'dependabot[bot]')"
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Clone repository

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'scss/**'
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 env:
@@ -19,7 +19,7 @@ permissions:
 jobs:
   css:
     runs-on: ubuntu-latest
-    if: "!(contains(github.event.*.labels.*.name, 'skip:ci') || github.actor == 'dependabot[bot]')"
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Clone repository

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -8,7 +8,7 @@ on:
       - 'scss/**'
       - 'site/**'
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 env:
@@ -18,7 +18,7 @@ env:
 jobs:
   pa11y:
     runs-on: ubuntu-latest
-    if: "!(contains(github.event.*.labels.*.name, 'skip:ci') || contains(github.event.*.labels.*.name, 'skip:pa11y') || github.actor == 'dependabot[bot]')"
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
### Description

This PR drops the `labeled` and `unlabeled` workflows triggers to handle `skip:ci` and `skip:pa11y` GH labels.

### Motivation & Context

The recent workflows added to handle our board add and remove labels which triggers several times all the jobs... Skipping CI jobs is native (source: https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs) so `skip:ci` can be removed safely and is rarely used anyway. There's no native `skip:pa11y` but it's also rarely used so it can be safely removed as well IMO.

### Types of change

- Enhancement (non-breaking change which adds functionality)

### Checklist

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

### Checklist (for Core Team only)

#### After the merge

- [x] Drop `skip:ci` label
- [x] Drop `skip:pa11y` label
