### PR TITLE
Dark mode: make accordion's background  transparent

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1671,7 +1671,7 @@ $card-footer-color:                 $gray-700 !default; // Boosted mod
 $accordion-padding-y:                     $spacer * .5 !default; // Boosted mod
 $accordion-padding-x:                     0 !default; // Boosted mod
 $accordion-color:                         var(--#{$prefix}body-color) !default;
-$accordion-bg:                            transparent !default;
+$accordion-bg:                            transparent !default; // Boosted mod: instead of `var(--#{$prefix}body-bg)`
 // stylelint-disable-next-line function-disallowed-list
 $accordion-border-width:                  calc(var(--#{$prefix}border-width) * .5) !default; // Boosted mod
 $accordion-border-color:                  var(--#{$prefix}border-color-translucent) !default; // Boosted mod

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1671,7 +1671,7 @@ $card-footer-color:                 $gray-700 !default; // Boosted mod
 $accordion-padding-y:                     $spacer * .5 !default; // Boosted mod
 $accordion-padding-x:                     0 !default; // Boosted mod
 $accordion-color:                         var(--#{$prefix}body-color) !default;
-$accordion-bg:                            var(--#{$prefix}body-bg) !default;
+$accordion-bg:                            transparent !default;
 // stylelint-disable-next-line function-disallowed-list
 $accordion-border-width:                  calc(var(--#{$prefix}border-width) * .5) !default; // Boosted mod
 $accordion-border-color:                  var(--#{$prefix}border-color-translucent) !default; // Boosted mod


### PR DESCRIPTION
### Description
Completes #2259 to make accordion's background transparent like in designs
I juste made it directly transparent, it seems to work...

### Links

- https://deploy-preview-2284--boosted.netlify.app/docs/5.3/components/accordions/
- https://deploy-preview-2284--boosted.netlify.app/docs/5.3/dark-mode/#accordions