### PR TITLE
Dark mode: Stickers

### DIFF
--- a/scss/_sticker.scss
+++ b/scss/_sticker.scss
@@ -2,6 +2,7 @@
   // scss-docs-start sticker-css-vars
   --#{$prefix}sticker-size: #{$sticker-size-md};
   --#{$prefix}sticker-font-weight: #{$font-weight-bold};
+  --#{$prefix}sticker-color: #{$black};
   --#{$prefix}sticker-background-color: #{$brand-orange};
   --#{$prefix}sticker-content-max-width: #{$sticker-content-max-width-md};
   // scss-docs-end sticker-css-vars
@@ -13,6 +14,7 @@
   width: var(--#{$prefix}sticker-size);
   height: var(--#{$prefix}sticker-size);
   font-weight: var(--#{$prefix}sticker-font-weight);
+  color: var(--#{$prefix}sticker-color);
   text-align: center;
   word-wrap: break-word;
   background-color: var(--#{$prefix}sticker-background-color);

--- a/scss/_sticker.scss
+++ b/scss/_sticker.scss
@@ -1,9 +1,9 @@
 .sticker {
   // scss-docs-start sticker-css-vars
   --#{$prefix}sticker-size: #{$sticker-size-md};
-  --#{$prefix}sticker-font-weight: #{$font-weight-bold};
-  --#{$prefix}sticker-color: #{$black};
-  --#{$prefix}sticker-background-color: #{$brand-orange};
+  --#{$prefix}sticker-font-weight: #{$sticker-font-weight};
+  --#{$prefix}sticker-color: #{$sticker-color};
+  --#{$prefix}sticker-background-color: #{$sticker-background-color};
   --#{$prefix}sticker-content-max-width: #{$sticker-content-max-width-md};
   // scss-docs-end sticker-css-vars
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -2242,6 +2242,10 @@ $step-link-text-decoration:   $link-decoration !default;
 
 //// Sticker
 // scss-docs-start sticker
+$sticker-color:                         $black !default;
+$sticker-background-color:              $brand-orange !default;
+$sticker-font-weight:                   $font-weight-bold !default;
+
 $sticker-size-sm:                       $spacer * 7 !default;
 $sticker-size-md:                       $spacer * 9 !default;
 $sticker-size-lg:                       $spacer * 14 !default;

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -712,7 +712,7 @@ Additional variables for dark-mode (temporary)
 <h4 class="mt-3">Dark theme on component</h4>
 
 <div class="border border-tertiary p-3 d-flex" style="background-color: #282d55;">
-  <div class="sticker sticker-sm">
+  <div class="sticker sticker-sm" data-bs-theme="dark">
     <p class="mb-0">
       <span class="sticker-fs-s mb-0 d-block text-decoration-line-through" aria-hidden="true">69.99 €</span>
       <span class="sticker-fs-xl mb-0 d-block" aria-hidden="true">39.99 €</span>
@@ -720,7 +720,7 @@ Additional variables for dark-mode (temporary)
       <span class="visually-hidden">39.99 € per month instead of 69.99 €</span>
     </p>
   </div>
-  <div class="sticker sticker-sm">
+  <div class="sticker sticker-sm" data-bs-theme="dark">
     <svg width="35" height="35" aria-hidden="true" focusable="false">
       <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#success"/>
     </svg>
@@ -733,7 +733,7 @@ Additional variables for dark-mode (temporary)
 <h4 class="mt-3">Light theme on component</h4>
 
 <div class="border border-tertiary p-3 d-flex" style="background-color: #b5e8f7">
-  <div class="sticker sticker-sm">
+  <div class="sticker sticker-sm" data-bs-theme="light">
     <p class="mb-0">
       <span class="sticker-fs-s mb-0 d-block text-decoration-line-through" aria-hidden="true">69.99 €</span>
       <span class="sticker-fs-xl mb-0 d-block" aria-hidden="true">39.99 €</span>
@@ -741,7 +741,7 @@ Additional variables for dark-mode (temporary)
       <span class="visually-hidden">39.99 € per month instead of 69.99 €</span>
     </p>
   </div>
-  <div class="sticker sticker-sm">
+  <div class="sticker sticker-sm" data-bs-theme="light">
     <svg width="35" height="35" aria-hidden="true" focusable="false">
       <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#success"/>
     </svg>

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -644,6 +644,113 @@ Additional variables for dark-mode (temporary)
   </nav>
 </div>
 
+### Stickers
+
+<h4 class="mt-3">No theme</h4>
+
+<div class="border border-tertiary p-3 d-flex">
+  <div class="sticker sticker-sm">
+    <p class="mb-0">
+      <span class="sticker-fs-s mb-0 d-block text-decoration-line-through" aria-hidden="true">69.99 €</span>
+      <span class="sticker-fs-xl mb-0 d-block" aria-hidden="true">39.99 €</span>
+      <span aria-hidden="true">Per month</span>
+      <span class="visually-hidden">39.99 € per month instead of 69.99 €</span>
+    </p>
+  </div>
+  <div class="sticker sticker-sm">
+    <svg width="35" height="35" aria-hidden="true" focusable="false">
+      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#success"/>
+    </svg>
+    <p class="mb-2">
+      <span class="sticker-fs-m">Free delivery</span>
+    </p>
+  </div>
+</div>
+
+<h4 class="mt-3">Dark theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body d-flex" data-bs-theme="dark">
+  <div class="sticker sticker-sm">
+    <p class="mb-0">
+      <span class="sticker-fs-s mb-0 d-block text-decoration-line-through" aria-hidden="true">69.99 €</span>
+      <span class="sticker-fs-xl mb-0 d-block" aria-hidden="true">39.99 €</span>
+      <span aria-hidden="true">Per month</span>
+      <span class="visually-hidden">39.99 € per month instead of 69.99 €</span>
+    </p>
+  </div>
+  <div class="sticker sticker-sm">
+    <svg width="35" height="35" aria-hidden="true" focusable="false">
+      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#success"/>
+    </svg>
+    <p class="mb-2">
+      <span class="sticker-fs-m">Free delivery</span>
+    </p>
+  </div>
+</div>
+
+<h4 class="mt-3">Light theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body d-flex" data-bs-theme="light">
+  <div class="sticker sticker-sm">
+    <p class="mb-0">
+      <span class="sticker-fs-s mb-0 d-block text-decoration-line-through" aria-hidden="true">69.99 €</span>
+      <span class="sticker-fs-xl mb-0 d-block" aria-hidden="true">39.99 €</span>
+      <span aria-hidden="true">Per month</span>
+      <span class="visually-hidden">39.99 € per month instead of 69.99 €</span>
+    </p>
+  </div>
+  <div class="sticker sticker-sm">
+    <svg width="35" height="35" aria-hidden="true" focusable="false">
+      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#success"/>
+    </svg>
+    <p class="mb-2">
+      <span class="sticker-fs-m">Free delivery</span>
+    </p>
+  </div>
+</div>
+
+<h4 class="mt-3">Dark theme on component</h4>
+
+<div class="border border-tertiary p-3 d-flex" style="background-color: #282d55;">
+  <div class="sticker sticker-sm">
+    <p class="mb-0">
+      <span class="sticker-fs-s mb-0 d-block text-decoration-line-through" aria-hidden="true">69.99 €</span>
+      <span class="sticker-fs-xl mb-0 d-block" aria-hidden="true">39.99 €</span>
+      <span aria-hidden="true">Per month</span>
+      <span class="visually-hidden">39.99 € per month instead of 69.99 €</span>
+    </p>
+  </div>
+  <div class="sticker sticker-sm">
+    <svg width="35" height="35" aria-hidden="true" focusable="false">
+      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#success"/>
+    </svg>
+    <p class="mb-2">
+      <span class="sticker-fs-m">Free delivery</span>
+    </p>
+  </div>
+</div>
+
+<h4 class="mt-3">Light theme on component</h4>
+
+<div class="border border-tertiary p-3 d-flex" style="background-color: #b5e8f7">
+  <div class="sticker sticker-sm">
+    <p class="mb-0">
+      <span class="sticker-fs-s mb-0 d-block text-decoration-line-through" aria-hidden="true">69.99 €</span>
+      <span class="sticker-fs-xl mb-0 d-block" aria-hidden="true">39.99 €</span>
+      <span aria-hidden="true">Per month</span>
+      <span class="visually-hidden">39.99 € per month instead of 69.99 €</span>
+    </p>
+  </div>
+  <div class="sticker sticker-sm">
+    <svg width="35" height="35" aria-hidden="true" focusable="false">
+      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#success"/>
+    </svg>
+    <p class="mb-2">
+      <span class="sticker-fs-m">Free delivery</span>
+    </p>
+  </div>
+</div>
+
 ## Forms
 
 ### Color


### PR DESCRIPTION
This PR handles the dark mode for the Sticker component.

New CSS vars:
- `--#{$prefix}sticker-color: #{$sticker-color};`

New Sass vars:
- `$sticker-color`
- `$sticker-background-color`
- `$sticker-font-weight`

### Live previews
- https://deploy-preview-2288--boosted.netlify.app/docs/5.3/dark-mode/#stickers
- https://deploy-preview-2288--boosted.netlify.app/docs/5.3/components/sticker
- https://deploy-preview-2288--boosted.netlify.app/docs/5.3/examples/stickers/