### PR TITLE
Dark mode: Add solid bg under `.form-helper`

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1091,6 +1091,7 @@ $form-label-required-color:             var(--#{$prefix}link-hover-color) !defau
 // scss-docs-start form-helper-variables
 $form-helper-size:                      1.25rem !default; // Boosted mod
 $form-helper-color:                     var(--#{$prefix}info) !default; // Boosted mod
+$form-helper-bg:                        var(--#{$prefix}highlight-color) !default; // Boosted mod
 $form-helper-icon:                      escape-svg($helper-icon) !default; // Boosted mod
 $form-helper-label-margin-bottom:       $form-label-margin-bottom - divide(($form-helper-size - $font-size-base), 2) !default; // Boosted mod
 // scss-docs-end form-helper-variables

--- a/scss/forms/_labels.scss
+++ b/scss/forms/_labels.scss
@@ -23,6 +23,7 @@
 }
 
 .form-helper {
+  position: relative;
   display: inline-block;
   flex-shrink: 0;
   padding: 0;
@@ -30,6 +31,18 @@
   border: 0;
 
   &::before {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: calc(#{$form-helper-size} - 5px); // stylelint-disable-line function-disallowed-list
+    height: calc(#{$form-helper-size} - 5px); // stylelint-disable-line function-disallowed-list
+    content: "";
+    background-color: $form-helper-bg;
+    border-radius: 50%; // stylelint-disable-line property-disallowed-list
+    transform: translate(-50%, -50%);
+  }
+
+  &::after {
     display: block;
     width: $form-helper-size;
     height: $form-helper-size;


### PR DESCRIPTION
### Description

Form checks in dark mode, by using existing and new Sass vars :

| Sass var | Previous value | New value |
| :------- | :--------------: | :----------: |
| `$form-helper-bg` | - | `var(--#{$prefix}highlight-color)` |

### Links

- https://deploy-preview-2305--boosted.netlify.app/docs/5.3/forms/overview#form-helper/
- https://deploy-preview-2305--boosted.netlify.app/docs/5.3/dark-mode/#helper
