### PR TITLE
fix(dark variant): some text colors were light gray instead of white

### DIFF
--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -40,7 +40,7 @@ $light-border-subtle-dark:          $light !default; // Boosted mod: instead of 
 $dark-border-subtle-dark:           $dark !default; // Boosted mod: instead of `$gray-800`
 // scss-docs-end theme-border-subtle-dark-variables
 
-$body-color-dark:                   $gray-300 !default;
+$body-color-dark:                   $white !default; // Boosted mod: instead of `$gray-300`
 $body-bg-dark:                      $black !default; // Boosted mod: instead of `$gray-900`
 $body-secondary-color-dark:         rgba($body-color-dark, .75) !default;
 $body-secondary-bg-dark:            $gray-800 !default;


### PR DESCRIPTION
### Description

This PR fixes some rendering issues observed for our dark variants where the text color is `rgb(238, 238, 238)`  and should be `white`.

It has been included with the dark mode coming from Bootstrap where there's a switch between `$body-color` and `$body-color-dark` to set `--bs-body-color`. The problem is that `$body-color-dark` was set to `$gray-300` instead of `$white`.

We could have used `--bs-emphasis-color` to fix this issue in all impacted components, but I think this fix is easier to maintain has in the dark mode, we will use a light gray default text color instead of white.

Here's a list of identified components in dark variant having the wrong text color.

⚠️ Please double-check all usages in the framework of `$body-color` and `--bs-body-color` to be sure to not introduce another regression.

#### Alerts

[Dark variant](https://boosted.netlify.app/docs/5.3/components/alerts/#dark-variant) text color is `rgb(238, 238, 238)` instead of white (the icon has already the right color).

#### Footer

In [our documentation](https://boosted.netlify.app), the text color of "This documentation is an adaptation made by Orange. Ori[...]"  is `rgb(238, 238, 238)` instead of white.

#### Cards

For cards, it's not seeable in the documentation directly since we prefer to use `.card-*` classes, and that dark examples force a `.text-white`. I don't think a fix is needed right now since it is an edge case and that we will refactor this usage for the dark mode.

#### Tags

[Dark variant](https://boosted.netlify.app/docs/5.3/components/tags/#dark-variant) text color is `rgb(238, 238, 238)` instead of white (the icon has already the right color).

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

Here's a list of renderings that are fixed/modified. **Please also review all dark variants for non-regression testing.**

- https://deploy-preview-2263--boosted.netlify.app (for the footer)
- https://deploy-preview-2263--boosted.netlify.app/docs/5.3/components/alerts/#dark-variant
- https://deploy-preview-2263--boosted.netlify.app/docs/5.3/components/tags/#dark-variant

