### PR TITLE
Dark mode: Title bars

### DIFF
--- a/scss/_title-bars.scss
+++ b/scss/_title-bars.scss
@@ -1,5 +1,7 @@
 .title-bar {
   // scss-docs-start title-bar-css-vars
+  --#{$prefix}title-bar-bg: #{$title-bar-bg};
+  --#{$prefix}title-bar-color: #{$title-bar-color};
   --#{$prefix}title-bar-image-ratio: #{$title-bar-image-ratio};
   --#{$prefix}title-bar-padding-y: #{$title-bar-padding-y};
   --#{$prefix}title-bar-font-size: #{$title-bar-font-size};
@@ -9,6 +11,8 @@
   --#{$prefix}title-bar-border-color: #{$title-bar-border-color};
   // scss-docs-end title-bar-css-vars
 
+  color: var(--#{$prefix}title-bar-color);
+  background-color: var(--#{$prefix}title-bar-bg);
   border-bottom: var(--#{$prefix}title-bar-border-width) solid var(--#{$prefix}title-bar-border-color);
 
   @include media-breakpoint-up(md) {
@@ -19,11 +23,6 @@
   @include media-breakpoint-up(xl) {
     --#{$prefix}title-bar-font-size: #{$title-bar-font-size-xl};
     --#{$prefix}title-bar-letter-spacing: #{$title-bar-letter-spacing-xl};
-  }
-
-  &.bg-dark,
-  &.bg-secondary {
-    --#{$prefix}title-bar-border-color: #{$title-bar-border-color-dark};
   }
 
   > [class*="container"] {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -2065,13 +2065,15 @@ $figure-caption-color:              $gray-900 !default; // Boosted mod: instead 
 // Title bars
 
 // scss-docs-start title-bars-variables
+$title-bar-bg:                      var(--#{$prefix}body-bg) !default;
+$title-bar-color:                   var(--#{$prefix}body-color) !default;
 $title-bar-image-ratio:             1.8em !default;
 $title-bar-padding-y:               .3333333em !default;
 $title-bar-font-size:               $h2-font-size !default;
 $title-bar-line-height:             $display-line-height !default;
 $title-bar-letter-spacing:          $h2-spacing !default;
 $title-bar-border-width:            calc(var(--#{$prefix}border-width) * .5) !default; // stylelint-disable-line function-disallowed-list
-$title-bar-border-color:            $gray-500 !default;
+$title-bar-border-color:            var(--#{$prefix}border-color-translucent) !default;
 
 $title-bar-font-size-md:            $display2-size !default;
 $title-bar-letter-spacing-md:       $display2-spacing !default;
@@ -2079,7 +2081,9 @@ $title-bar-letter-spacing-md:       $display2-spacing !default;
 $title-bar-font-size-xl:            $display1-size !default;
 $title-bar-letter-spacing-xl:       $display1-spacing !default;
 
-$title-bar-border-color-dark:       $gray-700 !default;
+// fusv-disable
+$title-bar-border-color-dark:       $gray-700 !default; // Deprecated in v5.3.3
+// fusv-enable
 // scss-docs-end title-bars-variables
 // End mod
 

--- a/site/content/docs/5.3/components/title-bars.md
+++ b/site/content/docs/5.3/components/title-bars.md
@@ -19,15 +19,15 @@ See them in action in our [examples page]({{<docsref "/examples/title-bars">}}).
 
 ## Background color
 
-To change the appearance of a title bar, use our [background utilities]({{<docsref "/utilities/background">}}). Orange branded background utilities are `.bg-dark`, `.bg-white` and `.bg-supporting-*`.'
+To change the appearance of a title bar, use our [background utilities]({{<docsref "/utilities/background">}}). Orange branded background utilities are `.bg-supporting-*`.'
 
-Title bars can be displayed with black or white backgrounds. When using black or white backgrounds, illustrations can be included as an option, but it's not necessary.
+Title bars can be displayed with dark or white backgrounds. When using dark or white backgrounds, illustrations can be included as an option, but it's not necessary.
 Supporting colors can also be used as the background color for title bars, but not the supporting light and dark tint colors. When using one of the supporting colors, illustrations must be used.
 
-The image should not overlap on title and the title shouldn't wrap. If this happens, please **transform your title bar** into a white/black one without any image.
+The image should not overlap on title and the title shouldn't wrap. If this happens, please **transform your title bar** into a white/dark one without any image.
 
 {{< example class="p-0">}}
-<div class="bg-body title-bar">
+<div class="title-bar">
   <div class="container-xxl">
     <h1 class="display-1">Title</h1>
   </div>
@@ -35,7 +35,7 @@ The image should not overlap on title and the title shouldn't wrap. If this happ
 
 <div class="mt-3"></div>
 
-<div class="bg-dark title-bar">
+<div class="bg-dark title-bar" data-bs-theme="dark">
   <div class="container-xxl">
     <h1 class="display-1">Title</h1>
   </div>
@@ -43,7 +43,7 @@ The image should not overlap on title and the title shouldn't wrap. If this happ
 
 <div class="mt-3"></div>
 
-<div class="bg-supporting-green title-bar">
+<div class="bg-supporting-green title-bar" data-bs-theme="light">
   <div class="container-xxl">
     <h1 class="display-1">Title</h1>
     <picture>
@@ -68,7 +68,7 @@ Several options are available to add an image in a title bar.
 We **strongly recommend** to use `srcset` attribute as it is [well supported](https://caniuse.com/srcset) by browsers and allows you to load an image depending on the user's device. However, it might introduce a delay to display the image while resizing.
 
 {{< example class="p-0">}}
-<div class="bg-supporting-pink title-bar">
+<div class="bg-supporting-pink title-bar" data-bs-theme="light">
   <div class="container-xxl">
     <h1 class="display-1">Title</h1>
     <picture>
@@ -87,7 +87,7 @@ We **strongly recommend** to use `srcset` attribute as it is [well supported](ht
 ### HTML `<svg>` tag
 
 {{< example class="p-0">}}
-<div class="bg-supporting-purple title-bar">
+<div class="bg-supporting-purple title-bar" data-bs-theme="light">
   <div class="container-xxl">
     <h1 class="display-1">Title</h1>
     <svg aria-hidden="true" focusable="false" width="1.8em"><use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#document"/></svg>
@@ -98,7 +98,7 @@ We **strongly recommend** to use `srcset` attribute as it is [well supported](ht
 ### HTML `<img>` tag
 
 {{< example class="p-0">}}
-<div class="bg-supporting-green title-bar">
+<div class="bg-supporting-green title-bar" data-bs-theme="light">
   <div class="container-xxl">
     <h1 class="display-1">Title</h1>
     <img src="/docs/{{< param docs_version >}}/assets/img/title-bars-illustrations/illustration-320.png" alt="" class="d-sm-none">

--- a/site/content/docs/5.3/components/title-bars.md
+++ b/site/content/docs/5.3/components/title-bars.md
@@ -19,9 +19,9 @@ See them in action in our [examples page]({{<docsref "/examples/title-bars">}}).
 
 ## Background color
 
-To change the appearance of a title bar, use our [background utilities]({{<docsref "/utilities/background">}}). Orange branded background utilities are `.bg-supporting-*`.'
+To change the appearance of a title bar, use our [background utilities]({{<docsref "/utilities/background">}}). Orange branded background utilities are `.bg-dark`, `.bg-white` and `.bg-supporting-*`.
 
-Title bars can be displayed with dark or white backgrounds. When using dark or white backgrounds, illustrations can be included as an option, but it's not necessary.
+Title bars can be displayed with `.bg-black`, `.bg-dark`, `.bg-white` or no background. When using `.bg-black`, `.bg-dark`, `.bg-white` or no background, illustrations can be included as an option, but it's not necessary.
 Supporting colors can also be used as the background color for title bars, but not the supporting light and dark tint colors. When using one of the supporting colors, illustrations must be used.
 
 The image should not overlap on title and the title shouldn't wrap. If this happens, please **transform your title bar** into a white/dark one without any image.

--- a/site/content/docs/5.3/components/title-bars.md
+++ b/site/content/docs/5.3/components/title-bars.md
@@ -21,10 +21,11 @@ See them in action in our [examples page]({{<docsref "/examples/title-bars">}}).
 
 To change the appearance of a title bar, use our [background utilities]({{<docsref "/utilities/background">}}). Orange branded background utilities are `.bg-dark`, `.bg-white` and `.bg-supporting-*`.
 
-Title bars can be displayed with `.bg-black`, `.bg-dark`, `.bg-white` or no background. When using `.bg-black`, `.bg-dark`, `.bg-white` or no background, illustrations can be included as an option, but it's not necessary.
+Title bars can be displayed with `.bg-black`, `.bg-dark`, `.bg-white` or with the default background color. When using `.bg-black`, `.bg-dark`, `.bg-white` or the default background color, illustrations can be included as an option, but it's not necessary.
+
 Supporting colors can also be used as the background color for title bars, but not the supporting light and dark tint colors. When using one of the supporting colors, illustrations must be used.
 
-The image should not overlap on title and the title shouldn't wrap. If this happens, please **transform your title bar** into a white/dark one without any image.
+The image should not overlap on title and the title shouldn't wrap. If this happens, please transform your title bar into a title bar with `.bg-black`, `.bg-dark`, `.bg-white` or with the default background color without any image.
 
 {{< example class="p-0">}}
 <div class="title-bar">

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -7670,3 +7670,55 @@ sitemap_exclude: true
   <div class="form-check"><input class="form-check-input is-invalid" type="radio" value="" checked data-bs-theme="light"><p class="mb-0 invalid-feedback" data-bs-theme="light">Invalid feedback</p></div>
   <div class="quantity-selector w-100" data-bs-theme="light"><input type="number" class="form-control is-invalid" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector"><button type="button" class="btn btn-icon btn-outline-secondary" data-bs-step="down"><span class="visually-hidden">Step down</span></button><button type="button" class="btn btn-icon btn-outline-secondary" data-bs-step="up"><span class="visually-hidden">Step up</span></button><p class="mb-0 invalid-feedback" data-bs-theme="light">Invalid feedback</p></div>
 </div>
+
+### Title bars
+
+<h4 class="mt-3">No theme</h4>
+
+<div class="border border-tertiary p-3">
+  <div class="title-bar">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+    </div>
+  </div>
+</div>
+
+<h4 class="mt-3">Dark theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body" data-bs-theme="dark">
+  <div class="title-bar">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+    </div>
+  </div>
+</div>
+
+<h4 class="mt-3">Light theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body" data-bs-theme="light">
+  <div class="title-bar">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+    </div>
+  </div>
+</div>
+
+<h4 class="mt-3">Dark theme on component</h4>
+
+<div class="border border-tertiary p-3" style="background-color: #282d55;">
+  <div class="title-bar" data-bs-theme="dark">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+    </div>
+  </div>
+</div>
+
+<h4 class="mt-3">Light theme on component</h4>
+
+<div class="border border-tertiary p-3" style="background-color: #b5e8f7">
+  <div class="title-bar" data-bs-theme="light">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+    </div>
+  </div>
+</div>

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -5158,6 +5158,58 @@ sitemap_exclude: true
   </ul>
 </div>
 
+### Title bars
+
+<h4 class="mt-3">No theme</h4>
+
+<div class="border border-tertiary p-3">
+  <div class="title-bar">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+    </div>
+  </div>
+</div>
+
+<h4 class="mt-3">Dark theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body" data-bs-theme="dark">
+  <div class="title-bar">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+    </div>
+  </div>
+</div>
+
+<h4 class="mt-3">Light theme on container</h4>
+
+<div class="border border-tertiary p-3 bg-body" data-bs-theme="light">
+  <div class="title-bar">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+    </div>
+  </div>
+</div>
+
+<h4 class="mt-3">Dark theme on component</h4>
+
+<div class="border border-tertiary p-3" style="background-color: #282d55;">
+  <div class="title-bar" data-bs-theme="dark">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+    </div>
+  </div>
+</div>
+
+<h4 class="mt-3">Light theme on component</h4>
+
+<div class="border border-tertiary p-3" style="background-color: #b5e8f7">
+  <div class="title-bar" data-bs-theme="light">
+    <div class="container-xxl">
+      <h1 class="display-1">Title</h1>
+    </div>
+  </div>
+</div>
+
 ### Tooltips
 
 <h4 class="mt-3">No theme</h4>
@@ -7669,56 +7721,4 @@ sitemap_exclude: true
   <div class="form-check"><input class="form-check-input is-invalid" type="radio" value="" data-bs-theme="light"><p class="mb-0 invalid-feedback" data-bs-theme="light">Invalid feedback</p></div>
   <div class="form-check"><input class="form-check-input is-invalid" type="radio" value="" checked data-bs-theme="light"><p class="mb-0 invalid-feedback" data-bs-theme="light">Invalid feedback</p></div>
   <div class="quantity-selector w-100" data-bs-theme="light"><input type="number" class="form-control is-invalid" aria-live="polite" data-bs-step="counter" name="quantity" title="quantity" value="0" min="0" max="10" step="1" data-bs-round="0" aria-label="Quantity selector"><button type="button" class="btn btn-icon btn-outline-secondary" data-bs-step="down"><span class="visually-hidden">Step down</span></button><button type="button" class="btn btn-icon btn-outline-secondary" data-bs-step="up"><span class="visually-hidden">Step up</span></button><p class="mb-0 invalid-feedback" data-bs-theme="light">Invalid feedback</p></div>
-</div>
-
-### Title bars
-
-<h4 class="mt-3">No theme</h4>
-
-<div class="border border-tertiary p-3">
-  <div class="title-bar">
-    <div class="container-xxl">
-      <h1 class="display-1">Title</h1>
-    </div>
-  </div>
-</div>
-
-<h4 class="mt-3">Dark theme on container</h4>
-
-<div class="border border-tertiary p-3 bg-body" data-bs-theme="dark">
-  <div class="title-bar">
-    <div class="container-xxl">
-      <h1 class="display-1">Title</h1>
-    </div>
-  </div>
-</div>
-
-<h4 class="mt-3">Light theme on container</h4>
-
-<div class="border border-tertiary p-3 bg-body" data-bs-theme="light">
-  <div class="title-bar">
-    <div class="container-xxl">
-      <h1 class="display-1">Title</h1>
-    </div>
-  </div>
-</div>
-
-<h4 class="mt-3">Dark theme on component</h4>
-
-<div class="border border-tertiary p-3" style="background-color: #282d55;">
-  <div class="title-bar" data-bs-theme="dark">
-    <div class="container-xxl">
-      <h1 class="display-1">Title</h1>
-    </div>
-  </div>
-</div>
-
-<h4 class="mt-3">Light theme on component</h4>
-
-<div class="border border-tertiary p-3" style="background-color: #b5e8f7">
-  <div class="title-bar" data-bs-theme="light">
-    <div class="container-xxl">
-      <h1 class="display-1">Title</h1>
-    </div>
-  </div>
 </div>

--- a/site/content/docs/5.3/examples/title-bars/index.html
+++ b/site/content/docs/5.3/examples/title-bars/index.html
@@ -11,7 +11,7 @@ aliases:
 ---
 
 <main>
-  <div class="bg-body title-bar">
+  <div class="title-bar">
     <div class="container-xxl">
       <h1 class="display-1">Title</h1>
     </div>
@@ -19,7 +19,7 @@ aliases:
 
   <div class="b-example-divider"></div>
 
-  <div class="bg-supporting-pink title-bar">
+  <div class="bg-supporting-pink title-bar" data-bs-theme="light">
     <div class="container-xxl">
       <h1 class="display-1">Title</h1>
       <picture>
@@ -46,7 +46,7 @@ aliases:
 
   <div class="b-example-divider"></div>
 
-  <div class="bg-supporting-blue title-bar">
+  <div class="bg-supporting-blue title-bar" data-bs-theme="light">
     <div class="container-xxl">
       <h1 class="display-1">Title</h1>
       <div class="col example-title-bar-custom-background"></div>


### PR DESCRIPTION
### Description

Title bars in dark mode, by using existing and new Sass vars :

| Sass var | Previous value | New value |
| :------- | :--------------: | :----------: |
| `$title-bar-bg` | - | `var(--#{$prefix}body-bg)` |
| `$title-bar-color` | - | `var(--#{$prefix}body-color)` |
| `$title-bar-border-color` | `$gray-500` | `var(--#{$prefix}border-color-translucent)` |

⚠️ Deprecated `$title-bar-border-color-dark`
⚠️ New CSS var that could be avoided by #2313: `--bs-title-bar-bg` & `--bs-title-bar-color`

### Links

- https://deploy-preview-2350--boosted.netlify.app/docs/5.3/components/title-bars
- https://deploy-preview-2350--boosted.netlify.app/docs/5.3/dark-mode/#title-bars