### PR TITLE
fix(docs): add `/docs/customize/color-modes` redirection

### DIFF
--- a/site/content/docs/5.3/customize/color-modes.md
+++ b/site/content/docs/5.3/customize/color-modes.md
@@ -6,6 +6,7 @@ group: customize
 aliases:
   - "/docs/customize/color-modes/"
 toc: true
+added: "5.3"
 ---
 
 {{< callout >}}

--- a/site/content/docs/5.3/customize/color-modes.md
+++ b/site/content/docs/5.3/customize/color-modes.md
@@ -3,8 +3,9 @@ layout: docs
 title: Color modes
 description: Boosted now supports color modes, or themes, as of v5.3.0. Explore our default light color mode and the new dark mode, or create your own using our styles as your template.
 group: customize
+aliases:
+  - "/docs/customize/color-modes/"
 toc: true
-added: "5.3"
 ---
 
 {{< callout >}}


### PR DESCRIPTION
### Related issues

Closes #2225

### Description

This PR adds a redirection from `/docs/customize/color-modes` to `/docs/x.y/customize/color-modes` as it's done for other pages in 'Customize' section.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

- https://deploy-preview-2226--boosted.netlify.app/docs/customize/color-modes (should redirect to https://deploy-preview-2226--boosted.netlify.app/docs/5.3/customize/color-modes
