### PR TITLE
fix(docs): add missing `/examples/download-app` redirection

### DIFF
--- a/site/content/docs/5.3/examples/download-app/index.html
+++ b/site/content/docs/5.3/examples/download-app/index.html
@@ -7,6 +7,7 @@ extra_js:
   - src: "download-app.js"
 aliases:
   - "/download-app"
+  - "/examples/download-app"
   - "/docs/examples/download-app"
 ---
 


### PR DESCRIPTION
### Description

This PR adds a missing redirection for https://boosted.orange.com/examples/download-app. This kind of redirection is available for all other examples in our doc and is missing for this specific example.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Local test

```
$ npm run docs
$ ls _site/examples/download-app # Must be generated
```

### Live previews

- https://deploy-preview-2216--boosted.netlify.app/download-app/
- https://deploy-preview-2216--boosted.netlify.app/examples/download-app/
- https://deploy-preview-2216--boosted.netlify.app/docs/examples/download-app/
- https://deploy-preview-2216--boosted.netlify.app/docs/5.3/examples/download-app/