### PR TITLE
Chore merge from 256ad91 to 317cb2a

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -43,6 +43,7 @@
     "dropright",
     "dropstart",
     "dropup",
+    "dgst",
     "errorf",
     "evenodd",
     "favicon",

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -62,13 +62,19 @@ Make sure to use [`preconnect` resource hint](https://www.w3.org/TR/resource-hin
 
 We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our documentation. However, in some cases—like in some specific countries or environments—you may need to use other CDN providers like [cdnjs](https://cdnjs.com/) or [unpkg](https://unpkg.com/).
 
-You'll find the same files on these CDN providers, albeit with different URLs. When changing the URLs, you'll also need to update the `integrity` attribute. Tools like [SRI Hash Generator](https://www.srihash.org/) can help you generate the correct values.
+You'll find the same files on these CDN providers, albeit with different URLs. With cdnjs, you can [use this direct Boosted package link](https://cdnjs.com/libraries/boosted) to copy and paste ready-to-use HTML snippets for each dist file from any version of Boosted.
 
-With cdnjs, you can [use this direct Boosted package link](https://cdnjs.com/libraries/boosted) to copy and paste ready-to-use HTML snippets for each dist file from any version of Boosted.
+{{< callout warning>}}
+**If the SRI hashes differ for a given file, you shouldn't use the files from that CDN, because it means that the file was modified by someone else.**
+{{< /callout >}}
 
-## Package managers
+Note that you should compare same length hashes, e.g. `sha384` with `sha384`, otherwise it's expected for them to be different.
+As such, you can use an online tool like [SRI Hash Generator](https://www.srihash.org/) to make sure that the hashes are the same for a given file.
+Alternatively, assuming you have OpenSSL installed, you can achieve the same from the CLI, for example:
 
-Pull in Boosted's **source files** into nearly any project with some of the most popular package managers. No matter the package manager, Boosted will **require a [Sass compiler]({{< docsref "/getting-started/contribute#sass" >}}) and [Autoprefixer](https://github.com/postcss/autoprefixer)** for a setup that matches our official compiled versions.
+```sh
+openssl dgst -sha384 -binary boosted.min.js | openssl base64 -A
+```
 
 ### npm
 

--- a/site/layouts/_default/examples.html
+++ b/site/layouts/_default/examples.html
@@ -78,6 +78,10 @@
       .bd-mode-toggle {
         z-index: 1500;
       }
+
+      .bd-mode-toggle .dropdown-menu .active .bi {
+        display: block !important;
+      }
     </style>
 
     {{ range .Page.Params.extra_css }}


### PR DESCRIPTION
- [x] ~~https://github.com/twbs/bootstrap/commit/256ad91185c5b6979e19fac89134545ca2672bba~~: Browserstack badge was already deleted from our README
- [x] https://github.com/twbs/bootstrap/commit/8df9899e98118478afad3aa24ef2aa635f027261
- [x] https://github.com/twbs/bootstrap/commit/317cb2ae094ec0edcfc38a1af9bd51880389ca65

From there, all Bootstrap's commits are gathered for the v5.3.2.