### PR TITLE
fix(tooltips): two CSS vars had a double prefix

### DIFF
--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -29,7 +29,7 @@
   @include reset-text();
   @include font-size(var(--#{$prefix}tooltip-font-size));
   font-weight: var(--#{$prefix}tooltip-font-weight); // Boosted mod
-  line-height: var(--#{$prefix}--#{$prefix}tooltip-line-height); // Boosted mod
+  line-height: var(--#{$prefix}tooltip-line-height); // Boosted mod
   // Allow breaking very long words so they don't overflow the tooltip's bounds
   word-wrap: break-word;
   opacity: 0;
@@ -64,7 +64,7 @@
 
   &::before {
     bottom: 0;
-    border-top-color: var(--#{$prefix}--#{$prefix}tooltip-arrow-border);
+    border-top-color: var(--#{$prefix}tooltip-arrow-border);
   }
 
   &::after {


### PR DESCRIPTION
### Description

This PR fixes __tooltip.scss_ that contained two CSS vars with a double prefix.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

- <https://deploy-preview-2353--boosted.netlify.app/>

### Checklist

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)