### PR TITLE
Dark mode: Fix sidebar menu icons color

### DIFF
--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -3,7 +3,7 @@
 
 - title: Getting started
   icon: book-half
-  icon_color: black
+  icon_color: body-color
   pages:
     - title: Introduction
     - title: Download
@@ -20,7 +20,7 @@
 
 - title: Customize
   icon: palette2
-  icon_color: black
+  icon_color: body-color
   pages:
     - title: Overview
     - title: Sass
@@ -33,7 +33,7 @@
 
 - title: Layout
   icon: grid-fill
-  icon_color: black
+  icon_color: body-color
   pages:
     - title: Breakpoints
     - title: Containers
@@ -46,7 +46,7 @@
 
 - title: Content
   icon: file-earmark-richtext
-  icon_color: black
+  icon_color: body-color
   pages:
     - title: Reboot
     - title: Typography
@@ -56,7 +56,7 @@
 
 - title: Forms
   icon: ui-radios
-  icon_color: black
+  icon_color: body-color
   pages:
     - title: Overview
     - title: Form control
@@ -70,7 +70,7 @@
 
 - title: Components
   icon: menu-button-wide-fill
-  icon_color: black
+  icon_color: body-color
   pages:
     - title: Accordion
     - title: Alerts
@@ -107,7 +107,7 @@
 
 - title: Helpers
   icon: magic
-  icon_color: black
+  icon_color: body-color
   pages:
     - title: Clearfix
     - title: Color & background
@@ -124,7 +124,7 @@
 
 - title: Utilities
   icon: braces-asterisk
-  icon_color: black
+  icon_color: body-color
   pages:
     - title: API
     - title: Background
@@ -149,14 +149,14 @@
 
 - title: Extend
   icon: tools
-  icon_color: black
+  icon_color: body-color
   pages:
     - title: Approach
     - title: Icons
 
 - title: About
   icon: globe2
-  icon_color: black
+  icon_color: body-color
   pages:
     - title: Overview
     - title: Team


### PR DESCRIPTION
This PR fixes the sidebar menu icons color which were black on dark mode:

![Screenshot 2023-09-26 at 10 00 14](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/7ec490fc-225a-4835-b130-2182fcfb3791)

They are now using the body color: black on light mode, light gray on dark mode.