### PR TITLE
Dark mode: Change functionnal colors in dark mode

### DIFF
--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -40,11 +40,3 @@
   padding: var(--#{$prefix}badge-padding-y) var(--#{$prefix}badge-padding-x); // Boosted mod
   margin-left: map-get($spacers, 1); // Boosted mod
 }
-
-// Boosted mod: inconsistent background color & naming
-@each $color, $value in $theme-colors {
-  .badge.bg-#{$color} {
-    color: color-contrast($value);
-    background-color: $value !important; // stylelint-disable-line declaration-no-important
-  }
-}

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -102,19 +102,19 @@
 }
 
 .btn-success {
-  @include button-variant($green, $green, $white);
+  @include button-variant(var(--#{$prefix}success), var(--#{$prefix}success), var(--#{$prefix}highlight-color));
 }
 
 .btn-danger {
-  @include button-variant($red, $red, $white);
+  @include button-variant(var(--#{$prefix}danger), var(--#{$prefix}danger), var(--#{$prefix}highlight-color));
 }
 
 .btn-warning {
-  @include button-variant($yellow, $yellow, $black);
+  @include button-variant($warning, $warning, $black);
 }
 
 .btn-info {
-  @include button-variant($blue, $blue, $white);
+  @include button-variant(var(--#{$prefix}info), var(--#{$prefix}info), var(--#{$prefix}highlight-color));
 }
 
 .btn-light {

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -8,10 +8,10 @@
 
 // Boosted mod
 // scss-docs-start brand-colors-dark
-$functional-green-dark:  #32c832 !default;
-$functional-blue-dark:   #527edb !default;
+$functional-green-dark:  #6c6 !default;
+$functional-blue-dark:   #69f !default;
 $functional-yellow-dark: $functional-yellow !default;
-$functional-red-dark:    #d53f15 !default;
+$functional-red-dark:    #f66 !default;
 // scss-docs-end brand-colors-dark
 
 // scss-docs-start sass-dark-mode-vars

--- a/scss/helpers/_color-bg.scss
+++ b/scss/helpers/_color-bg.scss
@@ -11,7 +11,13 @@
   @include color-mode(dark) {
     @each $color, $value in $theme-colors-dark {
       .text-bg-#{$color} {
-        color: color-contrast($value) if($enable-important-utilities, !important, null);
+        $text-bg-color: var(--#{$prefix}highlight-color);
+        @if index(("primary", "warning", "light"), #{$color}) {
+          $text-bg-color: $black;
+        } @else if (#{$color} == "dark") {
+          $text-bg-color: $white;
+        }
+        color: $text-bg-color if($enable-important-utilities, !important, null);
       }
     }
   }

--- a/site/content/docs/5.3/components/badge.md
+++ b/site/content/docs/5.3/components/badge.md
@@ -37,7 +37,7 @@ This component should not be used because it does not exist in the Orange Design
 
 {{< example >}}
 <button type="button" class="btn btn-primary">
-  Notifications <span class="badge text-bg-secondary">4</span>
+  Notifications <span class="badge text-bg-dark">4</span>
 </button>
 {{< /example >}}
 

--- a/site/content/docs/5.3/components/badge.md
+++ b/site/content/docs/5.3/components/badge.md
@@ -63,7 +63,7 @@ Please refer to our Boosted [Navbars]({{< docsref "/examples/navbars" >}}) examp
     <use xlink:href="/docs/{{< param docs_version >}}/assets/img/boosted-sprite.svg#buy"/>
   </svg>
   <span class="visually-hidden">Shopping basket</span>
-  <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info text-white">
+  <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
     99+
     <span class="visually-hidden">shopping basket items</span>
   </span>

--- a/site/content/docs/5.3/components/list-group.md
+++ b/site/content/docs/5.3/components/list-group.md
@@ -120,21 +120,21 @@ These work great with custom content as well.
       Subheading
       <div class="fw-normal mt-1 lh-base">Content for list item</div>
     </div>
-    <span class="badge bg-info text-white rounded-pill">14</span>
+    <span class="badge text-bg-info rounded-pill">14</span>
   </li>
   <li class="list-group-item d-flex justify-content-between align-items-start">
     <div class="me-auto">
       Subheading
       <div class="fw-normal mt-1 lh-base">Content for list item</div>
     </div>
-    <span class="badge bg-info text-white rounded-pill">14</span>
+    <span class="badge text-bg-info rounded-pill">14</span>
   </li>
   <li class="list-group-item d-flex justify-content-between align-items-start">
     <div class="me-auto">
       Subheading
       <div class="fw-normal mt-1 lh-base">Content for list item</div>
     </div>
-    <span class="badge bg-info text-white rounded-pill">14</span>
+    <span class="badge text-bg-info rounded-pill">14</span>
   </li>
 </ol>
 {{< /example >}}
@@ -221,15 +221,15 @@ Add badges to any list group item to show unread counts, activity, and more with
 <ul class="list-group">
   <li class="list-group-item d-flex justify-content-between align-items-center">
     A list item
-    <span class="badge bg-info text-white rounded-pill">14</span>
+    <span class="badge text-bg-info rounded-pill">14</span>
   </li>
   <li class="list-group-item d-flex justify-content-between align-items-center">
     A second list item
-    <span class="badge bg-info text-white rounded-pill">2</span>
+    <span class="badge text-bg-info rounded-pill">2</span>
   </li>
   <li class="list-group-item d-flex justify-content-between align-items-center">
     A third list item
-    <span class="badge bg-info text-white rounded-pill">1</span>
+    <span class="badge text-bg-info rounded-pill">1</span>
   </li>
 </ul>
 {{< /example >}}

--- a/site/content/docs/5.3/components/orange-navbar.md
+++ b/site/content/docs/5.3/components/orange-navbar.md
@@ -192,7 +192,7 @@ An additional navbar (with text or icon items) can be added on the right of the 
               </svg>
               <span class="visually-hidden">Basket</span>
               <span class="position-relative align-self-start">
-                <span class="badge bg-info rounded-pill position-absolute top-0 fs-6 text-white translate-middle">
+                <span class="badge text-bg-info rounded-pill position-absolute top-0 fs-6 translate-middle">
                   1
                   <span class="visually-hidden">shopping basket items</span>
                 </span>

--- a/site/content/docs/5.3/components/progress.md
+++ b/site/content/docs/5.3/components/progress.md
@@ -148,7 +148,7 @@ If you're adding labels to progress bars with a custom background color, make su
   <div class="progress-bar bg-warning text-dark" style="width: 75%">75%</div>
 </div>
 <div class="progress" role="progressbar" aria-label="Danger example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
-  <div class="progress-bar bg-danger text-white" style="width: 100%">100%</div>
+  <div class="progress-bar bg-danger" style="width: 100%">100%</div>
 </div>
 {{< /example >}}
 

--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -4090,7 +4090,7 @@ sitemap_exclude: true
                 </svg>
                 <span class="visually-hidden">Basket</span>
                 <span class="position-relative align-self-start">
-                  <span class="badge bg-info rounded-pill position-absolute top-0 fs-6 text-white translate-middle">
+                  <span class="badge text-bg-info rounded-pill position-absolute top-0 fs-6 translate-middle">
                     1
                     <span class="visually-hidden">shopping basket items</span>
                   </span>
@@ -4178,7 +4178,7 @@ sitemap_exclude: true
                 </svg>
                 <span class="visually-hidden">Basket</span>
                 <span class="position-relative align-self-start">
-                  <span class="badge bg-info rounded-pill position-absolute top-0 fs-6 text-white translate-middle">
+                  <span class="badge text-bg-info rounded-pill position-absolute top-0 fs-6 translate-middle">
                     1
                     <span class="visually-hidden">shopping basket items</span>
                   </span>
@@ -4266,7 +4266,7 @@ sitemap_exclude: true
                 </svg>
                 <span class="visually-hidden">Basket</span>
                 <span class="position-relative align-self-start">
-                  <span class="badge bg-info rounded-pill position-absolute top-0 fs-6 text-white translate-middle">
+                  <span class="badge text-bg-info rounded-pill position-absolute top-0 fs-6 translate-middle">
                     1
                     <span class="visually-hidden">shopping basket items</span>
                   </span>
@@ -4354,7 +4354,7 @@ sitemap_exclude: true
                 </svg>
                 <span class="visually-hidden">Basket</span>
                 <span class="position-relative align-self-start">
-                  <span class="badge bg-info rounded-pill position-absolute top-0 fs-6 text-white translate-middle">
+                  <span class="badge text-bg-info rounded-pill position-absolute top-0 fs-6 translate-middle">
                     1
                     <span class="visually-hidden">shopping basket items</span>
                   </span>
@@ -4442,7 +4442,7 @@ sitemap_exclude: true
                 </svg>
                 <span class="visually-hidden">Basket</span>
                 <span class="position-relative align-self-start">
-                  <span class="badge bg-info rounded-pill position-absolute top-0 fs-6 text-white translate-middle">
+                  <span class="badge text-bg-info rounded-pill position-absolute top-0 fs-6 translate-middle">
                     1
                     <span class="visually-hidden">shopping basket items</span>
                   </span>
@@ -4700,7 +4700,7 @@ sitemap_exclude: true
     <div class="progress-bar bg-warning text-dark" style="width: 75%">75%</div>
   </div>
   <div class="progress" role="progressbar" aria-label="Danger example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
-    <div class="progress-bar bg-danger text-white" style="width: 100%">100%</div>
+    <div class="progress-bar bg-danger" style="width: 100%">100%</div>
   </div>
   <div class="progress" role="progressbar" aria-label="Primary example" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100">
     <div class="progress-bar text-bg-primary" style="width: 30%">30% (.text-bg-primary)</div>
@@ -4765,7 +4765,7 @@ sitemap_exclude: true
     <div class="progress-bar bg-warning text-dark" style="width: 75%">75%</div>
   </div>
   <div class="progress" role="progressbar" aria-label="Danger example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
-    <div class="progress-bar bg-danger text-white" style="width: 100%">100%</div>
+    <div class="progress-bar bg-danger" style="width: 100%">100%</div>
   </div>
   <div class="progress" role="progressbar" aria-label="Primary example" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100">
     <div class="progress-bar text-bg-primary" style="width: 30%">30% (.text-bg-primary)</div>
@@ -4830,7 +4830,7 @@ sitemap_exclude: true
     <div class="progress-bar bg-warning text-dark" style="width: 75%">75%</div>
   </div>
   <div class="progress" role="progressbar" aria-label="Danger example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
-    <div class="progress-bar bg-danger text-white" style="width: 100%">100%</div>
+    <div class="progress-bar bg-danger" style="width: 100%">100%</div>
   </div>
   <div class="progress" role="progressbar" aria-label="Primary example" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100">
     <div class="progress-bar text-bg-primary" style="width: 30%">30% (.text-bg-primary)</div>
@@ -4895,7 +4895,7 @@ sitemap_exclude: true
     <div class="progress-bar bg-warning text-dark" style="width: 75%">75%</div>
   </div>
   <div class="progress" role="progressbar" aria-label="Danger example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" data-bs-theme="dark">
-    <div class="progress-bar bg-danger text-white" style="width: 100%">100%</div>
+    <div class="progress-bar bg-danger" style="width: 100%">100%</div>
   </div>
   <div class="progress" role="progressbar" aria-label="Primary example" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100" data-bs-theme="dark">
     <div class="progress-bar text-bg-primary" style="width: 30%">30% (.text-bg-primary)</div>
@@ -4960,7 +4960,7 @@ sitemap_exclude: true
     <div class="progress-bar bg-warning text-dark" style="width: 75%">75%</div>
   </div>
   <div class="progress" role="progressbar" aria-label="Danger example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" data-bs-theme="light">
-    <div class="progress-bar bg-danger text-white" style="width: 100%">100%</div>
+    <div class="progress-bar bg-danger" style="width: 100%">100%</div>
   </div>
   <div class="progress" role="progressbar" aria-label="Primary example" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100" data-bs-theme="light">
     <div class="progress-bar text-bg-primary" style="width: 30%">30% (.text-bg-primary)</div>

--- a/site/layouts/shortcodes/orange-global-headers.html
+++ b/site/layouts/shortcodes/orange-global-headers.html
@@ -110,7 +110,7 @@
             </svg>
             <span class="visually-hidden">Basket</span>
             <span class="position-relative align-self-start">
-              <span class="badge bg-info rounded-pill position-absolute top-0 fs-6 text-white translate-middle">
+              <span class="badge text-bg-info rounded-pill position-absolute top-0 fs-6 translate-middle">
                 1
                 <span class="visually-hidden">shopping basket items</span>
               </span>

--- a/site/layouts/shortcodes/orange-supra.html
+++ b/site/layouts/shortcodes/orange-supra.html
@@ -43,7 +43,7 @@
           </svg>
           <span class="visually-hidden">Basket</span>
           <span class="position-relative align-self-start">
-            <span class="badge bg-info rounded-pill position-absolute top-0 fs-6 text-white translate-middle">
+            <span class="badge text-bg-info rounded-pill position-absolute top-0 fs-6 translate-middle">
               1
               <span class="visually-hidden">shopping basket items</span>
             </span>


### PR DESCRIPTION
### Description

⚠️ Adjusted the colors of `.text-bg-*` in dark mode (use the same trick as outlined buttons. Might be just temporary.
⚠️ Functional colors changed in dark mode.

Check all the list below to ensure everything is greatly colored.

### Links

- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/components/badge
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/components/buttons
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/components/list-group/#with-badges
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/components/orange-navbar
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/components/progress/#backgrounds
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/forms/validation
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/forms/overview/#form-helper
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/dark-mode/#buttons
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/dark-mode/#orange-navbar
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/dark-mode/#progress
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/dark-mode/#validation
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/dark-mode/#helper
- https://deploy-preview-2370--boosted.netlify.app/docs/5.3/examples/navbars
