### PR TITLE
fix(typography): modify `.lead` values to match the DSM body text

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -71,7 +71,7 @@ h2,
 .lead {
   @include font-size($h6-font-size);
   font-weight: $lead-font-weight;
-  line-height: $h6-line-height;
+  line-height: $lead-line-height;
 
   /* rtl:remove */
   letter-spacing: $h6-spacing;
@@ -119,10 +119,16 @@ h2,
 
   h4,
   h5,
-  h6,
-  .lead {
+  h6 {
     @include font-size($h5-font-size);
     line-height: $h5-line-height;
+
+    /* rtl:remove */
+    letter-spacing: $h5-spacing;
+  }
+
+  .lead {
+    @include font-size($h5-font-size);
 
     /* rtl:remove */
     letter-spacing: $h5-spacing;
@@ -194,7 +200,6 @@ h2,
 
   .lead {
     @include font-size($lead-font-size);
-    line-height: $lead-line-height;
 
     /* rtl:remove */
     letter-spacing: $lead-letter-spacing;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -816,7 +816,7 @@ $display-line-height:         $h1-line-height !default;
 $lead-font-size:              $font-size-xlg !default;
 $lead-font-weight:            400 !default;
 $lead-line-height:            1.5 !default;
-$lead-letter-spacing:         $letter-spacing-base * 2.5 !default;
+$lead-letter-spacing:         $letter-spacing-base * 4 !default;
 
 $small-font-size:             .875rem !default;
 

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -27,6 +27,10 @@ If you need more details about the changes, please refer to the [v5.3.3 release]
   - <span class="badge text-bg-success">New</span> List group with badges has been added to Orange Design System specifications and can now be used in your websites.
   - <span class="badge text-bg-warning">Warning</span> List group font weight is now bold by default. Please check that it doesn't break your design.
 
+### Contents
+
+- <span class="badge text-bg-warning">Warning</span> The `.lead` class has been updated to reflect the new font size values. Please check that it doesn't break your design.
+
 ### Forms
 
 - <span class="badge text-bg-warning">Warning</span> Quantity selector has been updated to ensure a proper visible focus state and the `.input-group` class has been removed. Make sure to incorporate these changes into your websites.


### PR DESCRIPTION
### Description

This PR fixes the `.lead` values (font-size, line-height and letter-spacing) for this class to match the [body text definition in the DSM's design token](https://design.orange.com/0c1af118d/p/68dbd8-typography/t/095277) (`ods.web.sys.font.body.m`).

This is needed for projects willing to have a less condensed rendering for articles for instance.

They are the following:

| Size | font-size | line-height | letter-spacing |
|---|---|---|---|
| Desktop | 20px | 1.5=30px | -0.40px | 
| Tablet | 18px | 1.5=27px | -0.20px | 
| Mobile | 16px | 1.5=24px | -0.10px |

The review must double-check these 3 values for each size: desktop, mobile and tablet.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

- https://deploy-preview-2363--boosted.netlify.app/docs/5.3/content/typography/#lead
- https://deploy-preview-2363--boosted.netlify.app/docs/5.3/migration/#contents

### Checklist

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
- [x] My change is compatible with a responsive display

### Checklist (for Core Team only)

- [x] My change introduces changes to the migration guide