### PR TITLE
chore(deps-dev): bump `tarteaucitronjs` from 1.14.0 to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "storybook": "^7.5.1",
         "stylelint": "^15.10.3",
         "stylelint-config-twbs-bootstrap": "^11.0.1",
-        "tarteaucitronjs": "^1.14.0",
+        "tarteaucitronjs": "^1.15.0",
         "terser": "^5.20.0",
         "vnu-jar": "^23.4.11"
       },
@@ -19924,9 +19924,9 @@
       "dev": true
     },
     "node_modules/tarteaucitronjs": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.14.0.tgz",
-      "integrity": "sha512-NjuzYq6gvoEdzSH9aO2+N3fJdjJ0tdtwrWT8vLYVHoPjoPMha29h5ULN3dHx8VPG1anzZzlBSczVHSe0h1IRpQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.15.0.tgz",
+      "integrity": "sha512-iLwDlbRR/jS6A5WiSA8XW26czFFFGGMV3sBvbZeSvZk5edAjl3j4pDZqkqWvpiWDRnEGC1xxHQ3RXp5IyIMdpA==",
       "dev": true
     },
     "node_modules/telejson": {
@@ -35758,9 +35758,9 @@
       }
     },
     "tarteaucitronjs": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.14.0.tgz",
-      "integrity": "sha512-NjuzYq6gvoEdzSH9aO2+N3fJdjJ0tdtwrWT8vLYVHoPjoPMha29h5ULN3dHx8VPG1anzZzlBSczVHSe0h1IRpQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.15.0.tgz",
+      "integrity": "sha512-iLwDlbRR/jS6A5WiSA8XW26czFFFGGMV3sBvbZeSvZk5edAjl3j4pDZqkqWvpiWDRnEGC1xxHQ3RXp5IyIMdpA==",
       "dev": true
     },
     "telejson": {

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "storybook": "^7.5.1",
     "stylelint": "^15.10.3",
     "stylelint-config-twbs-bootstrap": "^11.0.1",
-    "tarteaucitronjs": "^1.14.0",
+    "tarteaucitronjs": "^1.15.0",
     "terser": "^5.20.0",
     "vnu-jar": "^23.4.11"
   },


### PR DESCRIPTION
### Description

This PR bumps `tarteaucitronjs` dev dep from 1.14.0 to 1.15.0.

I analyzed the [diff between 1.14.0 and 1.15.0](https://github.com/AmauriC/tarteaucitron.js/compare/v1.14.0...v1.15.0) and couldn't spot any impacting modifications, even if some enhancements have been done on the CSS side.

Here's the rendering before:
<img width="1459" alt="Screenshot 2023-10-30 at 08 18 54" src="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/c3be8c89-a24e-46d8-bf1e-3df3afc5b255">
<img width="1206" alt="Screenshot 2023-10-30 at 08 18 43" src="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/9d4aff6a-afa0-485c-aac3-db4a65ec3c93">

Here's the new rendering:
<img width="1460" alt="Screenshot 2023-10-30 at 08 19 23" src="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/6b8c4c41-385c-49da-8127-77fa9dd840a5">
<img width="1202" alt="Screenshot 2023-10-30 at 08 19 02" src="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/7c226b3e-a426-4074-81e3-d2fce05a692a">

The only difference is the breakline which is not defined in ODS anyway. So let's continue to keep what's from tac. 
