### PR TITLE
Dark mode: handle focus visible

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -204,6 +204,9 @@
     --#{$prefix}border-color: #{$border-color-dark};
     --#{$prefix}border-color-translucent: #{$border-color-translucent-dark};
 
+    --#{$prefix}focus-visible-inner-color: #{$focus-visible-inner-color-dark}; // Boosted mod
+    --#{$prefix}focus-visible-outer-color: #{$focus-visible-outer-color-dark}; // Boosted mod
+
     --#{$prefix}form-valid-color: #{$form-valid-color-dark};
     --#{$prefix}form-valid-border-color: #{$form-valid-border-color-dark};
     --#{$prefix}form-invalid-color: #{$form-invalid-color-dark};

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -89,6 +89,9 @@ $code-color-dark:                   tint-color($code-color, 40%) !default;
 $mark-color-dark:                   $black !default; // Boosted mod: instead of `$body-color-dark`
 $mark-bg-dark:                      $white !default; // Boosted mod: instead of `$yellow-800`
 
+$focus-visible-inner-color-dark:    $black !default; // Boosted mod
+$focus-visible-outer-color-dark:    $white !default; // Boosted mod
+
 //
 // Forms
 //

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -650,11 +650,11 @@ $outline-offset:              $outline-width !default; // Deprecated in v5.2.3
 $focus-visible-zindex:                5 !default; // Boosted mod
 
 $focus-visible-inner-width:           2px !default; // Boosted mod
-$focus-visible-inner-color:           var(--#{$prefix}body-bg) !default; // Boosted mod
+$focus-visible-inner-color:           $white !default; // Boosted mod
 
 $focus-visible-outer-width:           3px !default;  // Boosted mod
 $focus-visible-outer-offset:          $focus-visible-inner-width !default; // Boosted mod
-$focus-visible-outer-color:           var(--#{$prefix}emphasis-color) !default; // Boosted mod
+$focus-visible-outer-color:           $black !default; // Boosted mod
 // scss-docs-end focus-visible-variables
 
 // scss-docs-start box-shadow-variables


### PR DESCRIPTION
### Description

Focus visible used to work fine with global color mode but break on nested themes. So instead of using a CSS var, redefining the variable each time we change the theme does the trick.

Focus visible in dark mode, by using existing and new Sass vars :
| Sass var | Previous value | New value |
| :------- | :--------------: | :----------: |
| `$focus-visible-inner-color` | `var(--#{$prefix}body-bg)` | `$white` |
| `$focus-visible-outer-color` | `var(--#{$prefix}emphasis-color)` | `$black` |
| `$focus-visible-inner-color-dark` | - | `$black` |
| `$focus-visible-outer-color-dark` | - | `$white` |

### Links

- https://deploy-preview-2279--boosted.netlify.app/docs/5.3/dark-mode