### PR TITLE
Dark Mode: Storybook addon

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,7 @@ const config = {
     options: {
       measure: false
     }
-  }, "@storybook/preset-scss"],
+  }, "@storybook/addon-themes", "@storybook/preset-scss"],
   "framework": "@storybook/html-webpack5",
   docs: {
     autodocs: true

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -2,5 +2,5 @@ import { addons } from '@storybook/addons';
 import OrangeTheme from 'ods-storybook-theme/OrangeTheme.js';
 
 addons.setConfig({
-  theme: OrangeTheme
+  theme: OrangeTheme,
 });

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -2,5 +2,5 @@ import { addons } from '@storybook/addons';
 import OrangeTheme from 'ods-storybook-theme/OrangeTheme.js';
 
 addons.setConfig({
-  theme: OrangeTheme,
+  theme: OrangeTheme
 });

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,13 @@
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { withThemeByDataAttribute } from '@storybook/addon-themes';
 import './storybook.scss';
 import prettier from 'prettier/esm/standalone';
 import htmlParser from 'prettier/esm/parser-html';
 
 export const preview = {
+  /* globalTypes: {
+    theme: { type: 'string' },
+  }, */
   parameters: {
     actions: { argTypesRegex: "^on[A-Z].*" },
     controls: {
@@ -21,7 +25,17 @@ export const preview = {
         // Pretty print the Docs code source
         return match ? prettier.format(match[1].trim(), {printWidth: 120, parser: "html", plugins: [htmlParser]}) : src;
       }
-    }
-  }
+    },
+  },
+  decorators: [
+    withThemeByDataAttribute({
+      themes: {
+        light: 'light',
+        dark: 'dark',
+      },
+      defaultTheme: 'light',
+      attributeName: 'data-bs-theme',
+    }),
+  ]
 }
 export default preview;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,9 +5,6 @@ import prettier from 'prettier/esm/standalone';
 import htmlParser from 'prettier/esm/parser-html';
 
 export const preview = {
-  /* globalTypes: {
-    theme: { type: 'string' },
-  }, */
   parameters: {
     actions: { argTypesRegex: "^on[A-Z].*" },
     controls: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@rollup/plugin-replace": "^5.0.2",
         "@storybook/addon-a11y": "^7.5.0",
         "@storybook/addon-essentials": "^7.5.0",
+        "@storybook/addon-themes": "^7.5.0",
         "@storybook/html": "^7.5.0",
         "@storybook/html-webpack5": "^7.5.0",
         "@storybook/preset-scss": "^1.0.3",
@@ -4572,6 +4573,38 @@
         "@storybook/global": "^5.0.0",
         "@storybook/manager-api": "7.5.0",
         "@storybook/preview-api": "7.5.0",
+        "@storybook/types": "7.5.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-themes": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-7.5.0.tgz",
+      "integrity": "sha512-U6pEwomoh1InNckNTABoBpmCy6lHEv5GrhgdLrqNwjfXGE/t9y5kttREUCFVNW4WWL540Dv7SDriBPW5edga+g==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.5.0",
+        "@storybook/components": "7.5.0",
+        "@storybook/core-events": "7.5.0",
+        "@storybook/manager-api": "7.5.0",
+        "@storybook/preview-api": "7.5.0",
+        "@storybook/theming": "7.5.0",
         "@storybook/types": "7.5.0",
         "ts-dedent": "^2.0.0"
       },
@@ -24408,6 +24441,22 @@
         "@storybook/global": "^5.0.0",
         "@storybook/manager-api": "7.5.0",
         "@storybook/preview-api": "7.5.0",
+        "@storybook/types": "7.5.0",
+        "ts-dedent": "^2.0.0"
+      }
+    },
+    "@storybook/addon-themes": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-7.5.0.tgz",
+      "integrity": "sha512-U6pEwomoh1InNckNTABoBpmCy6lHEv5GrhgdLrqNwjfXGE/t9y5kttREUCFVNW4WWL540Dv7SDriBPW5edga+g==",
+      "dev": true,
+      "requires": {
+        "@storybook/client-logger": "7.5.0",
+        "@storybook/components": "7.5.0",
+        "@storybook/core-events": "7.5.0",
+        "@storybook/manager-api": "7.5.0",
+        "@storybook/preview-api": "7.5.0",
+        "@storybook/theming": "7.5.0",
         "@storybook/types": "7.5.0",
         "ts-dedent": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@rollup/plugin-replace": "^5.0.2",
     "@storybook/addon-a11y": "^7.5.0",
     "@storybook/addon-essentials": "^7.5.0",
+    "@storybook/addon-themes": "^7.5.0",
     "@storybook/html": "^7.5.0",
     "@storybook/html-webpack5": "^7.5.0",
     "@storybook/preset-scss": "^1.0.3",


### PR DESCRIPTION
### Description

This PR adds a new dev dependency named `@storybook/addon-themes` which allows the addition of a theme switcher within the Storybook interface (see https://storybook.js.org/blog/introducing-theme-switcher-addon/).

![Screenshot 2023-10-18 at 08 56 44](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/e7e85f1d-522b-4c94-98eb-9177f43f1246)

This is not directly useful for Boosted team, but could be through ZeroHeight one day.
However, it allows us to be sure that https://github.com/Orange-OpenSource/ods-storybook-theme is working correctly with Boosted components, and this, can be useful for the projects when they develop their components in isolation.

Technically it handles a switch with our `data-bs-theme` attribute.

Be careful, the other button in the toolbar handles the dark mode of the SB interface (so only the background behind the stories right now).

![Screenshot 2023-10-18 at 08 56 37](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/13abd2e6-5da8-4a29-a432-69fa3643aa4a)

- [ ] Try to update ODS Storybook Theme for dark mode

### [Live preview](https://deploy-preview-2310--boosted.netlify.app/storybook/?path=/story/components-accordion--accordion-0)



