### PR TITLE
Auto color and bg-color with data-bs-theme

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./dist/css/boosted-reboot.css",
-      "maxSize": "4.5 kB"
+      "maxSize": "4.75 kB"
     },
     {
       "path": "./dist/css/boosted-reboot.min.css",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./dist/css/boosted-reboot.css",
-      "maxSize": "4.75 kB"
+      "maxSize": "4.5 kB"
     },
     {
       "path": "./dist/css/boosted-reboot.min.css",

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -34,6 +34,8 @@
   --#{$prefix}accordion-active-color: #{$accordion-button-active-color};
   --#{$prefix}accordion-active-bg: #{$accordion-button-active-bg};
   // scss-docs-end accordion-css-vars
+
+  background-color: transparent; // Boosted mod
 }
 
 .accordion-button {

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -78,7 +78,7 @@
 
 @each $state, $value in $alert-colors {
   .alert-#{$state} {
-    --#{$prefix}alert-color: var(--#{$prefix}body-color); // Boosted mod: instead of `var(--#{$prefix}#{$state}-text-emphasis)`
+    // Boosted mod: no --#{$prefix}alert-color
     --#{$prefix}alert-border-color: var(--#{$prefix}#{$state}-border-subtle);
     // Boosted mod: no `--#{$prefix}alert-link-color`
     // Boosted mod

--- a/scss/_back-to-top.scss
+++ b/scss/_back-to-top.scss
@@ -38,6 +38,7 @@
   bottom: var(--#{$prefix}back-to-top-bottom);
   z-index: var(--#{$prefix}back-to-top-zindex);
   pointer-events: none;
+  background-color: transparent;
 }
 
 .back-to-top-link {

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -33,7 +33,7 @@
   flex-direction: column;
   min-width: 0; // See https://github.com/twbs/bootstrap/pull/22740#issuecomment-305868106
   height: var(--#{$prefix}card-height);
-  color: var(--#{$prefix}body-color);
+  // Boosted mod: no color
   word-wrap: break-word;
   background-color: var(--#{$prefix}card-bg);
   background-clip: border-box;

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -32,6 +32,7 @@
   // No need to set list-style: none; since .list-group-item is block level
   padding-left: 0; // reset padding because ul and ol
   margin-bottom: 0;
+  background-color: transparent; // Boosted mod
   @include border-radius(var(--#{$prefix}list-group-border-radius));
 
   // Boosted mod

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -50,6 +50,7 @@
   // We deliberately don't use `-webkit-overflow-scrolling: touch;` due to a
   // gnarly iOS Safari bug: https://bugs.webkit.org/show_bug.cgi?id=158342
   // See also https://github.com/twbs/bootstrap/issues/17695
+  background-color: transparent; // Boosted mod
 }
 
 // Shell div to position the modal with bottom padding

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -19,6 +19,7 @@
   padding-left: 0;
   margin-bottom: 0;
   list-style: none;
+  background-color: transparent; // Boosted mod
 }
 
 .nav-link {
@@ -240,6 +241,7 @@
   // scss-docs-end tab-content-css-vars
 
   padding: var(--#{$prefix}tab-content-padding-y) var(--#{$prefix}tab-content-padding-x);
+  background-color: transparent;
   border: var(--#{$prefix}tab-content-border-width) solid var(--#{$prefix}tab-content-border-color);
   border-top: 0;
   // End mod

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -36,7 +36,7 @@
       display: flex;
       flex-direction: column;
       max-width: 100%;
-      color: var(--#{$prefix}offcanvas-color);
+      // Boosted mod: no color
       visibility: hidden;
       background-color: var(--#{$prefix}offcanvas-bg);
       background-clip: padding-box;
@@ -137,10 +137,12 @@
 .offcanvas-title {
   margin-bottom: 0;
   line-height: var(--#{$prefix}offcanvas-title-line-height);
+  color: var(--#{$prefix}offcanvas-color); // Boosted mod
 }
 
 .offcanvas-body {
   flex-grow: 1;
   padding: var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x);
   overflow-y: auto;
+  color: var(--#{$prefix}offcanvas-color); // Boosted mod
 }

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -36,6 +36,7 @@
   display: flex;
   flex-wrap: if($pagination-margin-start == (-$pagination-border-width), null, wrap); // Boosted mod
   margin: var(--#{$prefix}pagination-margin-y) 0; // Boosted mod
+  background-color: transparent; // Boosted mod
   @include list-unstyled();
 }
 

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -69,7 +69,7 @@ body {
   @include font-size(var(--#{$prefix}body-font-size));
   font-weight: var(--#{$prefix}body-font-weight);
   line-height: var(--#{$prefix}body-line-height);
-  color: var(--#{$prefix}body-color);
+  // Boosted mod: no color
   text-align: var(--#{$prefix}body-text-align);
 
   /* rtl:remove */
@@ -501,7 +501,6 @@ th {
 label {
   display: inline-block; // 1
   font-weight: $form-label-font-weight; // Boosted mod
-  color: var(--#{$prefix}body-color); // Boosted mod
 }
 
 // Remove the default `border-radius` that macOS Chrome adds.

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,6 +1,17 @@
+// Boosted mod
+:root,
+[data-bs-theme] {
+  color: var(--#{$prefix}body-color);
+  background-color: var(--#{$prefix}body-bg);
+}
+
+// Note that some of the following variables in `:root, [data-bs-theme="light"]` could be extracted into `:root` only selector since they are not modified by other color modes!
+// End mod
+
 :root,
 [data-bs-theme="light"] {
   color-scheme: light; // Boosted mod
+
   // Note: Custom variable values only support SassScript inside `#{}`.
 
   // Colors

--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -9,6 +9,7 @@
   height: var(--#{$prefix}spinner-height);
   color: #{$spinner-color}; // Boosted mod
   vertical-align: var(--#{$prefix}spinner-vertical-align);
+  background-color: transparent; // Boosted mod
   // stylelint-disable-next-line property-disallowed-list
   border-radius: 50%;
   animation: var(--#{$prefix}spinner-animation-speed) linear infinite var(--#{$prefix}spinner-animation-name);

--- a/scss/_tags.scss
+++ b/scss/_tags.scss
@@ -105,7 +105,7 @@
 a.tag,
 button.tag,
 label.tag {
-  color: var(--#{$prefix}body-color);
+  color: var(--#{$prefix}tag-color);
   text-decoration: none;
   cursor: pointer;
 

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -82,7 +82,7 @@ $body-tertiary-bg-dark:             $black !default; // Boosted mod: instead of 
 $body-emphasis-color-dark:          $white !default; // Boosted mod: instead of `$gray-100`
 $border-color-dark:                 $white !default; // Boosted mod: instead of `$gray-700`
 $border-color-translucent-dark:     $gray-700 !default; // Boosted mod instead of `rgba($white, .15)`
-$headings-color-dark:               $white !default; // Boosted mod: instead of `inherit`
+$headings-color-dark:               inherit !default;
 $link-color-dark:                   $white !default; // Boosted mod: instead of `tint-color($primary, 40%)`
 $link-hover-color-dark:             $brand-orange !default; // Boosted mod: instead of `shift-color($link-color-dark, -$link-shade-percentage)`
 $code-color-dark:                   tint-color($code-color, 40%) !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1146,7 +1146,7 @@ $input-focus-width:                     $input-btn-focus-width !default;
 $input-focus-box-shadow:                none !default; // Boosted mod
 
 $input-placeholder-color:               var(--#{$prefix}placeholder-color) !default; // Boosted mod: instead of `var(--#{$prefix}secondary-color)`
-$input-plaintext-color:                 null !default;
+$input-plaintext-color:                 null !default; // Boosted mod: instead of `var(--#{$prefix}body-color)`
 
 // Boosted mod: no $input-height-border
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -799,7 +799,7 @@ $headings-font-family:        null !default;
 $headings-font-style:         null !default;
 $headings-font-weight:        700 !default;
 $headings-line-height:        $h6-line-height !default;
-$headings-color:              $black !default; // Boosted mod: instead of `inherit`
+$headings-color:              inherit !default;
 // scss-docs-end headings-variables
 
 // scss-docs-start display-headings

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1436,7 +1436,7 @@ $nav-link-padding-y:                $spacer * .5 !default;
 $nav-link-padding-x:                $spacer !default;
 $nav-link-font-size:                null !default;
 $nav-link-font-weight:              $font-weight-bold !default;
-$nav-link-color:                    var(--#{$prefix}link-color) !default;
+$nav-link-color:                    inherit !default; // Boosted mod: instead of `var(--#{$prefix}link-color)`
 $nav-link-hover-color:              var(--#{$prefix}link-hover-color) !default;
 $nav-link-transition:               null !default; // Boosted mod
 $nav-link-disabled-color:           var(--#{$prefix}disabled-color) !default; // Boosted mod: instead of `var(--#{$prefix}secondary-color)`
@@ -1640,7 +1640,7 @@ $pagination-padding-x:              null !default; // Boosted mod: instead of `.
 
 $pagination-font-size:              $font-size-base !default;
 
-$pagination-color:                  var(--#{$prefix}link-color) !default;
+$pagination-color:                  inherit !default; // Boosted mod: instead of `var(--#{$prefix}link-color)`
 $pagination-bg:                     transparent !default; // Boosted mod: instead of `var(--#{$prefix}body-bg)`
 $pagination-border-radius:          var(--#{$prefix}border-radius) !default;
 $pagination-border-width:           var(--#{$prefix}border-width) !default;
@@ -1951,7 +1951,7 @@ $modal-scale-transform:             scale(1.02) !default;
 $alert-padding-y:                   1rem !default;
 $alert-padding-x:                   $spacer !default;
 $alert-margin-bottom:               $spacer !default;
-$alert-color:                       inherit !default; // Boosted mod
+$alert-color:                       var(--#{$prefix}body-color) !default; // Boosted mod
 $alert-border-radius:               var(--#{$prefix}border-radius) !default;
 $alert-link-font-weight:            null !default; // Boosted mod
 $alert-heading-font-weight:         $font-weight-bold !default; // Boosted mod
@@ -2068,7 +2068,7 @@ $figure-caption-color:              $gray-900 !default; // Boosted mod: instead 
 
 // scss-docs-start title-bars-variables
 $title-bar-bg:                      var(--#{$prefix}body-bg) !default;
-$title-bar-color:                   var(--#{$prefix}heading-color) !default;
+$title-bar-color:                   var(--#{$prefix}body-color) !default;
 $title-bar-image-ratio:             1.8em !default;
 $title-bar-padding-y:               .3333333em !default;
 $title-bar-font-size:               $h2-font-size !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1095,7 +1095,7 @@ $form-label-margin-bottom:              .5rem !default; // Boosted mod
 $form-label-font-size:                  null !default;
 $form-label-font-style:                 null !default;
 $form-label-font-weight:                $font-weight-bold !default;
-$form-label-color:                      var(--#{$prefix}body-color) !default; // Boosted mod: instead of `null`
+$form-label-color:                      null !default;
 $form-label-disabled-color:             var(--#{$prefix}disabled-color) !default; // Boosted mod
 $form-label-required-margin-left:       .1875rem !default; // Boosted mod
 $form-label-required-color:             var(--#{$prefix}link-hover-color) !default; // Boosted mod
@@ -1130,7 +1130,7 @@ $input-disabled-color:                  var(--#{$prefix}placeholder-color) !defa
 $input-disabled-bg:                     var(--#{$prefix}secondary-bg) !default;
 $input-disabled-border-color:           null !default;
 
-$input-color:                           var(--#{$prefix}body-color) !default;
+$input-color:                           null !default; // Boosted mod: instead of `var(--#{$prefix}body-color)`
 $input-border-color:                    var(--#{$prefix}border-color-translucent) !default; // Boosted mod: instead of var(--#{$prefix}border-color)
 $input-border-width:                    $input-btn-border-width !default;
 $input-box-shadow:                      none !default; // Boosted mod
@@ -1146,7 +1146,7 @@ $input-focus-width:                     $input-btn-focus-width !default;
 $input-focus-box-shadow:                none !default; // Boosted mod
 
 $input-placeholder-color:               var(--#{$prefix}placeholder-color) !default; // Boosted mod: instead of `var(--#{$prefix}secondary-color)`
-$input-plaintext-color:                 var(--#{$prefix}body-color) !default;
+$input-plaintext-color:                 null !default;
 
 // Boosted mod: no $input-height-border
 
@@ -1304,7 +1304,7 @@ $form-select-border-color:        $input-border-color !default;
 $form-select-border-radius:       $input-border-radius !default;
 $form-select-box-shadow:          none !default; // Boosted mod
 
-$form-select-focus-border-color:  $input-color !default; // Boosted mod: for border to show in Firefox
+$form-select-focus-border-color:  $input-focus-border-color !default;
 // Boosted mod: no $form-select-focus-width
 $form-select-focus-box-shadow:    none !default; // Boosted mod
 
@@ -1368,7 +1368,7 @@ $form-feedback-icon-valid:          var(--#{$prefix}success-icon) !default;
 $form-feedback-icon-invalid:        var(--#{$prefix}error-icon) !default;
 $form-feedback-icon-size:           add($spacer * .25, $spacer * .5) !default; // Boosted mod
 $form-feedback-line-height:         $line-height-sm !default; // Boosted mod
-$form-feedback-color:               var(--#{$prefix}body-color) !default; // Boosted mod
+$form-feedback-color:               null !default; // Boosted mod
 // scss-docs-end form-feedback-variables
 
 // scss-docs-start form-validation-colors
@@ -1595,7 +1595,7 @@ $dropdown-divider-bg:               $dropdown-border-color !default;
 $dropdown-divider-margin-y:         $spacer * .25 !default; // Boosted mod: instead of `$spacer * .5`
 $dropdown-box-shadow:               var(--#{$prefix}box-shadow) !default;
 
-$dropdown-link-color:               var(--#{$prefix}body-color) !default;
+$dropdown-link-color:               null !default; // Boosted mod: instead of `var(--#{$prefix}body-color)`
 $dropdown-link-hover-color:         $dropdown-link-color !default;
 $dropdown-link-hover-bg:            var(--#{$prefix}border-color-translucent) !default; // Boosted mod: instead of `var(--#{$prefix}tertiary-bg)`
 
@@ -1607,7 +1607,7 @@ $dropdown-link-disabled-color:      var(--#{$prefix}disabled-color) !default; //
 $dropdown-item-padding-y:           $spacer * .5 !default; // Boosted mod: instead of `$spacer * .25`
 $dropdown-item-padding-x:           $spacer * .5 !default; // Boosted mod: instead of `$spacer`
 
-$dropdown-header-color:             var(--#{$prefix}body-color) !default; // Boosted mod: instead of `$gray-600`
+$dropdown-header-color:             null !default; // Boosted mod: instead of `$gray-600`
 $dropdown-header-padding-x:         $dropdown-item-padding-x !default;
 $dropdown-header-padding-y:         $spacer !default; // Boosted mod: instead of `$dropdown-padding-y`
 // fusv-disable
@@ -1730,7 +1730,7 @@ $card-footer-color:                 var(--#{$prefix}placeholder-color) !default;
 // scss-docs-start accordion-variables
 $accordion-padding-y:                     $spacer * .5 !default; // Boosted mod
 $accordion-padding-x:                     0 !default; // Boosted mod
-$accordion-color:                         var(--#{$prefix}body-color) !default;
+$accordion-color:                         null !default; // Boosted mod: instead of `var(--#{$prefix}body-color)`
 $accordion-bg:                            transparent !default; // Boosted mod: instead of `var(--#{$prefix}body-bg)`
 // stylelint-disable-next-line function-disallowed-list
 $accordion-border-width:                  calc(var(--#{$prefix}border-width) * .5) !default; // Boosted mod
@@ -1749,12 +1749,12 @@ $accordion-body-padding-x:                $spacer !default; // Deprecated in Boo
 
 $accordion-button-padding-y:              $accordion-padding-y !default;
 $accordion-button-padding-x:              $accordion-padding-x !default;
-$accordion-button-color:                  var(--#{$prefix}body-color) !default;
+$accordion-button-color:                  null !default; // Boosted mod: instead of `var(--#{$prefix}body-color)`
 $accordion-button-bg:                     var(--#{$prefix}accordion-bg) !default;
 $accordion-transition:                    $btn-transition, border-radius .15s ease !default;
 $accordion-button-hover-bg:               var(--#{$prefix}secondary-bg) !default; // Boosted mod
 $accordion-button-active-bg:              null !default; // Boosted mod: instead of `var(--#{$prefix}primary-bg-subtle)`
-$accordion-button-active-color:           var(--#{$prefix}body-color) !default; // Boosted mod: instead of `var(--#{$prefix}primary-text-emphasis)`
+$accordion-button-active-color:           $accordion-button-color !default; // Boosted mod: instead of `var(--#{$prefix}primary-text-emphasis)`
 
 // Boosted mod: no $accordion-button-focus-border-color
 // Boosted mod: no $accordion-button-focus-box-shadow
@@ -1789,7 +1789,7 @@ $tooltip-font-size:                 $font-size-sm !default;
 $tooltip-font-weight:               $font-weight-bold !default; // Boosted mod
 $tooltip-line-height:               $line-height-sm !default; // Boosted mod
 $tooltip-max-width:                 $spacer * 10 !default;
-$tooltip-color:                     var(--#{$prefix}body-color) !default; // Boosted mod: instead of `var(--#{$prefix}body-bg)`
+$tooltip-color:                     null !default; // Boosted mod: instead of `var(--#{$prefix}body-bg)`
 $tooltip-bg:                        var(--#{$prefix}body-bg) !default; // Boosted mod: instead of `var(--#{$prefix}emphasis-color)`
 // stylelint-disable-next-line function-disallowed-list
 $tooltip-border-width:              calc(var(--#{$prefix}border-width) * .5) !default; // Boosted mod
@@ -1834,7 +1834,7 @@ $popover-header-padding-bottom:     map-get($spacers, 2) !default; // Boosted mo
 $popover-header-padding-y:          initial !default; // Boosted mod: instead of `.5rem`
 $popover-header-padding-x:          $spacer * .9 !default; // Boosted mod: instead of `$spacer`
 
-$popover-body-color:                var(--#{$prefix}body-color) !default;
+$popover-body-color:                null !default; // Boosted mod: instead of `var(--#{$prefix}body-color)`
 $popover-body-padding-top:          0 !default; // Boosted mod
 $popover-body-padding-bottom:       $popover-padding-y !default; // Boosted mod
 $popover-body-padding-y:            initial !default; // Boosted mod: instead of `$spacer`
@@ -1897,7 +1897,7 @@ $modal-title-line-height:           $line-height-base !default;
 $modal-content-padding-y:           $spacer !default; // Boosted mod
 $modal-content-padding-x:           0 !default; // Boosted mod
 $modal-content-padding:             $modal-content-padding-y $modal-content-padding-x !default; // Boosted mod
-$modal-content-color:               var(--#{$prefix}body-color) !default; // Boosted mod: instead of `null`
+$modal-content-color:               null !default;
 $modal-content-bg:                  var(--#{$prefix}body-bg) !default;
 $modal-content-border-color:        var(--#{$prefix}border-color-translucent) !default;
 $modal-content-border-width:        var(--#{$prefix}border-width) !default;
@@ -2005,7 +2005,7 @@ $progress-height-xs:                $spacer * .25 !default;
 
 // scss-docs-start list-group-variables
 $list-group-font-weight:              $font-weight-bold !default; // Boosted mod
-$list-group-color:                    var(--#{$prefix}body-color) !default;
+$list-group-color:                    null !default; // Boosted mod: instead of `var(--#{$prefix}body-color)`
 $list-group-bg:                       transparent !default; // Boosted mod: instead of `var(--#{$prefix}body-bg)`
 $list-group-border-color:             var(--#{$prefix}border-color-translucent) !default; // Boosted mod: instead of `var(--#{$prefix}border-color)`
 $list-group-border-width:             var(--#{$prefix}border-width) !default;
@@ -2068,7 +2068,7 @@ $figure-caption-color:              $gray-900 !default; // Boosted mod: instead 
 
 // scss-docs-start title-bars-variables
 $title-bar-bg:                      var(--#{$prefix}body-bg) !default;
-$title-bar-color:                   var(--#{$prefix}body-color) !default;
+$title-bar-color:                   var(--#{$prefix}heading-color) !default;
 $title-bar-image-ratio:             1.8em !default;
 $title-bar-padding-y:               .3333333em !default;
 $title-bar-font-size:               $h2-font-size !default;
@@ -2139,7 +2139,7 @@ $carousel-indicators-margin-bottom:     $spacer !default;
 // End mod
 
 $carousel-caption-width:             70% !default;
-$carousel-caption-color:             var(--#{$prefix}body-color) !default;
+$carousel-caption-color:             null !default; // Boosted mod: instead of `var(--#{$prefix}body-color)`
 $carousel-caption-bg:                var(--#{$prefix}body-bg) !default; // Boosted mod
 $carousel-caption-padding-y:         $spacer !default;
 $carousel-caption-padding-x:         $spacer !default; // Boosted mod
@@ -2169,7 +2169,7 @@ $carousel-transition:                transform $carousel-transition-duration $tr
 // Spinners
 
 // scss-docs-start spinner-variables
-$spinner-color:           var(--#{$prefix}body-color) !default; // Boosted mod
+$spinner-color:           null !default; // Boosted mod
 $spinner-width:           $spacer * 2 !default;
 $spinner-height:          $spinner-width !default;
 $spinner-vertical-align:  -.125em !default;
@@ -2455,7 +2455,7 @@ $tag-font-size-sm:                  $font-size-sm !default;
 
 // scss-docs-start local-nav-variables
 $local-nav-padding-y:           $navbar-nav-link-padding-y !default;
-$local-nav-color:               var(--#{$prefix}body-color) !default;
+$local-nav-color:               null !default;
 $local-nav-bg:                  var(--#{$prefix}body-bg) !default;
 $local-nav-hover-color:         var(--#{$prefix}hover-color) !default;
 $local-nav-hover-bg:            var(--#{$prefix}secondary-bg) !default;

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -158,6 +158,7 @@
 
   min-height: $form-switch-width * .5;
   padding-left: $form-switch-padding-start;
+  background-color: transparent;
 
   .form-check-input {
     --#{$prefix}form-switch-bg: #{escape-svg($form-switch-bg-image)};

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -8,6 +8,7 @@
   flex-wrap: wrap; // For form validation feedback
   align-items: stretch;
   width: 100%;
+  background-color: transparent; // Boosted mod
 
   > .form-control,
   > .form-select,

--- a/scss/forms/_star-rating.scss
+++ b/scss/forms/_star-rating.scss
@@ -8,7 +8,9 @@
   --#{$prefix}star-rating-hover-color: #{$form-star-rating-hover-color};
   --#{$prefix}star-rating-checked-icon: #{$form-star-rating-checked-icon};
   --#{$prefix}star-rating-unchecked-icon: #{$form-star-rating-unchecked-icon};
+
   font-size: $form-star-size;
+  background-color: transparent;
 
   &:disabled {
     pointer-events: none;

--- a/scss/helpers/_chevron-link.scss
+++ b/scss/helpers/_chevron-link.scss
@@ -2,6 +2,7 @@
 .link-chevron {
   font-weight: $font-weight-bold;
   text-decoration: if($link-decoration == none, null, none);
+  background-color: transparent;
 
   &::after {
     display: inline-block;

--- a/scss/helpers/_color-bg.scss
+++ b/scss/helpers/_color-bg.scss
@@ -1,25 +1,15 @@
 // All-caps `RGBA()` function used because of this Sass bug: https://github.com/sass/node-sass/issues/2251
 @each $color, $value in $theme-colors {
   .text-bg-#{$color} {
-    color: color-contrast($value) if($enable-important-utilities, !important, null);
+    // Boosted mod: Force colors to have a good rendering
+    $text-bg-color: var(--#{$prefix}highlight-color);
+    @if index(("primary", "warning", "light"), #{$color}) {
+      $text-bg-color: $black;
+    } @else if (#{$color} == "dark") {
+      $text-bg-color: $white;
+    }
+    // End mod
+    color: $text-bg-color if($enable-important-utilities, !important, null); // Boosted mod: instead of `color-contrast($value)`
     background-color: RGBA(var(--#{$prefix}#{$color}-rgb), var(--#{$prefix}bg-opacity, 1)) if($enable-important-utilities, !important, null);
   }
 }
-
-// Boosted mod
-@if $enable-dark-mode {
-  @include color-mode(dark) {
-    @each $color, $value in $theme-colors-dark {
-      .text-bg-#{$color} {
-        $text-bg-color: var(--#{$prefix}highlight-color);
-        @if index(("primary", "warning", "light"), #{$color}) {
-          $text-bg-color: $black;
-        } @else if (#{$color} == "dark") {
-          $text-bg-color: $white;
-        }
-        color: $text-bg-color if($enable-important-utilities, !important, null);
-      }
-    }
-  }
-}
-// End mod

--- a/scss/mixins/_color-mode.scss
+++ b/scss/mixins/_color-mode.scss
@@ -13,18 +13,9 @@
       }
     }
   } @else {
-    // Boosted mod
-    @if $mode == "light" {
-      :root,
-      [data-bs-theme="#{$mode}"] {
-        @content;
-      }
-    } @else {
-      [data-bs-theme="#{$mode}"] {
-        @content;
-      }
+    [data-bs-theme="#{$mode}"] {
+      @content;
     }
-    // End mod
   }
 }
 // scss-docs-end color-mode-mixin

--- a/scss/mixins/_color-mode.scss
+++ b/scss/mixins/_color-mode.scss
@@ -13,9 +13,18 @@
       }
     }
   } @else {
-    [data-bs-theme="#{$mode}"] {
-      @content;
+    // Boosted mod
+    @if $mode == "light" {
+      :root,
+      [data-bs-theme="#{$mode}"] {
+        @content;
+      }
+    } @else {
+      [data-bs-theme="#{$mode}"] {
+        @content;
+      }
     }
+    // End mod
   }
 }
 // scss-docs-end color-mode-mixin

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -63,6 +63,7 @@
       font-weight: $font-weight-bold; // Boosted mod
       line-height: $form-feedback-line-height; // Boosted mod
       color: $form-feedback-color; // Boosted mod
+      background-color: transparent; // Boosted mod
 
       // Boosted mod: status should not rely on color only
       @if $enable-validation-icons {

--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -111,6 +111,7 @@
   .dropdown-menu {
     --bs-dropdown-bg: #{mix($blue-500, $blue-600)};
     --bs-dropdown-link-color: var(--bs-white);
+    --bs-dropdown-link-active-color: var(--bs-white);
     --bs-dropdown-link-active-bg: #{$blue-700};
     --bs-dropdown-link-hover-color: var(--bs-white);
     --bs-dropdown-link-hover-bg: #{$blue-600};

--- a/site/content/docs/5.3/about/brand.md
+++ b/site/content/docs/5.3/about/brand.md
@@ -21,7 +21,7 @@ Have a need for Boosted's brand resources? Great! We have only a few guidelines 
     <div class="ratio ratio-1x1">
     <figure class="d-flex bg-dark">
       <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" class="figure-img img-fluid m-auto" width="220" height="220" role="img" alt="Orange" loading="lazy">
-      <figcaption class="figure-caption fw-bold text-body position-absolute">Master logo</figcaption>
+      <figcaption class="figure-caption fw-bold position-absolute">Master logo</figcaption>
     </figure>
     </div>
   </div>
@@ -29,7 +29,7 @@ Have a need for Boosted's brand resources? Great! We have only a few guidelines 
     <div class="ratio ratio-1x1">
     <figure class="d-flex bg-dark">
       <img src="/docs/{{< param docs_version >}}/assets/brand/orange-logo.svg" class="figure-img m-auto" width="30" height="30" role="img" alt="Orange" loading="lazy">
-      <figcaption class="figure-caption fw-bold text-body position-absolute">Small logo</figcaption>
+      <figcaption class="figure-caption fw-bold position-absolute">Small logo</figcaption>
     </figure>
     </div>
   </div>
@@ -50,7 +50,7 @@ Orange Business Services has its own logo that contains the Orange logo and the 
     <div class="ratio ratio-1x1">
     <figure class="d-flex bg-dark">
       <img src="/docs/{{< param docs_version >}}/assets/brand/OBS-logo.svg" class="figure-img img-fluid m-auto" width="220" height="220" role="img" alt="Orange" loading="lazy">
-      <figcaption class="figure-caption fw-bold text-body position-absolute">Orange Business Services logo</figcaption>
+      <figcaption class="figure-caption fw-bold position-absolute">Orange Business Services logo</figcaption>
     </figure>
     </div>
   </div>

--- a/site/content/docs/5.3/components/spinners.md
+++ b/site/content/docs/5.3/components/spinners.md
@@ -43,7 +43,7 @@ The border spinner uses `currentColor` for its `border-color`, meaning you can c
 <div class="spinner-border text-primary" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
-<div class="spinner-border text-body" role="status">
+<div class="spinner-border" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
 {{< /example >}}
@@ -72,7 +72,7 @@ Once again, this spinner is built with `currentColor`, so you can easily change 
 <div class="spinner-grow text-primary" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
-<div class="spinner-grow text-body" role="status">
+<div class="spinner-grow" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
 {{< /example >}}

--- a/site/content/docs/5.3/customize/color-modes.md
+++ b/site/content/docs/5.3/customize/color-modes.md
@@ -160,7 +160,7 @@ For example, you can create a "blue theme" with the selector `data-bs-theme="blu
 
 {{< scss-docs name="custom-color-mode" file="site/assets/scss/_content.scss" >}}
 
-<div class="bd-example text-body bg-body" data-bs-theme="blue">
+<div class="bd-example" data-bs-theme="blue">
   <div class="h4">Example blue theme</div>
   <p>Some paragraph text to show how the blue theme might look with written copy.</p>
 

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -5733,6 +5733,10 @@ sitemap_exclude: true
         <button class="close" aria-labelledby="labelTag51" disabled><span class="visually-hidden">Close</span></button>
       </span></p>
     </li>
+    <li>
+      <input type="checkbox" class="btn-check" id="btncheck-mobile-disabled1" autocomplete="off" disabled>
+      <label class="tag" for="btncheck-mobile-disabled1"><span class="visually-hidden">Filter by</span>Mobile</label>
+    </li>
   </ul>
 </div>
 
@@ -5775,6 +5779,10 @@ sitemap_exclude: true
         Input
         <button class="close" aria-labelledby="labelTag52" disabled><span class="visually-hidden">Close</span></button>
       </span></p>
+    </li>
+    <li>
+      <input type="checkbox" class="btn-check" id="btncheck-mobile-disabled2" autocomplete="off" disabled>
+      <label class="tag" for="btncheck-mobile-disabled2"><span class="visually-hidden">Filter by</span>Mobile</label>
     </li>
   </ul>
 </div>
@@ -5819,6 +5827,10 @@ sitemap_exclude: true
         <button class="close" aria-labelledby="labelTag53" disabled><span class="visually-hidden">Close</span></button>
       </span></p>
     </li>
+    <li>
+      <input type="checkbox" class="btn-check" id="btncheck-mobile-disabled3" autocomplete="off" disabled>
+      <label class="tag" for="btncheck-mobile-disabled3"><span class="visually-hidden">Filter by</span>Mobile</label>
+    </li>
   </ul>
 </div>
 
@@ -5862,6 +5874,10 @@ sitemap_exclude: true
         <button class="close" aria-labelledby="labelTag54" disabled><span class="visually-hidden">Close</span></button>
       </span></p>
     </li>
+    <li>
+      <input type="checkbox" class="btn-check" id="btncheck-mobile-disabled4" autocomplete="off" disabled>
+      <label class="tag" for="btncheck-mobile-disabled4" data-bs-theme="dark"><span class="visually-hidden">Filter by</span>Mobile</label>
+    </li>
   </ul>
 </div>
 
@@ -5904,6 +5920,10 @@ sitemap_exclude: true
         Input
         <button class="close" aria-labelledby="labelTag55" disabled><span class="visually-hidden">Close</span></button>
       </span></p>
+    </li>
+    <li>
+      <input type="checkbox" class="btn-check" id="btncheck-mobile-disabled5" autocomplete="off" disabled>
+      <label class="tag" for="btncheck-mobile-disabled5" data-bs-theme="light"><span class="visually-hidden">Filter by</span>Mobile</label>
     </li>
   </ul>
 </div>

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -531,20 +531,9 @@ sitemap_exclude: true
 <h4 class="mt-3">No theme</h4>
 
 <div class="d-flex gap-2 flex-wrap border p-3">
-  <h6>Example heading <span class="badge text-bg-secondary">New</span></h6>
   <button type="button" class="btn btn-primary">
     Notifications <span class="badge text-bg-dark">4</span>
   </button>
-  <a href="#" class="position-relative">
-    <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
-      <use xlink:href="/docs/5.3/assets/img/boosted-sprite.svg#buy"/>
-    </svg>
-    <span class="visually-hidden">Shopping basket</span>
-    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
-      99+
-      <span class="visually-hidden">shopping basket items</span>
-    </span>
-  </a>
   <div>
     <span class="badge text-bg-primary">Primary</span>
     <span class="badge text-bg-secondary">Secondary</span>
@@ -560,20 +549,9 @@ sitemap_exclude: true
 <h4 class="mt-3">Dark theme on container</h4>
 
 <div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
-  <h6>Example heading <span class="badge text-bg-secondary">New</span></h6>
   <button type="button" class="btn btn-primary">
     Notifications <span class="badge text-bg-dark">4</span>
   </button>
-  <a href="#" class="position-relative">
-    <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
-      <use xlink:href="/docs/5.3/assets/img/boosted-sprite.svg#buy"/>
-    </svg>
-    <span class="visually-hidden">Shopping basket</span>
-    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
-      99+
-      <span class="visually-hidden">shopping basket items</span>
-    </span>
-  </a>
   <div>
     <span class="badge text-bg-primary">Primary</span>
     <span class="badge text-bg-secondary">Secondary</span>
@@ -589,20 +567,9 @@ sitemap_exclude: true
 <h4 class="mt-3">Light theme on container</h4>
 
 <div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
-  <h6>Example heading <span class="badge text-bg-secondary">New</span></h6>
   <button type="button" class="btn btn-primary">
     Notifications <span class="badge text-bg-dark">4</span>
   </button>
-  <a href="#" class="position-relative">
-    <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
-      <use xlink:href="/docs/5.3/assets/img/boosted-sprite.svg#buy"/>
-    </svg>
-    <span class="visually-hidden">Shopping basket</span>
-    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
-      99+
-      <span class="visually-hidden">shopping basket items</span>
-    </span>
-  </a>
   <div>
     <span class="badge text-bg-primary">Primary</span>
     <span class="badge text-bg-secondary">Secondary</span>
@@ -618,20 +585,9 @@ sitemap_exclude: true
 <h4 class="mt-3">Dark theme on component</h4>
 
 <div class="d-flex gap-2 flex-wrap border p-3" style="background-color: #282d55;">
-  <h6 data-bs-theme="dark">Example heading <span class="badge text-bg-secondary">New</span></h6>
   <button type="button" class="btn btn-primary" data-bs-theme="dark">
     Notifications <span class="badge text-bg-dark">4</span>
   </button>
-  <a href="#" class="position-relative" data-bs-theme="dark">
-    <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
-      <use xlink:href="/docs/5.3/assets/img/boosted-sprite.svg#buy"/>
-    </svg>
-    <span class="visually-hidden">Shopping basket</span>
-    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
-      99+
-      <span class="visually-hidden">shopping basket items</span>
-    </span>
-  </a>
   <div>
     <span class="badge text-bg-primary" data-bs-theme="dark">Primary</span>
     <span class="badge text-bg-secondary" data-bs-theme="dark">Secondary</span>
@@ -647,20 +603,9 @@ sitemap_exclude: true
 <h4 class="mt-3">Light theme on component</h4>
 
 <div class="d-flex gap-2 flex-wrap border p-3" style="background-color: #b5e8f7">
-  <h6 data-bs-theme="light">Example heading <span class="badge text-bg-secondary">New</span></h6>
   <button type="button" class="btn btn-primary" data-bs-theme="light">
     Notifications <span class="badge text-bg-dark">4</span>
   </button>
-  <a href="#" class="position-relative" data-bs-theme="light">
-    <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
-      <use xlink:href="/docs/5.3/assets/img/boosted-sprite.svg#buy"/>
-    </svg>
-    <span class="visually-hidden">Shopping basket</span>
-    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
-      99+
-      <span class="visually-hidden">shopping basket items</span>
-    </span>
-  </a>
   <div>
     <span class="badge text-bg-primary" data-bs-theme="light">Primary</span>
     <span class="badge text-bg-secondary" data-bs-theme="light">Secondary</span>

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -4739,186 +4739,186 @@ sitemap_exclude: true
 <h4 class="mt-3">No theme</h4>
 
 <div class="d-flex flex-column gap-2 border p-3">
-  <span class="placeholder col-12 text-bg-primary placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-primary placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-secondary placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-secondary placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-dark placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-dark placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-success placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-success placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-info placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-info placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-warning placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-warning placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-danger placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-danger placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-green placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-green placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-purple placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-purple placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-yellow placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-yellow placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-blue placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-blue placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-pink placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-pink placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-orange placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-orange placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-light placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-light placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-white placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-white placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-body bg-body placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-body bg-body placeholder-glow">Text</span>
+  <span class="placeholder col-12 bg-primary placeholder-wave"></span>
+  <span class="placeholder col-12 bg-primary placeholder-glow"></span>
+  <span class="placeholder col-12 bg-secondary placeholder-wave"></span>
+  <span class="placeholder col-12 bg-secondary placeholder-glow"></span>
+  <span class="placeholder col-12 bg-dark placeholder-wave"></span>
+  <span class="placeholder col-12 bg-dark placeholder-glow"></span>
+  <span class="placeholder col-12 bg-success placeholder-wave"></span>
+  <span class="placeholder col-12 bg-success placeholder-glow"></span>
+  <span class="placeholder col-12 bg-info placeholder-wave"></span>
+  <span class="placeholder col-12 bg-info placeholder-glow"></span>
+  <span class="placeholder col-12 bg-warning placeholder-wave"></span>
+  <span class="placeholder col-12 bg-warning placeholder-glow"></span>
+  <span class="placeholder col-12 bg-danger placeholder-wave"></span>
+  <span class="placeholder col-12 bg-danger placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-green placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-green placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-purple placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-purple placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-yellow placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-yellow placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-blue placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-blue placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-pink placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-pink placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-orange placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-orange placeholder-glow"></span>
+  <span class="placeholder col-12 bg-light placeholder-wave"></span>
+  <span class="placeholder col-12 bg-light placeholder-glow"></span>
+  <span class="placeholder col-12 bg-white placeholder-wave"></span>
+  <span class="placeholder col-12 bg-white placeholder-glow"></span>
+  <span class="placeholder col-12 bg-body placeholder-wave"></span>
+  <span class="placeholder col-12 bg-body placeholder-glow"></span>
 </div>
 
 <h4 class="mt-3">Dark theme on container</h4>
 
 <div class="d-flex flex-column gap-2 border p-3 bg-body" data-bs-theme="dark">
-  <span class="placeholder col-12 text-bg-primary placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-primary placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-secondary placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-secondary placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-dark placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-dark placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-success placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-success placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-info placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-info placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-warning placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-warning placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-danger placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-danger placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-green placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-green placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-purple placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-purple placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-yellow placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-yellow placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-blue placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-blue placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-pink placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-pink placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-orange placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-orange placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-light placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-light placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-white placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-white placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-body bg-body placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-body bg-body placeholder-glow">Text</span>
+  <span class="placeholder col-12 bg-primary placeholder-wave"></span>
+  <span class="placeholder col-12 bg-primary placeholder-glow"></span>
+  <span class="placeholder col-12 bg-secondary placeholder-wave"></span>
+  <span class="placeholder col-12 bg-secondary placeholder-glow"></span>
+  <span class="placeholder col-12 bg-dark placeholder-wave"></span>
+  <span class="placeholder col-12 bg-dark placeholder-glow"></span>
+  <span class="placeholder col-12 bg-success placeholder-wave"></span>
+  <span class="placeholder col-12 bg-success placeholder-glow"></span>
+  <span class="placeholder col-12 bg-info placeholder-wave"></span>
+  <span class="placeholder col-12 bg-info placeholder-glow"></span>
+  <span class="placeholder col-12 bg-warning placeholder-wave"></span>
+  <span class="placeholder col-12 bg-warning placeholder-glow"></span>
+  <span class="placeholder col-12 bg-danger placeholder-wave"></span>
+  <span class="placeholder col-12 bg-danger placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-green placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-green placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-purple placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-purple placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-yellow placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-yellow placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-blue placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-blue placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-pink placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-pink placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-orange placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-orange placeholder-glow"></span>
+  <span class="placeholder col-12 bg-light placeholder-wave"></span>
+  <span class="placeholder col-12 bg-light placeholder-glow"></span>
+  <span class="placeholder col-12 bg-white placeholder-wave"></span>
+  <span class="placeholder col-12 bg-white placeholder-glow"></span>
+  <span class="placeholder col-12 bg-body placeholder-wave"></span>
+  <span class="placeholder col-12 bg-body placeholder-glow"></span>
 </div>
 
 <h4 class="mt-3">Light theme on container</h4>
 
 <div class="d-flex flex-column gap-2 border p-3 bg-body" data-bs-theme="light">
-  <span class="placeholder col-12 text-bg-primary placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-primary placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-secondary placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-secondary placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-dark placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-dark placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-success placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-success placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-info placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-info placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-warning placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-warning placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-bg-danger placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-bg-danger placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-green placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-green placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-purple placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-purple placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-yellow placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-yellow placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-blue placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-blue placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-pink placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-pink placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-orange placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-supporting-orange placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-light placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-light placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-black bg-white placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-black bg-white placeholder-glow">Text</span>
-  <span class="placeholder col-12 text-body bg-body placeholder-wave">Text</span>
-  <span class="placeholder col-12 text-body bg-body placeholder-glow">Text</span>
+  <span class="placeholder col-12 bg-primary placeholder-wave"></span>
+  <span class="placeholder col-12 bg-primary placeholder-glow"></span>
+  <span class="placeholder col-12 bg-secondary placeholder-wave"></span>
+  <span class="placeholder col-12 bg-secondary placeholder-glow"></span>
+  <span class="placeholder col-12 bg-dark placeholder-wave"></span>
+  <span class="placeholder col-12 bg-dark placeholder-glow"></span>
+  <span class="placeholder col-12 bg-success placeholder-wave"></span>
+  <span class="placeholder col-12 bg-success placeholder-glow"></span>
+  <span class="placeholder col-12 bg-info placeholder-wave"></span>
+  <span class="placeholder col-12 bg-info placeholder-glow"></span>
+  <span class="placeholder col-12 bg-warning placeholder-wave"></span>
+  <span class="placeholder col-12 bg-warning placeholder-glow"></span>
+  <span class="placeholder col-12 bg-danger placeholder-wave"></span>
+  <span class="placeholder col-12 bg-danger placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-green placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-green placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-purple placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-purple placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-yellow placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-yellow placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-blue placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-blue placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-pink placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-pink placeholder-glow"></span>
+  <span class="placeholder col-12 bg-supporting-orange placeholder-wave"></span>
+  <span class="placeholder col-12 bg-supporting-orange placeholder-glow"></span>
+  <span class="placeholder col-12 bg-light placeholder-wave"></span>
+  <span class="placeholder col-12 bg-light placeholder-glow"></span>
+  <span class="placeholder col-12 bg-white placeholder-wave"></span>
+  <span class="placeholder col-12 bg-white placeholder-glow"></span>
+  <span class="placeholder col-12 bg-body placeholder-wave"></span>
+  <span class="placeholder col-12 bg-body placeholder-glow"></span>
 </div>
 
 <h4 class="mt-3">Dark theme on component</h4>
 
 <div class="d-flex flex-column gap-2 border p-3" style="background-color: #282d55;">
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-primary placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-primary placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-secondary placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-secondary placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-dark placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-dark placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-success placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-success placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-info placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-info placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-warning placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-warning placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-danger placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-bg-danger placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-green placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-green placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-purple placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-purple placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-yellow placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-yellow placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-blue placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-blue placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-pink placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-pink placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-orange placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-supporting-orange placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-light placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-light placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-white placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-black bg-white placeholder-glow">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-body bg-body placeholder-wave">Text</span>
-  <span data-bs-theme="dark" class="placeholder col-12 text-body bg-body placeholder-glow">Text</span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-primary placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-primary placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-secondary placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-secondary placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-dark placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-dark placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-success placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-success placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-info placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-info placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-warning placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-warning placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-danger placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-danger placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-green placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-green placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-purple placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-purple placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-yellow placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-yellow placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-blue placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-blue placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-pink placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-pink placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-orange placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-supporting-orange placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-light placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-light placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-white placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-white placeholder-glow"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-body placeholder-wave"></span>
+  <span data-bs-theme="dark" class="placeholder col-12 bg-body placeholder-glow"></span>
 </div>
 
 <h4 class="mt-3">Light theme on component</h4>
 
 <div class="d-flex flex-column gap-2 border p-3" style="background-color: #b5e8f7">
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-primary placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-primary placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-secondary placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-secondary placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-dark placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-dark placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-success placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-success placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-info placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-info placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-warning placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-warning placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-danger placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-bg-danger placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-green placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-green placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-purple placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-purple placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-yellow placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-yellow placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-blue placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-blue placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-pink placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-pink placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-orange placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-supporting-orange placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-light placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-light placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-white placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-black bg-white placeholder-glow">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-body bg-body placeholder-wave">Text</span>
-  <span data-bs-theme="light" class="placeholder col-12 text-body bg-body placeholder-glow">Text</span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-primary placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-primary placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-secondary placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-secondary placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-dark placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-dark placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-success placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-success placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-info placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-info placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-warning placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-warning placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-danger placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-danger placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-green placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-green placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-purple placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-purple placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-yellow placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-yellow placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-blue placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-blue placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-pink placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-pink placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-orange placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-supporting-orange placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-light placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-light placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-white placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-white placeholder-glow"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-body placeholder-wave"></span>
+  <span data-bs-theme="light" class="placeholder col-12 bg-body placeholder-glow"></span>
 </div>
 
 ### Popovers

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -548,7 +548,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <button type="button" class="btn btn-primary">
     Notifications <span class="badge text-bg-dark">4</span>
   </button>
@@ -566,7 +566,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <button type="button" class="btn btn-primary">
     Notifications <span class="badge text-bg-dark">4</span>
   </button>
@@ -4775,7 +4775,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex flex-column gap-2 border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex flex-column gap-2 border p-3" data-bs-theme="dark">
   <span class="placeholder col-12 bg-primary placeholder-wave"></span>
   <span class="placeholder col-12 bg-primary placeholder-glow"></span>
   <span class="placeholder col-12 bg-secondary placeholder-wave"></span>
@@ -4812,7 +4812,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex flex-column gap-2 border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex flex-column gap-2 border p-3" data-bs-theme="light">
   <span class="placeholder col-12 bg-primary placeholder-wave"></span>
   <span class="placeholder col-12 bg-primary placeholder-glow"></span>
   <span class="placeholder col-12 bg-secondary placeholder-wave"></span>

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -6094,7 +6094,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex flex-column align-items-start border p-3 bg-body text-body" data-bs-theme="dark">
+<div class="d-flex flex-column align-items-start border p-3 bg-body" data-bs-theme="dark">
   <h1>H1</h1>
   <h2>H2</h2>
   <h3>H3</h3>
@@ -6170,7 +6170,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex flex-column align-items-start border p-3 bg-body text-body" data-bs-theme="light">
+<div class="d-flex flex-column align-items-start border p-3 bg-body" data-bs-theme="light">
   <h1>H1</h1>
   <h2>H2</h2>
   <h3>H3</h3>
@@ -6251,10 +6251,10 @@ sitemap_exclude: true
   <h2 data-bs-theme="dark">H2</h2>
   <h3 data-bs-theme="dark">H3</h3>
   <h4 data-bs-theme="dark">H4</h4>
-  <p class="text-body" data-bs-theme="dark">Paragraph</p>
+  <p data-bs-theme="dark">Paragraph</p>
   <a data-bs-theme="dark" href="#">Link</a>
   <hr class="w-100" data-bs-theme="dark">
-  <ul class="text-body" data-bs-theme="dark">
+  <ul data-bs-theme="dark">
     <li>First layer
       <ul>
         <li>Second layer
@@ -6265,7 +6265,7 @@ sitemap_exclude: true
       </ul>
     </li>
   </ul>
-  <ol class="text-body" data-bs-theme="dark">
+  <ol data-bs-theme="dark">
     <li>First layer
       <ol>
         <li>Second layer
@@ -6276,7 +6276,7 @@ sitemap_exclude: true
       </ol>
     </li>
   </ol>
-  <dl class="text-body" data-bs-theme="dark">
+  <dl data-bs-theme="dark">
     <dt>Description lists</dt>
     <dd>First description</dd>
     <dt>Second title</dt>
@@ -6286,17 +6286,17 @@ sitemap_exclude: true
   <pre data-bs-theme="dark">Preformatted text</pre>
   <var data-bs-theme="dark">Variable text</var>
   <kbd data-bs-theme="dark">Keyboard input</kbd>
-  <samp class="text-body" data-bs-theme="dark">Sample output</samp>
-  <address class="text-body" data-bs-theme="dark">
+  <samp data-bs-theme="dark">Sample output</samp>
+  <address data-bs-theme="dark">
     <strong>Address</strong><br>
     1123 Fictional St,<br>
     San Francisco, CA 94103<br>
     <abbr title="Phone">P:</abbr> (123) 456-7890
   </address>
-  <blockquote class="text-body" data-bs-theme="dark">
+  <blockquote data-bs-theme="dark">
     Blockquote
   </blockquote>
-  <figure class="text-body" data-bs-theme="dark">
+  <figure data-bs-theme="dark">
     <blockquote class="blockquote">
       <p>Styles Blockquote</p>
     </blockquote>
@@ -6304,19 +6304,19 @@ sitemap_exclude: true
       Figcaption <cite title="Source Title">Source</cite>
     </figcaption>
   </figure>
-  <abbr class="text-body" data-bs-theme="dark" title="Abbreviation">Abbr</abbr>
-  <details class="text-body" data-bs-theme="dark">
+  <abbr data-bs-theme="dark" title="Abbreviation">Abbr</abbr>
+  <details data-bs-theme="dark">
     <summary>Summary</summary>
     <p>Details</p>
   </details>
   <p><mark data-bs-theme="dark">highlight</mark></p>
-  <p><del class="text-body" data-bs-theme="dark">This line of text is meant to be treated as deleted text.</del></p>
-  <p><s class="text-body" data-bs-theme="dark">This line of text is meant to be treated as no longer accurate.</s></p>
-  <p><ins class="text-body" data-bs-theme="dark">This line of text is meant to be treated as an addition to the document.</ins></p>
-  <p><u class="text-body" data-bs-theme="dark">This line of text will render as underlined.</u></p>
-  <p><small class="text-body" data-bs-theme="dark">This line of text is meant to be treated as fine print.</small></p>
-  <p><strong class="text-body" data-bs-theme="dark">This line rendered as bold text.</strong></p>
-  <p><em class="text-body" data-bs-theme="dark">This line rendered as bold text too.</em></p>
+  <p><del data-bs-theme="dark">This line of text is meant to be treated as deleted text.</del></p>
+  <p><s data-bs-theme="dark">This line of text is meant to be treated as no longer accurate.</s></p>
+  <p><ins data-bs-theme="dark">This line of text is meant to be treated as an addition to the document.</ins></p>
+  <p><u data-bs-theme="dark">This line of text will render as underlined.</u></p>
+  <p><small data-bs-theme="dark">This line of text is meant to be treated as fine print.</small></p>
+  <p><strong data-bs-theme="dark">This line rendered as bold text.</strong></p>
+  <p><em data-bs-theme="dark">This line rendered as bold text too.</em></p>
   <svg data-bs-theme="dark" class="bd-placeholder-img img-thumbnail" width="200" height="200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A generic square placeholder image with a gray border around it: 200x200" preserveAspectRatio="xMidYMid slice" focusable="false"><title>A generic square placeholder image with a gray border around it</title><rect width="100%" height="100%" fill="var(--bs-secondary-bg)"/><text x="50%" y="50%" fill="#999" dy=".3em">200x200</text></svg>
 </div>
 
@@ -6327,10 +6327,10 @@ sitemap_exclude: true
   <h2 data-bs-theme="light">H2</h2>
   <h3 data-bs-theme="light">H3</h3>
   <h4 data-bs-theme="light">H4</h4>
-  <p class="text-body" data-bs-theme="light">Paragraph</p>
+  <p data-bs-theme="light">Paragraph</p>
   <a data-bs-theme="light" href="#">Link</a>
   <hr class="w-100" data-bs-theme="light">
-  <ul class="text-body" data-bs-theme="light">
+  <ul data-bs-theme="light">
     <li>First layer
       <ul>
         <li>Second layer
@@ -6341,7 +6341,7 @@ sitemap_exclude: true
       </ul>
     </li>
   </ul>
-  <ol class="text-body" data-bs-theme="light">
+  <ol data-bs-theme="light">
     <li>First layer
       <ol>
         <li>Second layer
@@ -6352,7 +6352,7 @@ sitemap_exclude: true
       </ol>
     </li>
   </ol>
-  <dl class="text-body" data-bs-theme="light">
+  <dl data-bs-theme="light">
     <dt>Description lists</dt>
     <dd>First description</dd>
     <dt>Second title</dt>
@@ -6362,17 +6362,17 @@ sitemap_exclude: true
   <pre data-bs-theme="light">Preformatted text</pre>
   <var data-bs-theme="light">Variable text</var>
   <kbd data-bs-theme="light">Keyboard input</kbd>
-  <samp class="text-body" data-bs-theme="light">Sample output</samp>
-  <address class="text-body" data-bs-theme="light">
+  <samp data-bs-theme="light">Sample output</samp>
+  <address data-bs-theme="light">
     <strong>Address</strong><br>
     1123 Fictional St,<br>
     San Francisco, CA 94103<br>
     <abbr title="Phone">P:</abbr> (123) 456-7890
   </address>
-  <blockquote class="text-body" data-bs-theme="light">
+  <blockquote data-bs-theme="light">
     Blockquote
   </blockquote>
-  <figure class="text-body" data-bs-theme="light">
+  <figure data-bs-theme="light">
     <blockquote class="blockquote">
       <p>Styles Blockquote</p>
     </blockquote>
@@ -6380,19 +6380,19 @@ sitemap_exclude: true
       Figcaption <cite title="Source Title">Source</cite>
     </figcaption>
   </figure>
-  <abbr class="text-body" data-bs-theme="light" title="Abbreviation">Abbr</abbr>
-  <details class="text-body" data-bs-theme="light">
+  <abbr data-bs-theme="light" title="Abbreviation">Abbr</abbr>
+  <details data-bs-theme="light">
     <summary>Summary</summary>
     <p>Details</p>
   </details>
   <p><mark data-bs-theme="light">highlight</mark></p>
-  <p><del class="text-body" data-bs-theme="light">This line of text is meant to be treated as deleted text.</del></p>
-  <p><s class="text-body" data-bs-theme="light">This line of text is meant to be treated as no longer accurate.</s></p>
-  <p><ins class="text-body" data-bs-theme="light">This line of text is meant to be treated as an addition to the document.</ins></p>
-  <p><u class="text-body" data-bs-theme="light">This line of text will render as underlined.</u></p>
-  <p><small class="text-body" data-bs-theme="light">This line of text is meant to be treated as fine print.</small></p>
-  <p><strong class="text-body" data-bs-theme="light">This line rendered as bold text.</strong></p>
-  <p><em class="text-body" data-bs-theme="light">This line rendered as bold text too.</em></p>
+  <p><del data-bs-theme="light">This line of text is meant to be treated as deleted text.</del></p>
+  <p><s data-bs-theme="light">This line of text is meant to be treated as no longer accurate.</s></p>
+  <p><ins data-bs-theme="light">This line of text is meant to be treated as an addition to the document.</ins></p>
+  <p><u data-bs-theme="light">This line of text will render as underlined.</u></p>
+  <p><small data-bs-theme="light">This line of text is meant to be treated as fine print.</small></p>
+  <p><strong data-bs-theme="light">This line rendered as bold text.</strong></p>
+  <p><em data-bs-theme="light">This line rendered as bold text too.</em></p>
   <svg data-bs-theme="light" class="bd-placeholder-img img-thumbnail" width="200" height="200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A generic square placeholder image with a gray border around it: 200x200" preserveAspectRatio="xMidYMid slice" focusable="false"><title>A generic square placeholder image with a gray border around it</title><rect width="100%" height="100%" fill="var(--bs-secondary-bg)"/><text x="50%" y="50%" fill="#999" dy=".3em">200x200</text></svg>
 </div>
 
@@ -6505,7 +6505,7 @@ sitemap_exclude: true
     </p>
     <p>
       <label for="output1">Example output</label>
-      <output name="result1" id="output1" class="text-body">100</output>
+      <output name="result1" id="output1">100</output>
     </p>
     <p>
       <button type="submit">Button submit</button>
@@ -6629,7 +6629,7 @@ sitemap_exclude: true
     </p>
     <p>
       <label for="output2">Example output</label>
-      <output name="result2" id="output2" class="text-body">100</output>
+      <output name="result2" id="output2">100</output>
     </p>
     <p>
       <button type="submit">Button submit</button>
@@ -6753,7 +6753,7 @@ sitemap_exclude: true
     </p>
     <p>
       <label for="output3">Example output</label>
-      <output name="result3" id="output3" class="text-body">100</output>
+      <output name="result3" id="output3">100</output>
     </p>
     <p>
       <button type="submit">Button submit</button>
@@ -6774,7 +6774,7 @@ sitemap_exclude: true
 
 <div class="border p-3" style="background-color: #282d55;">
   <fieldset>
-    <legend class="text-body" data-bs-theme="dark">Example legend</legend>
+    <legend data-bs-theme="dark">Example legend</legend>
     <p>
       <label for="input4" data-bs-theme="dark">Example input</label>
       <input type="text" id="input4" data-bs-theme="dark" placeholder="Example input">
@@ -6877,7 +6877,7 @@ sitemap_exclude: true
     </p>
     <p>
       <label for="output4" data-bs-theme="dark">Example output</label>
-      <output name="result4" id="output4" data-bs-theme="dark" class="text-body">100</output>
+      <output name="result4" id="output4" data-bs-theme="dark">100</output>
     </p>
     <p>
       <button type="submit" data-bs-theme="dark">Button submit</button>
@@ -6898,7 +6898,7 @@ sitemap_exclude: true
 
 <div class="border p-3" style="background-color: #b5e8f7">
   <fieldset>
-    <legend class="text-body" data-bs-theme="light">Example legend</legend>
+    <legend data-bs-theme="light">Example legend</legend>
     <p>
       <label for="input5" data-bs-theme="light">Example input</label>
       <input type="text" id="input5" data-bs-theme="light" placeholder="Example input">
@@ -7001,7 +7001,7 @@ sitemap_exclude: true
     </p>
     <p>
       <label for="output5" data-bs-theme="light">Example output</label>
-      <output name="result5" id="output5" data-bs-theme="light" class="text-body">100</output>
+      <output name="result5" id="output5" data-bs-theme="light">100</output>
     </p>
     <p>
       <button type="submit" data-bs-theme="light">Button submit</button>

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -180,7 +180,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <div class="accordion" id="accordionExample2">
     <div class="accordion-item">
       <h2 class="accordion-header">
@@ -221,7 +221,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <div class="accordion" id="accordionExample3">
     <div class="accordion-item">
       <h2 class="accordion-header">
@@ -367,7 +367,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <div class="alert alert-success" role="alert">
     <span class="alert-icon"><span class="visually-hidden">Success</span></span>
     <p>Success notification text goes here.</p>
@@ -388,7 +388,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <div class="alert alert-success" role="alert">
     <span class="alert-icon"><span class="visually-hidden">Success</span></span>
     <p>Success notification text goes here.</p>
@@ -468,7 +468,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <nav aria-label="Standard back to top example2" class="back-to-top position-static ps-5 ms-5">
     <a href="#" class="back-to-top-link btn btn-icon btn-outline-secondary position-relative top-0" data-bs-label="Back to top">
       <span class="visually-hidden">Back to top</span>
@@ -483,7 +483,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <nav aria-label="Standard back to top example3" class="back-to-top position-static ps-5 ms-5">
     <a href="#" class="back-to-top-link btn btn-icon btn-outline-secondary position-relative top-0" data-bs-label="Back to top">
       <span class="visually-hidden">Back to top</span>
@@ -693,7 +693,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <nav aria-label="breadcrumb2">
     <ol class="breadcrumb mb-0">
       <li class="breadcrumb-item"><a href="#">Home</a></li>
@@ -709,7 +709,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <nav aria-label="breadcrumb3">
     <ol class="breadcrumb mb-0">
       <li class="breadcrumb-item"><a href="#">Home</a></li>
@@ -810,7 +810,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <button type="button" class="btn btn-primary">Primary</button>
   <button type="button" class="btn btn-primary" disabled>Primary</button>
   <button type="button" class="btn btn-secondary">Secondary</button>
@@ -861,7 +861,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <button type="button" class="btn btn-primary">Primary</button>
   <button type="button" class="btn btn-primary" disabled>Primary</button>
   <button type="button" class="btn btn-secondary">Secondary</button>
@@ -1079,7 +1079,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="row row-cols-1 row-cols-xl-3 border p-3 bg-body" data-bs-theme="dark">
+<div class="row row-cols-1 row-cols-xl-3 border p-3" data-bs-theme="dark">
   <div class="col">
     <div class="card">
       <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="var(--bs-secondary-bg)"/>
@@ -1142,7 +1142,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="row row-cols-1 row-cols-xl-3 border p-3 bg-body" data-bs-theme="light">
+<div class="row row-cols-1 row-cols-xl-3 border p-3" data-bs-theme="light">
   <div class="col">
     <div class="card">
       <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title><rect width="100%" height="100%" fill="var(--bs-secondary-bg)"/>
@@ -1381,7 +1381,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <div id="carouselExample2" class="carousel slide" data-bs-ride="carousel" data-bs-pause="false" data-bs-wrap="false">
     <div class="carousel-action-bar">
       <button type="button" class="btn btn-icon carousel-control-play-pause pause" data-bs-target="#carouselExample2" data-bs-play-text="Play Carousel" data-bs-pause-text="Pause Carousel" title="Pause Carousel">
@@ -1429,7 +1429,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <div id="carouselExample3" class="carousel slide" data-bs-ride="carousel" data-bs-pause="false" data-bs-wrap="false">
     <div class="carousel-action-bar">
       <button type="button" class="btn btn-icon carousel-control-play-pause pause" data-bs-target="#carouselExample3" data-bs-play-text="Play Carousel" data-bs-pause-text="Pause Carousel" title="Pause Carousel">
@@ -1598,7 +1598,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <button type="button" class="btn-close" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Close"><span class="visually-hidden">Close</span></button>
   <button type="button" class="btn-close" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Close" disabled><span class="visually-hidden">Close</span></button>
   <button type="button" class="btn btn-icon btn-no-outline" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Close">
@@ -1621,7 +1621,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <button type="button" class="btn-close" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Close"><span class="visually-hidden">Close</span></button>
   <button type="button" class="btn-close" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Close" disabled><span class="visually-hidden">Close</span></button>
   <button type="button" class="btn btn-icon btn-no-outline" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Close">
@@ -1806,7 +1806,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <div class="btn-group">
     <div class="dropdown">
       <button class="btn btn-dropdown dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Dropdown button</button>
@@ -1920,7 +1920,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <div class="btn-group">
     <div class="dropdown">
       <button class="btn btn-dropdown dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Dropdown button</button>
@@ -2436,7 +2436,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <footer class="footer navbar">
     <h2 class="visually-hidden">Sitemap &amp; information</h2>
     <div class="container-xxl footer-title-content">
@@ -2576,7 +2576,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <footer class="footer navbar">
     <h2 class="visually-hidden">Sitemap &amp; information</h2>
     <div class="container-xxl footer-title-content">
@@ -3033,7 +3033,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex flex-column gap-2 align-items-start border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex flex-column gap-2 align-items-start border p-3" data-bs-theme="dark">
   <ol class="list-group list-group-numbered">
     <li class="list-group-item">A list item</li>
     <li class="list-group-item active" aria-current="true">A list item</li>
@@ -3068,7 +3068,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex flex-column gap-2 align-items-start border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex flex-column gap-2 align-items-start border p-3" data-bs-theme="light">
   <ol class="list-group list-group-numbered">
     <li class="list-group-item">A list item</li>
     <li class="list-group-item active" aria-current="true">A list item</li>
@@ -3195,7 +3195,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <nav class="local-nav" aria-label="Basic local navigation">
     <button class="local-nav-button collapsed d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLocalNav2" aria-expanded="false" aria-controls="collapseLocalNav2">
       <span class="container-xxl">Shop</span>
@@ -3215,7 +3215,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <nav class="local-nav" aria-label="Basic local navigation">
     <button class="local-nav-button collapsed d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLocalNav3" aria-expanded="false" aria-controls="collapseLocalNav3">
       <span class="container-xxl">Shop</span>
@@ -3308,7 +3308,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalExample2">
     Launch modal
   </button>
@@ -3339,7 +3339,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalExample3">
     Launch modal
   </button>
@@ -3477,7 +3477,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <nav class="navbar navbar-expand-lg">
     <div class="container-fluid">
       <div class="navbar-brand">
@@ -3520,7 +3520,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <nav class="navbar navbar-expand-lg">
     <div class="container-fluid">
       <div class="navbar-brand">
@@ -3753,7 +3753,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <ul class="nav nav-underline">
     <li class="nav-item">
       <a class="nav-link active" aria-current="page" href="#">Active</a>
@@ -3826,7 +3826,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <ul class="nav nav-underline">
     <li class="nav-item">
       <a class="nav-link active" aria-current="page" href="#">Active</a>
@@ -4076,7 +4076,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasExample2" aria-controls="offcanvasExample2">
     Button with data-bs-target
   </button>
@@ -4105,7 +4105,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasExample3" aria-controls="offcanvasExample3">
     Button with data-bs-target
   </button>
@@ -4282,7 +4282,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <header>
     <nav class="navbar navbar-expand-lg supra" aria-label="Supra navigation2">
       <div class="container-xxl">
@@ -4370,7 +4370,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <header>
     <nav class="navbar navbar-expand-lg supra" aria-label="Supra navigation3">
       <div class="container-xxl">
@@ -4667,7 +4667,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex flex-column gap-2 border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex flex-column gap-2 border p-3" data-bs-theme="dark">
   <nav aria-label="Page navigation example2">
     <ul class="pagination mb-0">
       <li class="page-item"><a class="page-link disabled" aria-label="Next" aria-disabled="true">Previous</a></li>
@@ -4698,7 +4698,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex flex-column gap-2 border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex flex-column gap-2 border p-3" data-bs-theme="light">
   <nav aria-label="Page navigation example3">
     <ul class="pagination mb-0">
       <li class="page-item"><a class="page-link disabled" aria-label="Next" aria-disabled="true">Previous</a></li>
@@ -4987,14 +4987,14 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap align-items-center border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap align-items-center border p-3" data-bs-theme="dark">
   <div class="popover bs-popover-auto fade show position-relative" role="tooltip" data-popper-placement="right"><div class="popover-arrow" style="position: absolute; top: 0px; transform: translate(0px, 49px);"></div><h3 class="popover-header">Popover title</h3><div class="popover-body">And here's some amazing content. It's very engaging. Right?</div></div>
   <button type="button" class="btn btn-primary" data-bs-toggle="popover" data-bs-title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
 </div>
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap align-items-center border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap align-items-center border p-3" data-bs-theme="light">
   <div class="popover bs-popover-auto fade show position-relative" role="tooltip" data-popper-placement="right"><div class="popover-arrow" style="position: absolute; top: 0px; transform: translate(0px, 49px);"></div><h3 class="popover-header">Popover title</h3><div class="popover-body">And here's some amazing content. It's very engaging. Right?</div></div>
   <button type="button" class="btn btn-primary" data-bs-toggle="popover" data-bs-title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
 </div>
@@ -5082,7 +5082,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex flex-column gap-2 border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex flex-column gap-2 border p-3" data-bs-theme="dark">
   <div class="progress" role="progressbar" aria-label="Primary example" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100">
     <div class="progress-bar" style="width: 30%">30%</div>
   </div>
@@ -5147,7 +5147,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex flex-column gap-2 border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex flex-column gap-2 border p-3" data-bs-theme="light">
   <div class="progress" role="progressbar" aria-label="Primary example" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100">
     <div class="progress-bar" style="width: 30%">30%</div>
   </div>
@@ -5351,7 +5351,7 @@ sitemap_exclude: true
   <div class="spinner-border text-primary" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-border text-body" role="status">
+  <div class="spinner-border" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
   <div class="spinner-grow" role="status">
@@ -5360,21 +5360,21 @@ sitemap_exclude: true
   <div class="spinner-grow text-primary" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-grow text-body" role="status">
+  <div class="spinner-grow" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
 </div>
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <div class="spinner-border" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
   <div class="spinner-border text-primary" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-border text-body" role="status">
+  <div class="spinner-border" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
   <div class="spinner-grow" role="status">
@@ -5383,21 +5383,21 @@ sitemap_exclude: true
   <div class="spinner-grow text-primary" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-grow text-body" role="status">
+  <div class="spinner-grow" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
 </div>
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <div class="spinner-border" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
   <div class="spinner-border text-primary" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-border text-body" role="status">
+  <div class="spinner-border" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
   <div class="spinner-grow" role="status">
@@ -5406,7 +5406,7 @@ sitemap_exclude: true
   <div class="spinner-grow text-primary" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-grow text-body" role="status">
+  <div class="spinner-grow" role="status">
     <span class="visually-hidden">Loading...</span>
   </div>
 </div>
@@ -5420,7 +5420,7 @@ sitemap_exclude: true
   <div class="spinner-border text-primary" role="status" data-bs-theme="dark">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-border text-body" role="status" data-bs-theme="dark">
+  <div class="spinner-border" role="status" data-bs-theme="dark">
     <span class="visually-hidden">Loading...</span>
   </div>
   <div class="spinner-grow" role="status" data-bs-theme="dark">
@@ -5429,7 +5429,7 @@ sitemap_exclude: true
   <div class="spinner-grow text-primary" role="status" data-bs-theme="dark">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-grow text-body" role="status" data-bs-theme="dark">
+  <div class="spinner-grow" role="status" data-bs-theme="dark">
     <span class="visually-hidden">Loading...</span>
   </div>
 </div>
@@ -5443,7 +5443,7 @@ sitemap_exclude: true
   <div class="spinner-border text-primary" role="status" data-bs-theme="light">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-border text-body" role="status" data-bs-theme="light">
+  <div class="spinner-border" role="status" data-bs-theme="light">
     <span class="visually-hidden">Loading...</span>
   </div>
   <div class="spinner-grow" role="status" data-bs-theme="light">
@@ -5452,7 +5452,7 @@ sitemap_exclude: true
   <div class="spinner-grow text-primary" role="status" data-bs-theme="light">
     <span class="visually-hidden">Loading...</span>
   </div>
-  <div class="spinner-grow text-body" role="status" data-bs-theme="light">
+  <div class="spinner-grow" role="status" data-bs-theme="light">
     <span class="visually-hidden">Loading...</span>
   </div>
 </div>
@@ -5486,7 +5486,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <nav class="stepped-process" aria-label="Checkout process">
     <p class="float-start mt-2 me-2 fw-bold d-sm-none">Step</p>
     <ol>
@@ -5511,7 +5511,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <nav class="stepped-process" aria-label="Checkout process">
     <p class="float-start mt-2 me-2 fw-bold d-sm-none">Step</p>
     <ol>
@@ -5609,7 +5609,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body d-flex" data-bs-theme="dark">
+<div class="border p-3 d-flex" data-bs-theme="dark">
   <div class="sticker sticker-sm">
     <p class="mb-0">
       <span class="sticker-fs-s mb-0 d-block text-decoration-line-through" aria-hidden="true">69.99 €</span>
@@ -5630,7 +5630,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body d-flex" data-bs-theme="light">
+<div class="border p-3 d-flex" data-bs-theme="light">
   <div class="sticker sticker-sm">
     <p class="mb-0">
       <span class="sticker-fs-s mb-0 d-block text-decoration-line-through" aria-hidden="true">69.99 €</span>
@@ -5738,7 +5738,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <ul class="list-unstyled d-flex gap-2 flex-wrap m-0">
     <li>
       <input type="checkbox" class="btn-check" id="btncheck-mobile2" autocomplete="off">
@@ -5781,7 +5781,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <ul class="list-unstyled d-flex gap-2 flex-wrap m-0">
     <li>
       <input type="checkbox" class="btn-check" id="btncheck-mobile3" autocomplete="off">
@@ -5922,7 +5922,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <div class="title-bar">
     <div class="container-xxl">
       <h1 class="display-1">Title</h1>
@@ -5932,7 +5932,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <div class="title-bar">
     <div class="container-xxl">
       <h1 class="display-1">Title</h1>
@@ -5974,7 +5974,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap align-items-center border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap align-items-center border p-3" data-bs-theme="dark">
   <div class="tooltip bs-tooltip-auto show position-relative" role="tooltip" data-popper-placement="right">
     <div class="tooltip-arrow position-absolute " style="transform: translate(0px, 14px);"></div>
     <div class="tooltip-inner">Tooltip</div>
@@ -5984,7 +5984,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap align-items-center border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap align-items-center border p-3" data-bs-theme="light">
   <div class="tooltip bs-tooltip-auto show position-relative" role="tooltip" data-popper-placement="right">
     <div class="tooltip-arrow position-absolute " style="transform: translate(0px, 14px);"></div>
     <div class="tooltip-inner">Tooltip</div>
@@ -6094,7 +6094,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex flex-column align-items-start border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex flex-column align-items-start border p-3" data-bs-theme="dark">
   <h1>H1</h1>
   <h2>H2</h2>
   <h3>H3</h3>
@@ -6170,7 +6170,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex flex-column align-items-start border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex flex-column align-items-start border p-3" data-bs-theme="light">
   <h1>H1</h1>
   <h2>H2</h2>
   <h3>H3</h3>
@@ -6524,7 +6524,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <fieldset>
     <legend>Example legend</legend>
     <p>
@@ -6648,7 +6648,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <fieldset>
     <legend>Example legend</legend>
     <p>
@@ -7097,7 +7097,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <table class="table table-hover mb-5">
     <caption>Boosted tables basic and hover look</caption>
     <thead>
@@ -7172,7 +7172,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <table class="table table-hover mb-5">
     <caption>Boosted tables basic and hover look</caption>
     <thead>
@@ -7408,14 +7408,14 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <input type="color" class="form-control form-control-color" value="#a885d8" title="Choose your color">
   <input type="color" class="form-control form-control-color" value="#a885d8" title="Choose your color" disabled>
 </div>
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <input type="color" class="form-control form-control-color" value="#a885d8" title="Choose your color">
   <input type="color" class="form-control form-control-color" value="#a885d8" title="Choose your color" disabled>
 </div>
@@ -7453,7 +7453,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body bd-example-indeterminate" data-bs-theme="dark">
+<div class="border p-3 bd-example-indeterminate" data-bs-theme="dark">
   <input class="form-check-input" type="checkbox" value="">
   <input class="form-check-input" type="checkbox" value="" checked>
   <input class="form-check-input" type="checkbox" value="" id="Indeterminate1">
@@ -7468,7 +7468,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body bd-example-indeterminate" data-bs-theme="light">
+<div class="border p-3 bd-example-indeterminate" data-bs-theme="light">
   <input class="form-check-input" type="checkbox" value="">
   <input class="form-check-input" type="checkbox" value="" checked>
   <input class="form-check-input" type="checkbox" value="" id="Indeterminate3">
@@ -7527,7 +7527,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <input type="text" class="form-control" placeholder="Input placeholder">
   <textarea class="form-control" rows="2" placeholder="Textarea placeholder"></textarea>
   <input type="text" class="form-control" placeholder="Disabled input placeholder" disabled>
@@ -7539,7 +7539,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <input type="text" class="form-control" placeholder="Input placeholder">
   <textarea class="form-control" rows="2" placeholder="Textarea placeholder"></textarea>
   <input type="text" class="form-control" placeholder="Disabled input placeholder" disabled>
@@ -7584,14 +7584,14 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <input class="form-control" type="file">
   <input class="form-control" type="file" disabled>
 </div>
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <input class="form-control" type="file">
   <input class="form-control" type="file" disabled>
 </div>
@@ -7624,7 +7624,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <button type="button" class="form-helper" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Help for input"><span class="visually-hidden">Helper for input</span></button>
   <div>
     <label class="form-label is-required">Input label</label>
@@ -7634,7 +7634,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <button type="button" class="form-helper" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Help for input"><span class="visually-hidden">Helper for input</span></button>
   <div>
     <label class="form-label is-required">Input label</label>
@@ -7687,7 +7687,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <div class="mb-3">
     <div class="input-group">
       <span class="input-group-text">Input group text</span>
@@ -7708,7 +7708,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <div class="mb-3">
     <div class="input-group">
       <span class="input-group-text">Input group text</span>
@@ -7783,7 +7783,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex flex-column border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex flex-column border p-3" data-bs-theme="dark">
   <label class="form-label">Form label</label>
   <label class="form-label is-required">Form label</label>
   <label class="form-label is-disabled">Form label</label>
@@ -7793,7 +7793,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex flex-column border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex flex-column border p-3" data-bs-theme="light">
   <label class="form-label">Form label</label>
   <label class="form-label is-required">Form label</label>
   <label class="form-label is-disabled">Form label</label>
@@ -7848,7 +7848,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 border p-3" data-bs-theme="dark">
   <div class="quantity-selector">
     <input type="number" id="inputQuantitySelector1" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="5" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
     <button type="button" class="btn btn-icon btn-outline-secondary" aria-describedby="inputQuantitySelector1" data-bs-step="down">
@@ -7871,7 +7871,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 border p-3" data-bs-theme="light">
   <div class="quantity-selector">
     <input type="number" id="inputQuantitySelector2" class="form-control" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="5" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector">
     <button type="button" class="btn btn-icon btn-outline-secondary" aria-describedby="inputQuantitySelector2" data-bs-step="down">
@@ -7949,14 +7949,14 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <input type="range" class="form-range">
   <input type="range" class="form-range" disabled>
 </div>
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <input type="range" class="form-range">
   <input type="range" class="form-range" disabled>
 </div>
@@ -7996,7 +7996,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <select class="form-select" aria-label="Default select example">
     <option selected>Open this select menu</option>
     <option value="1">One</option>
@@ -8013,7 +8013,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <select class="form-select" aria-label="Default select example">
     <option selected>Open this select menu</option>
     <option value="1">One</option>
@@ -8107,7 +8107,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="dark">
+<div class="border p-3" data-bs-theme="dark">
   <form><fieldset class="star-rating">
     <legend class="visually-hidden">Results relevance</legend>
     <input type="radio" id="terrible2" name="rating" value="1" class="visually-hidden">
@@ -8148,7 +8148,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="border p-3 bg-body" data-bs-theme="light">
+<div class="border p-3" data-bs-theme="light">
   <form><fieldset class="star-rating">
     <legend class="visually-hidden">Results relevance</legend>
     <input type="radio" id="terrible3" name="rating" value="1" class="visually-hidden">
@@ -8290,7 +8290,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex border p-3" data-bs-theme="dark">
   <div class="form-check form-switch">
     <input class="form-check-input" type="checkbox" role="switch">
   </div>
@@ -8307,7 +8307,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex border p-3" data-bs-theme="light">
   <div class="form-check form-switch">
     <input class="form-check-input" type="checkbox" role="switch">
   </div>
@@ -8467,7 +8467,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex flex-column gap-2 align-items-start border border-tertiary p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex flex-column gap-2 align-items-start border border-tertiary p-3" data-bs-theme="dark">
   <div class="d-flex gap-2 flex-wrap">
     <input type="checkbox" class="btn-check" id="btn-check11" autocomplete="off">
     <label class="btn btn-toggle" for="btn-check11">Single toggle</label>
@@ -8574,7 +8574,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex flex-column gap-2 align-items-start border border-tertiary p-3 bg-body" data-bs-theme="light">
+<div class="d-flex flex-column gap-2 align-items-start border border-tertiary p-3" data-bs-theme="light">
   <div class="d-flex gap-2 flex-wrap">
     <input type="checkbox" class="btn-check" id="btn-check12" autocomplete="off">
     <label class="btn btn-toggle" for="btn-check12">Single toggle</label>
@@ -8920,7 +8920,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-column border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-column border p-3" data-bs-theme="dark">
   <input type="text" class="form-control is-valid" value="Mark">
   <select class="form-select is-valid"><option selected disabled value="">Choose...</option><option>...</option></select>
   <input type="file" class="form-control is-valid">
@@ -8943,7 +8943,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-column border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-column border p-3" data-bs-theme="light">
   <input type="text" class="form-control is-valid" value="Mark">
   <select class="form-select is-valid"><option selected disabled value="">Choose...</option><option>...</option></select>
   <input type="file" class="form-control is-valid">
@@ -9040,7 +9040,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary);" class="bg-primary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary);" class="bg-secondary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary);" class="bg-success"></div>
@@ -9064,7 +9064,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary);" class="bg-primary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary);" class="bg-secondary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary);" class="bg-success"></div>
@@ -9153,7 +9153,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <div style="width: 2.5rem; height: 2.5rem; background-color: var(--bs-secondary-bg);" class="border border-primary"></div>
   <div style="width: 2.5rem; height: 2.5rem; background-color: var(--bs-secondary-bg);" class="border border-secondary"></div>
   <div style="width: 2.5rem; height: 2.5rem; background-color: var(--bs-secondary-bg);" class="border border-success"></div>
@@ -9168,7 +9168,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <div style="width: 2.5rem; height: 2.5rem; background-color: var(--bs-secondary-bg);" class="border border-primary"></div>
   <div style="width: 2.5rem; height: 2.5rem; background-color: var(--bs-secondary-bg);" class="border border-secondary"></div>
   <div style="width: 2.5rem; height: 2.5rem; background-color: var(--bs-secondary-bg);" class="border border-success"></div>
@@ -9234,7 +9234,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="text-primary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="text-secondary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="text-success"></div>
@@ -9253,7 +9253,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="text-primary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="text-secondary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="text-success"></div>
@@ -9326,7 +9326,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="link-primary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="link-secondary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="link-success"></div>
@@ -9340,7 +9340,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="link-primary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="link-secondary"></div>
   <div style="width: 2.5rem; height: 2.5rem; border: 2px solid var(--bs-secondary); background-color: currentColor;" class="link-success"></div>
@@ -9399,7 +9399,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary);" class="text-bg-primary"><div style="width: 100%; height: 100%; background-color: currentColor;"></div></div>
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary);" class="text-bg-secondary"><div style="width: 100%; height: 100%; background-color: currentColor;"></div></div>
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary);" class="text-bg-success"><div style="width: 100%; height: 100%; background-color: currentColor;"></div></div>
@@ -9412,7 +9412,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary);" class="text-bg-primary"><div style="width: 100%; height: 100%; background-color: currentColor;"></div></div>
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary);" class="text-bg-secondary"><div style="width: 100%; height: 100%; background-color: currentColor;"></div></div>
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary);" class="text-bg-success"><div style="width: 100%; height: 100%; background-color: currentColor;"></div></div>
@@ -9466,7 +9466,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary); background-color: var(--bs-focus-ring-color);" class="focus-ring-primary"></div>
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary); background-color: var(--bs-focus-ring-color);" class="focus-ring-secondary"></div>
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary); background-color: var(--bs-focus-ring-color);" class="focus-ring-success"></div>
@@ -9479,7 +9479,7 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary); background-color: var(--bs-focus-ring-color);" class="focus-ring-primary"></div>
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary); background-color: var(--bs-focus-ring-color);" class="focus-ring-secondary"></div>
   <div style="width: 2.5rem; height: 2.5rem; padding: 8px; border: 2px solid var(--bs-secondary); background-color: var(--bs-focus-ring-color);" class="focus-ring-success"></div>
@@ -9526,13 +9526,13 @@ sitemap_exclude: true
 
 <h4 class="mt-3">Dark theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="dark">
   <a class="link-chevron" href="#">This is a sample link with chevron</a>
 </div>
 
 <h4 class="mt-3">Light theme on container</h4>
 
-<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+<div class="d-flex gap-2 flex-wrap border p-3" data-bs-theme="light">
   <a class="link-chevron" href="#">This is a sample link with chevron</a>
 </div>
 

--- a/site/content/docs/5.3/examples/download-app/index.html
+++ b/site/content/docs/5.3/examples/download-app/index.html
@@ -50,7 +50,7 @@ aliases:
 </header>
 
 <main>
-  <div class="text-body bg-dark mb-0 mb-md-2 border-dark border-bottom border-1 position-relative" data-bs-theme="dark">
+  <div class="bg-dark mb-0 mb-md-2 border-dark border-bottom border-1 position-relative" data-bs-theme="dark">
     <div class="col-12 col-lg-7 out-of-grid h-100 end-0 overflow-hidden">
       <img loading="lazy" class="h-100 object-fit-cover" alt="" src="img/Banner_image.png">
     </div>
@@ -192,7 +192,7 @@ aliases:
     </div>
   </div>
 
-  <div class="text-body bg-dark py-4 py-md-5 border-bottom border-1 border-dark" data-bs-theme="dark">
+  <div class="bg-dark py-4 py-md-5 border-bottom border-1 border-dark" data-bs-theme="dark">
     <div class="container-xxl pt-md-2 pb-2">
       <h2 class="h1 mb-4 mb-md-5 text-primary text-center">What you get from the showcase app</h2>
       <div class="row">
@@ -315,7 +315,7 @@ aliases:
     </div>
   </div>
 
-  <div class="py-4 py-md-5 text-body bg-supporting-yellow" data-bs-theme="light">
+  <div class="py-4 py-md-5 bg-supporting-yellow" data-bs-theme="light">
     <div class="container-xxl d-flex justify-content-center pt-md-2 pb-2">
       <div class="col-12 col-md-6">
         <h2 class="h1 mb-2 mb-md-3 text-center">Your feedback is valued</h2>

--- a/site/content/docs/5.3/examples/form/index.html
+++ b/site/content/docs/5.3/examples/form/index.html
@@ -70,7 +70,7 @@ aliases:
   </nav>
 </header>
 <main class="bd-content order-1">
-  <div class="bg-body title-bar">
+  <div class="title-bar">
     <div class="container-xxl d-block">
       <div class="row">
         <div class="col-sm-12 col-lg-5 offset-lg-3">

--- a/site/content/docs/5.3/guidelines/_index.md
+++ b/site/content/docs/5.3/guidelines/_index.md
@@ -17,7 +17,7 @@ aliases:
         <div class="card border-1 mb-2 mb-md-3 mb-lg-0">
           <img class="card-img-top" src="/docs/{{ $.Site.Params.docs_version }}/{{.image}}" alt="">
           <div class="card-body ps-2 pt-2">
-            <a href="{{.link}}" class="stretched-link text-decoration-none h4 text-body" aria-label="{{.description}}" title="{{.description}}">{{.name}}</a>
+            <a href="{{.link}}" class="stretched-link text-decoration-none h4" aria-label="{{.description}}" title="{{.description}}">{{.name}}</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Description

This PR tries a new approach with an automatic set of `color:` and `background-color:` linked to `[data-bs-theme]` attribute.

So when your create a `<div data-bs-theme="dark">` the content will be automatically rendered with a dark background and a white text in Boosted.

Based on this modification, this PR also sets the Sass and/or CSS variables of components handling color and/or bg color to `null` by default, or `inherit`, and also sometimes sets the background to transparent.

#### More info 

We decided to make big components (components with multiple layers) to inherit the color because it seemed more logical. Some components escape this logic such as spinners. It's because it's not really the color that is redefined but the use of `currentColor`. 
All this is due to a technical issue we have when the theme is set directly on the component.

If the component sets `color` at the top level, it overrides the `color` coming from the `data-bs-theme` so if it's set to `null` or `inherit`, it will inherit the color above and avoid `data-bs-theme` `color`. On multiple-layer components it's easier to handle since we only need to avoid declaring `color` at the top level of this component.

Weird behavior for titles. For example `h1` -> Redefines color but `.h1` -> inherits when the data theme is placed on them directly.

For basic elements, form elements and input labels, we decided to keep the behavior as-is. Most likely the theme won't be applied to "basic" elements themselves. And the users could override this behavior if they are using this edge case.

#### Note

- We got rid of `text-body` classes in dark mode page for basic elements introduced by https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2355 to really test the impact of this PR in this context.

<details>
<summary>We chose not to modify <code>color-mode()</code> mixin, here's why...</summary>

### Not covered in this PR

Based on this modification, it would be possible to do the following in components:

```scss
@include color-mode(light, true) {
  --#{$prefix}accordion-btn-icon: #{escape-svg($accordion-button-icon)};
  --#{$prefix}accordion-btn-active-icon: #{escape-svg($accordion-button-active-icon)};
}

@if $enable-dark-mode {
  @include color-mode(dark, true) {
    --#{$prefix}accordion-btn-icon: #{escape-svg($accordion-button-icon-dark)};
    --#{$prefix}accordion-btn-active-icon: #{escape-svg($accordion-button-active-icon-dark)};
  }
}
```

instead of the current in Bootstrap which doesn't work when a light accordion is declared within a dark container: 

```scss
@if $enable-dark-mode {
  @include color-mode(dark) {
    .accordion-button::after {
      --#{$prefix}accordion-btn-icon: #{escape-svg($accordion-button-icon-dark)};
      --#{$prefix}accordion-btn-active-icon: #{escape-svg($accordion-button-active-icon-dark)};
    }
  }
}
```
</details>