### PR TITLE
fix(form-control-color): adjust size when valid feedback

### DIFF
--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -30,7 +30,7 @@
           padding-right: $input-height-inner;
           background-image: escape-svg($icon);
           background-repeat: no-repeat;
-          background-position: right subtract($input-height-inner-quarter, 2px) top subtract($input-height-inner-quarter, 2px);
+          background-position: right subtract($input-height-inner-quarter, $input-border-width) top subtract($input-height-inner-quarter, $input-border-width);
           background-size: $input-height-inner-half $input-height-inner-half;
         }
       }
@@ -49,7 +49,7 @@
 
       .form-control-color {
         @include form-validation-state-selector($state) {
-          width: calc(#{$form-color-width} + #{$input-height-inner-half} + #{$input-height-inner-quarter} - 2px); // stylelint-disable-line function-disallowed-list
+          width: calc(#{$form-color-width} + #{$input-height-inner-half} + #{$input-height-inner-quarter} - #{$input-border-width}); // stylelint-disable-line function-disallowed-list
         }
       }
     }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -49,7 +49,7 @@
 
       .form-control-color {
         @include form-validation-state-selector($state) {
-          width: add($form-color-width, $input-height-inner);
+          width: calc($form-color-width + $form-feedback-icon-size + .8125rem); // stylelint-disable-line function-disallowed-list
         }
       }
     }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -30,7 +30,7 @@
           padding-right: $input-height-inner;
           background-image: escape-svg($icon);
           background-repeat: no-repeat;
-          background-position: right $input-height-inner-quarter top subtract($input-height-inner-quarter, 2px);
+          background-position: right subtract($input-height-inner-quarter, 2px) top subtract($input-height-inner-quarter, 2px);
           background-size: $input-height-inner-half $input-height-inner-half;
         }
       }
@@ -49,7 +49,7 @@
 
       .form-control-color {
         @include form-validation-state-selector($state) {
-          width: calc(#{$form-color-width} + #{$form-feedback-icon-size} + .8125rem); // stylelint-disable-line function-disallowed-list
+          width: calc(#{$form-color-width} + #{$input-height-inner-half} + subtract($input-height-inner-quarter, 2px)); // stylelint-disable-line function-disallowed-list
         }
       }
     }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -49,7 +49,7 @@
 
       .form-control-color {
         @include form-validation-state-selector($state) {
-          width: calc(#{$form-color-width} + #{$input-height-inner-half} + subtract(#{$input-height-inner-quarter}, 2px)); // stylelint-disable-line function-disallowed-list
+          width: calc(#{$form-color-width} + #{$input-height-inner-half} + #{$input-height-inner-quarter} - 2px); // stylelint-disable-line function-disallowed-list
         }
       }
     }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -49,7 +49,7 @@
 
       .form-control-color {
         @include form-validation-state-selector($state) {
-          width: calc($form-color-width + $form-feedback-icon-size + .8125rem); // stylelint-disable-line function-disallowed-list
+          width: calc(#{$form-color-width} + #{$form-feedback-icon-size} + .8125rem); // stylelint-disable-line function-disallowed-list
         }
       }
     }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -49,7 +49,7 @@
 
       .form-control-color {
         @include form-validation-state-selector($state) {
-          width: calc(#{$form-color-width} + #{$input-height-inner-half} + subtract($input-height-inner-quarter, 2px)); // stylelint-disable-line function-disallowed-list
+          width: calc(#{$form-color-width} + #{$input-height-inner-half} + subtract(#{$input-height-inner-quarter}, 2px)); // stylelint-disable-line function-disallowed-list
         }
       }
     }

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -11,6 +11,14 @@ extra_js:
     async: true
 ---
 
+## Form color validation test
+
+<div class="d-flex gap-2 flex-column border border-tertiary p-3">
+  <input type="color" class="form-control form-control-color" value="#a885d8" title="Choose your color">
+  <input type="color" class="form-control form-control-color is-valid" value="#a885d8" title="Choose your color">
+  <div><input type="color" class="form-control form-control-color is-invalid" value="#a885d8" title="Choose your color"><p class="mb-0 invalid-feedback">Invalid feedback</p></div>
+</div>
+
 {{< callout warning >}}
 We are aware that currently the client-side custom validation styles and tooltips are not accessible, since they are not exposed to assistive technologies. While we work on a solution, we'd recommend either using the server-side option or the default browser validation method.
 {{< /callout >}}

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -11,14 +11,6 @@ extra_js:
     async: true
 ---
 
-## Form color validation test
-
-<div class="d-flex gap-2 flex-column border border-tertiary p-3">
-  <input type="color" class="form-control form-control-color" value="#a885d8" title="Choose your color">
-  <input type="color" class="form-control form-control-color is-valid" value="#a885d8" title="Choose your color">
-  <div><input type="color" class="form-control form-control-color is-invalid" value="#a885d8" title="Choose your color"><p class="mb-0 invalid-feedback">Invalid feedback</p></div>
-</div>
-
 {{< callout warning >}}
 We are aware that currently the client-side custom validation styles and tooltips are not accessible, since they are not exposed to assistive technologies. While we work on a solution, we'd recommend either using the server-side option or the default browser validation method.
 {{< /callout >}}


### PR DESCRIPTION
### Description

Spotted in https://deploy-preview-2302--boosted.netlify.app/docs/5.3/dark-mode/#form-validation while working on the dark mode, the rendering of the form control color when the feedback is valid is odd:

![Screenshot 2023-10-26 at 08 18 12](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/c5928462-5082-497d-8198-3f15babe73a9)

The purple area should be square like for the other states.

This PR fixes it to have this unified rendering whatever the states:


![Screenshot 2023-10-26 at 12 11 56](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/b210191f-b843-49fa-afaf-0e55584e4abc)

While we were working on this issue, we spotted another issue that is linked to the right-padding of the valid icon which was too important. With this PR, this padding has the same value (for all form controls) as the top/bottom padding.
Only the left padding of the input is bigger, but this is probably by design.

Some issues have been created based on the development of this one:
- https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2342

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

- https://deploy-preview-2341--boosted.netlify.app/docs/5.3/forms/validation/

