### PR TITLE
docs: add Icons rendering section

### DIFF
--- a/site/content/docs/5.3/extend/icons.md
+++ b/site/content/docs/5.3/extend/icons.md
@@ -16,6 +16,20 @@ Please refer to the Solaris icons library [usage documentation]({{< param icons_
 
 They are not open-source though and should only be used for Orange projects. Please refer to the [icons license file]({{< param icons_license >}}) for legal information.
 
+## Icons rendering
+
+Icons are designed within a square layout to preserve consistency. Within this square, there exists a designated safety zone to guarantee that icons can be used in various sizes and contexts while maintaining alignment as intended by the designers. The dimensions of the icons encompass this safety zone, ensuring adaptability and consistency across diverse applications.
+
+<svg width="8em" height="8em" class="bg-body-secondary" aria-hidden="true" focusable="false">
+  <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#info"/>
+</svg>
+<svg width="8em" height="8em" class="bg-body-secondary" aria-hidden="true" focusable="false">
+  <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#buy"/>
+</svg>
+<svg width="8em" height="8em" class="bg-body-secondary" aria-hidden="true" focusable="false">
+  <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#tick"/>
+</svg>
+
 ## Use Solaris icons
 
 There are many ways to use Solaris icons in a web page:


### PR DESCRIPTION
### Description

This PR adds a section explaining how icons are built/rendered within a square and with a safe zone.

### Motivation & Context

In projects, we are often wondering whether this safe zone is normal or not. Some designers in the projects remove them, some keep them. The purpose here is to fix this rule in our documentation.

### Types of change

- Enhancement (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2217--boosted.netlify.app/docs/5.3/extend/icons/#icons-rendering

### Checklist

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly
