### PR TITLE
Dark mode: Make docs callouts more highlighted

### DIFF
--- a/site/assets/scss/_callouts.scss
+++ b/site/assets/scss/_callouts.scss
@@ -32,7 +32,7 @@
 @each $variant in $bd-callout-variants {
   .bd-callout-#{$variant} {
     --bd-callout-color: var(--bs-emphasis-color); // Boosted mod: instead of `var(--bs-#{$variant}-text-emphasis)`
-    --bd-callout-bg: var(--bs-tertiary-bg);
+    --bd-callout-bg: var(--bs-secondary-bg); // Boosted mod: instead of `var(--bs-#{$variant}-bg-subtle)`
     --bd-callout-border: var(--bs-#{$variant}-border-subtle);
   }
 }


### PR DESCRIPTION
### Description

Proposal to make docs callouts more highlighted than before in light and dark mode.

### Links

- https://deploy-preview-2375--boosted.netlify.app/docs/5.3/docsref