### PR TITLE
fix(examples): apply correctly `.header-minimized` to the Navbars example

### DIFF
--- a/site/content/docs/5.3/examples/navbars/index.html
+++ b/site/content/docs/5.3/examples/navbars/index.html
@@ -27,8 +27,8 @@ aliases:
   </header>
 
   <div class="b-example-divider"></div>
-  <header>
-    {{< orange-global-headers id="global-header-0" mode="actions" minimized=true aria_label="Global navigation - Minimized without title example" >}}
+  <header class="header-minimized">
+    {{< orange-global-headers id="global-header-0" mode="actions" aria_label="Global navigation - Minimized without title example" >}}
     {{< /orange-global-headers >}}
   </header>
 

--- a/site/layouts/shortcodes/orange-global-headers.html
+++ b/site/layouts/shortcodes/orange-global-headers.html
@@ -10,7 +10,6 @@
     * demo: if the global shortcode is called from the documentation (default: false)
     * labels: use generic labels instead of real-life labels (default: false)
     * labels_end: justify labels at the end (default: false)
-    * minimized: display a minimized global header (default: false)
     * navigation: add a navigation bar under the global header (default: false)
     * supra: if the global header is used with a supra bar (default: false)
     * aria_label: set the aria-label for the current global header
@@ -24,13 +23,12 @@
 {{- $demo := .Get "demo" | default false -}}
 {{- $labels := .Get "labels" | default false -}}
 {{- $labels_end := .Get "labels_end" | default false -}}
-{{- $minimized := .Get "minimized" | default false -}}
 {{- $navigation := .Get "navigation" | default false -}}
 {{- $supra := .Get "supra" | default false -}}
 {{- $aria_label := .Get "aria_label"}}
 {{- $input := .Inner -}}
 
-<nav class="navbar navbar-dark bg-dark navbar-expand-lg{{ cond $minimized " header-minimized" "" }}" aria-label="{{ $aria_label }}">
+<nav class="navbar navbar-dark bg-dark navbar-expand-lg" aria-label="{{ $aria_label }}">
   <div class="container-xxl">
     <div class="navbar-brand me-auto{{ cond (or $navigation $responsive_logo) "" " me-lg-4" }}">
       <a class="stretched-link" href="#">


### PR DESCRIPTION
### Description

This PR fixes the rendering of the minimized use case in Navbars example page by removing the `minimized` parameter from the `orange-navbar` shortcode.

![Screenshot 2023-11-06 at 08 12 10](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/39157f0c-7137-4250-b6a5-6d9f9a925709)


### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

- https://deploy-preview-2354--boosted.netlify.app/docs/5.3/examples/navbars/