### PR TITLE
Dark mode: Proposals to handle dark mode code highlights

### DIFF
--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -178,7 +178,7 @@
     font-weight: $font-weight-bold; // Boosted mod
     color: var(--bs-secondary-color);
     background-color: var(--bs-secondary-bg); // Boosted mod: instead of `var(--bs-tertiary-bg)`
-    border: var(--bs-border-width) solid var(--bs-border-color-translucent); // Boosted mod: instead of `var(--bs-border-color)`
+    border: var(--bs-border-width) solid var(--bs-border-color-translucent); // Boosted mod: instead of `var(--bs-border-width) solid var(--bs-border-color)`
 
     > div {
       display: flex;

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -4,7 +4,7 @@
 
 .bd-code-snippet {
   margin: 0 ($bd-gutter-x * -.5) 1rem;
-  border: solid $gray-400; // Boosted mod: instead of `var(--bs-border-color)`
+  border: solid var(--bs-border-color-translucent); // Boosted mod: instead of `var(--bs-border-color)`
   border-width: 1px 0;
 
   @include media-breakpoint-up(md) {
@@ -21,7 +21,7 @@
   position: relative;
   padding: var(--bd-example-padding);
   margin: 0 ($bd-gutter-x * -.5) 1rem;
-  border: solid $gray-400; // Boosted mod: instead of `var(--bs-border-color)`
+  border: solid var(--bs-border-color-translucent); // Boosted mod: instead of `var(--bs-border-color)`
   border-width: 1px 0;
   @include clearfix();
 
@@ -176,9 +176,9 @@
     display: inline-block;
     width: 9rem; // Boosted mod
     font-weight: $font-weight-bold; // Boosted mod
-    color: $gray-800; // Boosted mod: instead of `var(--bs-secondary-color)`
-    background-color: $gray-400; // Boosted mod: instead of `var(--bs-tertiary-bg)`
-    border: var(--bs-border-width) solid $gray-500; // Boosted mod
+    color: var(--bs-secondary-color);
+    background-color: var(--bs-secondary-bg); // Boosted mod: instead of `var(--bs-tertiary-bg)`
+    border: var(--bs-border-width) solid var(--bs-border-color-translucent); // Boosted mod: instead of `var(--bs-border-color)`
 
     > div {
       display: flex;
@@ -314,7 +314,7 @@
   min-height: 16.625rem; // Boosted mod: instead of `15rem`
 
   > div {
-    color: var(--bs-body-bg);
+    color: var(--bs-highlight-color);
     background-color: var(--bd-primary-light);
     border: 1px solid var(--bd-primary);
 
@@ -439,6 +439,6 @@
 // scss-docs-end sticker-fs-xl
 
 .border-gray-400 {
-  --bs-border-color: #{$gray-400};
+  --bs-border-color: var(--bs-border-color-translucent);
 }
 // End mod

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -438,7 +438,7 @@
 }
 // scss-docs-end sticker-fs-xl
 
-.border-gray-400 {
+.border-tertiary {
   --bs-border-color: var(--bs-border-color-translucent);
 }
 // End mod

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -314,7 +314,7 @@
   min-height: 16.625rem; // Boosted mod: instead of `15rem`
 
   > div {
-    color: var(--bs-highlight-color);
+    color: var(--bs-highlight-color); // Boosted mod: instead of `var(--bs-body-bg)`
     background-color: var(--bd-primary-light);
     border: 1px solid var(--bd-primary);
 

--- a/site/assets/scss/_variables.scss
+++ b/site/assets/scss/_variables.scss
@@ -39,7 +39,7 @@ $bd-callout-variants: info, warning, danger !default;
   // Boosted mod: no --bd-sidebar-link-bg
   // Boosted mod: no --bd-callout-link
   // Boosted mod: no --bd-callout-code-color
-  --bd-pre-bg: #{adjust-color($gray-900, $lightness: -2.5%)}; // stylelint-disable-line scss/at-function-named-arguments
+  // Boosted mod: no --bd-pre-bg
 }
 
 // Boosted mod

--- a/site/assets/scss/_variables.scss
+++ b/site/assets/scss/_variables.scss
@@ -39,7 +39,7 @@ $bd-callout-variants: info, warning, danger !default;
   // Boosted mod: no --bd-sidebar-link-bg
   // Boosted mod: no --bd-callout-link
   // Boosted mod: no --bd-callout-code-color
-  // Boosted mod: no --bd-pre-bg
+  --bd-pre-bg: var(--bs-tertiary-bg); // Boosted mod: instead of `#{adjust-color($gray-900, $lightness: -2.5%)}`
 }
 
 // Boosted mod

--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -28,7 +28,7 @@
 
   {{- if eq $show_markup true -}}
     {{- if eq $show_preview true -}}
-      <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-0 border-top border-bottom border-gray-400 border-1">
+      <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-0 border-top border-bottom border-tertiary border-1">
         <small class="font-monospace text-body-secondary text-uppercase">{{- $lang -}}</small>
         <div class="d-flex ms-auto">
           <button type="button" class="btn-edit text-nowrap"{{ with $stackblitz_add_js }} data-sb-js-snippet="{{ $stackblitz_add_js }}"{{ end }} title="Try it on StackBlitz">

--- a/site/layouts/shortcodes/js-docs.html
+++ b/site/layouts/shortcodes/js-docs.html
@@ -33,8 +33,8 @@
   {{- end -}}
 
   <div class="bd-example-snippet bd-code-snippet bd-file-ref">
-    <!-- Boosted mod: added `.border-1` and `.border-gray-400` -->
-    <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom border-1 border-gray-400">
+    <!-- Boosted mod: added `.border-1` and `.border-tertiary` -->
+    <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom border-1 border-tertiary">
       <a class="font-monospace link-body-emphasis link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}/{{ $file | replaceRE `\\` "/" }}">
         {{- $file -}}
       </a>

--- a/site/layouts/shortcodes/scss-docs.html
+++ b/site/layouts/shortcodes/scss-docs.html
@@ -46,8 +46,8 @@
   {{- end -}}
 
   <div class="bd-example-snippet bd-code-snippet bd-file-ref">
-    <!-- Boosted mod: added `.border-1` and `.border-gray-400` -->
-    <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom border-1 border-gray-400">
+    <!-- Boosted mod: added `.border-1` and `.border-tertiary` -->
+    <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom border-1 border-tertiary">
       <a class="font-monospace link-body-emphasis link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}/{{ $file | replaceRE `\\` "/" }}">
         {{- $file -}}
       </a>


### PR DESCRIPTION
### Description

Proposal to make docs code highlights less highlighted in dark mode. Adding some small changes in the borders as well.
Refactor Ratio examples to better fit dark mode. This change should be done anyway.

### Links

- https://deploy-preview-2378--boosted.netlify.app/docs/5.3/docsref
- https://deploy-preview-2378--boosted.netlify.app/docs/5.3/helpers/ratios