### PR TITLE
Dark mode: File input

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1318,7 +1318,7 @@ $form-range-thumb-transition:              background-color $transition-duration
 
 // scss-docs-start form-file-variables
 $form-file-button-color:          $input-color !default;
-$form-file-button-bg:             var(--#{$prefix}body-bg) !default;
+$form-file-button-bg:             $input-bg !default; // Boosted mod: instead of `var(--#{$prefix}tertiary-bg)`
 $form-file-button-hover-bg:       var(--#{$prefix}secondary-bg) !default;
 // scss-docs-end form-file-variables
 

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -1992,3 +1992,40 @@ sitemap_exclude: true
     <label for="excellent51" title="Excellent"><span class="visually-hidden">Excellent</span></label>
   </fieldset></form>
 </div>
+
+### File input
+
+<h4 class="mt-3">No theme</h4>
+
+<div class="border border-tertiary p-3">
+  <input class="form-control" type="file">
+  <input class="form-control" type="file" disabled>
+</div>
+
+<h4 class="mt-3">Dark theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body" data-bs-theme="dark">
+  <input class="form-control" type="file">
+  <input class="form-control" type="file" disabled>
+</div>
+
+<h4 class="mt-3">Light theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body" data-bs-theme="light">
+  <input class="form-control" type="file">
+  <input class="form-control" type="file" disabled>
+</div>
+
+<h4 class="mt-3">Dark theme on component</h4>
+
+<div class="border border-tertiary p-3" style="background-color: #282d55;">
+  <input class="form-control" type="file" data-bs-theme="dark">
+  <input class="form-control" type="file" data-bs-theme="dark" disabled>
+</div>
+
+<h4 class="mt-3">Light theme on component</h4>
+
+<div class="border border-tertiary p-3" style="background-color: #b5e8f7">
+  <input class="form-control" type="file" data-bs-theme="light">
+  <input class="form-control" type="file" data-bs-theme="light" disabled>
+</div>

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -1538,6 +1538,43 @@ sitemap_exclude: true
   <input type="text" class="form-control-plaintext" value="Readonly plaintext input" data-bs-theme="light" readonly>
 </div>
 
+### File input
+
+<h4 class="mt-3">No theme</h4>
+
+<div class="border border-tertiary p-3">
+  <input class="form-control" type="file">
+  <input class="form-control" type="file" disabled>
+</div>
+
+<h4 class="mt-3">Dark theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body" data-bs-theme="dark">
+  <input class="form-control" type="file">
+  <input class="form-control" type="file" disabled>
+</div>
+
+<h4 class="mt-3">Light theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body" data-bs-theme="light">
+  <input class="form-control" type="file">
+  <input class="form-control" type="file" disabled>
+</div>
+
+<h4 class="mt-3">Dark theme on component</h4>
+
+<div class="border border-tertiary p-3" style="background-color: #282d55;">
+  <input class="form-control" type="file" data-bs-theme="dark">
+  <input class="form-control" type="file" data-bs-theme="dark" disabled>
+</div>
+
+<h4 class="mt-3">Light theme on component</h4>
+
+<div class="border border-tertiary p-3" style="background-color: #b5e8f7">
+  <input class="form-control" type="file" data-bs-theme="light">
+  <input class="form-control" type="file" data-bs-theme="light" disabled>
+</div>
+
 ### Helper
 
 <h4 class="mt-3">No theme</h4>
@@ -1991,41 +2028,4 @@ sitemap_exclude: true
     <input type="radio" id="excellent51" name="rating" value="5" class="visually-hidden">
     <label for="excellent51" title="Excellent"><span class="visually-hidden">Excellent</span></label>
   </fieldset></form>
-</div>
-
-### File input
-
-<h4 class="mt-3">No theme</h4>
-
-<div class="border border-tertiary p-3">
-  <input class="form-control" type="file">
-  <input class="form-control" type="file" disabled>
-</div>
-
-<h4 class="mt-3">Dark theme on container</h4>
-
-<div class="border border-tertiary p-3 bg-body" data-bs-theme="dark">
-  <input class="form-control" type="file">
-  <input class="form-control" type="file" disabled>
-</div>
-
-<h4 class="mt-3">Light theme on container</h4>
-
-<div class="border border-tertiary p-3 bg-body" data-bs-theme="light">
-  <input class="form-control" type="file">
-  <input class="form-control" type="file" disabled>
-</div>
-
-<h4 class="mt-3">Dark theme on component</h4>
-
-<div class="border border-tertiary p-3" style="background-color: #282d55;">
-  <input class="form-control" type="file" data-bs-theme="dark">
-  <input class="form-control" type="file" data-bs-theme="dark" disabled>
-</div>
-
-<h4 class="mt-3">Light theme on component</h4>
-
-<div class="border border-tertiary p-3" style="background-color: #b5e8f7">
-  <input class="form-control" type="file" data-bs-theme="light">
-  <input class="form-control" type="file" data-bs-theme="light" disabled>
 </div>


### PR DESCRIPTION
### Description

Form file inputs in dark mode, by using existing Sass vars :

| Sass var | Previous value | New value |
| :------- | :--------------: | :----------: |
| `$form-file-button-bg` | `var(--#{$prefix}body-bg)` | `$input-bg` |

### Links

- https://deploy-preview-2295--boosted.netlify.app/docs/5.3/forms/form-control#file-input/
- https://deploy-preview-2295--boosted.netlify.app/docs/5.3/dark-mode/#file-input