### PR TITLE
Dark mode: Spinners

### DIFF
--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -7,6 +7,7 @@
   display: inline-block;
   width: var(--#{$prefix}spinner-width);
   height: var(--#{$prefix}spinner-height);
+  color: #{$spinner-color}; // Boosted mod
   vertical-align: var(--#{$prefix}spinner-vertical-align);
   // stylelint-disable-next-line property-disallowed-list
   border-radius: 50%;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -2092,6 +2092,7 @@ $carousel-transition:                transform $carousel-transition-duration $tr
 // Spinners
 
 // scss-docs-start spinner-variables
+$spinner-color:           var(--#{$prefix}body-color) !default; // Boosted mod
 $spinner-width:           $spacer * 2 !default;
 $spinner-height:          $spinner-width !default;
 $spinner-vertical-align:  -.125em !default;

--- a/site/content/docs/5.3/components/spinners.md
+++ b/site/content/docs/5.3/components/spinners.md
@@ -43,13 +43,7 @@ The border spinner uses `currentColor` for its `border-color`, meaning you can c
 <div class="spinner-border text-primary" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
-{{< /example >}}
-
-{{< example class="bg-dark" >}}
-<div class="spinner-border text-primary" role="status">
-  <span class="visually-hidden">Loading...</span>
-</div>
-<div class="spinner-border text-white" role="status">
+<div class="spinner-border text-body" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
 {{< /example >}}
@@ -78,13 +72,7 @@ Once again, this spinner is built with `currentColor`, so you can easily change 
 <div class="spinner-grow text-primary" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
-{{< /example >}}
-
-{{< example class="bg-dark" >}}
-<div class="spinner-grow text-primary" role="status">
-  <span class="visually-hidden">Loading...</span>
-</div>
-<div class="spinner-grow text-white" role="status">
+<div class="spinner-grow text-body" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
 {{< /example >}}
@@ -172,22 +160,22 @@ Use spinners within buttons to indicate an action is currently processing or tak
 
 {{< example >}}
 <button class="btn btn-primary" type="button" disabled>
-  <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+  <span class="spinner-border spinner-border-sm" aria-hidden="true" data-bs-theme="dark"></span>
   <span class="visually-hidden" role="status">Loading...</span>
 </button>
 <button class="btn btn-primary" type="button" disabled>
-  <span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>
+  <span class="spinner-border spinner-border-sm me-2" aria-hidden="true" data-bs-theme="dark"></span>
   <span role="status">Loading...</span>
 </button>
 {{< /example >}}
 
 {{< example >}}
 <button class="btn btn-primary" type="button" disabled>
-  <span class="spinner-grow spinner-grow-sm" aria-hidden="true"></span>
+  <span class="spinner-grow spinner-grow-sm" aria-hidden="true" data-bs-theme="dark"></span>
   <span class="visually-hidden" role="status">Loading...</span>
 </button>
 <button class="btn btn-primary" type="button" disabled>
-  <span class="spinner-grow spinner-grow-sm me-2" aria-hidden="true"></span>
+  <span class="spinner-grow spinner-grow-sm me-2" aria-hidden="true" data-bs-theme="dark"></span>
   <span role="status">Loading...</span>
 </button>
 {{< /example >}}

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -526,6 +526,123 @@ sitemap_exclude: true
   </nav>
 </div>
 
+### Spinners
+
+<h4 class="mt-3">No theme</h4>
+
+<div class="border border-tertiary p-3">
+  <div class="spinner-border" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border text-primary" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border text-body" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow text-primary" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow text-body" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+</div>
+
+<h4 class="mt-3">Dark theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body" data-bs-theme="dark">
+  <div class="spinner-border" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border text-primary" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border text-body" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow text-primary" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow text-body" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+</div>
+
+<h4 class="mt-3">Light theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body" data-bs-theme="light">
+  <div class="spinner-border" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border text-primary" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border text-body" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow text-primary" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow text-body" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+</div>
+
+<h4 class="mt-3">Dark theme on component</h4>
+
+<div class="border border-tertiary p-3" style="background-color: #282d55;">
+  <div class="spinner-border" role="status" data-bs-theme="dark">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border text-primary" role="status" data-bs-theme="dark">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border text-body" role="status" data-bs-theme="dark">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow" role="status" data-bs-theme="dark">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow text-primary" role="status" data-bs-theme="dark">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow text-body" role="status" data-bs-theme="dark">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+</div>
+
+<h4 class="mt-3">Light theme on component</h4>
+
+<div class="border border-tertiary p-3" style="background-color: #b5e8f7">
+  <div class="spinner-border" role="status" data-bs-theme="light">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border text-primary" role="status" data-bs-theme="light">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border text-body" role="status" data-bs-theme="light">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow" role="status" data-bs-theme="light">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow text-primary" role="status" data-bs-theme="light">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-grow text-body" role="status" data-bs-theme="light">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+</div>
+
 ### Stepped process
 
 <h4 class="mt-3">No theme</h4>


### PR DESCRIPTION
New Sass vars:
- `$spinner-color`

⚠️ Added temporary `data-bs-theme` for buttons containing spinners. This should go if we modify `color:` automatically with `[data-bs-theme]`.

### Live previews
- https://deploy-preview-2290--boosted.netlify.app/docs/5.3/components/spinners/
- https://deploy-preview-2290--boosted.netlify.app/docs/5.3/dark-mode/#spinners