### PR TITLE
Dark mode: change orange colors Sass vars

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -140,11 +140,11 @@
   .btn.active + &,
   &:active + * + .btn,
   &.active + * + .btn {
-    border-color: $brand-orange;
+    border-color: $supporting-orange;
   }
 
   .btn-group.show > &:not(:focus):not(:active)::before {
-    color: $brand-orange;
+    color: $supporting-orange;
     background-color: currentcolor;
   }
   // End mod

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -98,7 +98,7 @@
 
 // scss-docs-start btn-variant-loops
 .btn-primary {
-  @include button-variant($brand-orange, $brand-orange, $black, $active-background: var(--#{$prefix}highlight-color), $active-border: var(--#{$prefix}highlight-bg), $active-color: var(--#{$prefix}highlight-bg));
+  @include button-variant($supporting-orange, $supporting-orange, $black, $active-background: var(--#{$prefix}highlight-color), $active-border: var(--#{$prefix}highlight-bg), $active-color: var(--#{$prefix}highlight-bg));
 }
 
 .btn-success {

--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -110,7 +110,6 @@ $utilities-colors: $theme-colors-rgb !default;
 $utilities-text: map-merge(
   $utilities-colors,
   (
-    "primary": to-rgb($accessible-orange), // Boosted mod
     "black": to-rgb($black),
     "white": to-rgb($white),
     "body": to-rgb($body-color)

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -234,7 +234,7 @@
     --#{$prefix}form-invalid-border-color: #{$form-invalid-border-color-dark};
 
     // ******* Additions for dark-mode
-    --#{$prefix}hover-color: #{$brand-orange};
+    --#{$prefix}hover-color: #{$supporting-orange};
     --#{$prefix}active-bg: #{$gray-700};
     --#{$prefix}disabled-color: #{$gray-700};
     --#{$prefix}disabled-filter: #{$disabled-filter-dark};

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -680,7 +680,7 @@ $utilities: map-merge(
           "supporting-yellow": $supporting-yellow, // Boosted mod
           "supporting-pink": $supporting-pink, // Boosted mod
           "supporting-purple": $supporting-purple, // Boosted mod
-          "supporting-orange": $brand-orange, // Boosted mod
+          "supporting-orange": $supporting-orange, // Boosted mod
         )
       )
     ),

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -16,7 +16,7 @@ $functional-red-dark:    #f66 !default;
 
 // scss-docs-start sass-dark-mode-vars
 // scss-docs-start theme-color-dark-variables
-$primary-dark:                      $brand-orange !default;
+$primary-dark:                      $supporting-orange !default;
 $secondary-dark:                    $white !default;
 $success-dark:                      $functional-green-dark !default;
 $info-dark:                         $functional-blue-dark !default;
@@ -84,12 +84,12 @@ $border-color-dark:                 $white !default; // Boosted mod: instead of 
 $border-color-translucent-dark:     $gray-700 !default; // Boosted mod instead of `rgba($white, .15)`
 $headings-color-dark:               $white !default; // Boosted mod: instead of `inherit`
 $link-color-dark:                   $white !default; // Boosted mod: instead of `tint-color($primary, 40%)`
-$link-hover-color-dark:             $brand-orange !default; // Boosted mod: instead of `shift-color($link-color-dark, -$link-shade-percentage)`
+$link-hover-color-dark:             $supporting-orange !default; // Boosted mod: instead of `shift-color($link-color-dark, -$link-shade-percentage)`
 $code-color-dark:                   tint-color($code-color, 40%) !default;
 $mark-color-dark:                   $black !default; // Boosted mod: instead of `$body-color-dark`
 $mark-bg-dark:                      $white !default; // Boosted mod: instead of `$yellow-800`
 
-$focus-ring-color-dark:             rgba($brand-orange, $focus-ring-opacity) !default; // Boosted mod
+$focus-ring-color-dark:             rgba($supporting-orange, $focus-ring-opacity) !default; // Boosted mod
 
 $disabled-filter-dark:  brightness(0) invert(1) brightness(.4) !default; // Boosted mod
 

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -16,7 +16,7 @@ $functional-red-dark:    #f66 !default;
 
 // scss-docs-start sass-dark-mode-vars
 // scss-docs-start theme-color-dark-variables
-$primary-dark:                      $supporting-orange !default;
+$primary-dark:                      $ods-orange-200 !default;
 $secondary-dark:                    $white !default;
 $success-dark:                      $functional-green-dark !default;
 $info-dark:                         $functional-blue-dark !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -40,8 +40,8 @@ $grays: (
 // Boosted mod
 // scss-docs-start brand-colors
 //// Core colors
-$accessible-orange: #f16e00 !default;
-$brand-orange:      #ff7900 !default;
+$ods-orange-100: #f16e00 !default;
+$ods-orange-200: #ff7900 !default;
 //// Functional colors
 $functional-green:  #228722 !default;
 $functional-blue:   #4170d8 !default;
@@ -53,6 +53,7 @@ $supporting-yellow: #ffd200 !default;
 $supporting-green:  #50be87 !default;
 $supporting-purple: #a885d8 !default;
 $supporting-pink:   #ffb4e6 !default;
+$supporting-orange: $ods-orange-200 !default;
 // scss-docs-end brand-colors
 // End mod
 
@@ -63,7 +64,7 @@ $indigo:  $supporting-purple !default;
 $purple:  $supporting-purple !default;
 $pink:    $supporting-pink !default;
 $red:     $functional-red !default;
-$orange:  $accessible-orange !default;
+$orange:  $ods-orange-100 !default;
 $yellow:  $functional-yellow !default;
 $green:   $functional-green !default;
 $teal:    $supporting-green !default;
@@ -520,10 +521,10 @@ $body-emphasis-color:       $black !default;
 //
 // Style anchor elements.
 
-$link-color:                              $black !default; // Boosted mod
+$link-color:                              $black !default; // Boosted mod: instead of `$primary`
 $link-decoration:                         underline !default;
 $link-shade-percentage:                   20% !default;
-$link-hover-color:                        $accessible-orange !default; // Boosted mod
+$link-hover-color:                        $primary !default; // Boosted mod: instead of `shift-color($link-color, $link-shade-percentage)`
 $link-hover-decoration:                   null !default;
 
 $stretched-link-pseudo-element:           after !default;
@@ -670,7 +671,7 @@ $box-shadow-inset:  null !default; // Boosted mod: instead of `inset 0 1px 2px r
 // scss-docs-end box-shadow-variables
 
 $component-active-color:      $black !default;
-$component-active-bg:         $brand-orange !default;
+$component-active-bg:         $supporting-orange !default;
 
 // scss-docs-start focus-ring-variables
 $focus-ring-width:      .25rem !default;
@@ -989,8 +990,8 @@ $btn-border-width:            $input-btn-border-width !default;
 $btn-default-hover-bg:        var(--#{$prefix}highlight-bg) !default; // Boosted mod
 $btn-default-hover-border:    var(--#{$prefix}highlight-bg) !default; // Boosted mod
 $btn-default-hover-color:     var(--#{$prefix}highlight-color) !default; // Boosted mod
-$btn-default-active-bg:       $brand-orange !default; // Boosted mod
-$btn-default-active-border:   $brand-orange !default; // Boosted mod
+$btn-default-active-bg:       $supporting-orange !default; // Boosted mod
+$btn-default-active-border:   $supporting-orange !default; // Boosted mod
 $btn-default-active-color:    $black !default; // Boosted mod
 $btn-default-disabled-bg:     var(--#{$prefix}disabled-color) !default; // Boosted mod
 $btn-default-disabled-border: var(--#{$prefix}disabled-color) !default; // Boosted mod
@@ -999,8 +1000,8 @@ $btn-default-disabled-color:  var(--#{$prefix}highlight-color) !default; // Boos
 $btn-outline-default-hover-bg:        var(--#{$prefix}btn-color) !default; // Boosted mod
 $btn-outline-default-hover-border:    var(--#{$prefix}btn-border-color) !default; // Boosted mod
 $btn-outline-default-hover-color:     $white !default; // Boosted mod
-$btn-outline-default-active-bg:       $brand-orange !default; // Boosted mod
-$btn-outline-default-active-border:   $brand-orange !default; // Boosted mod
+$btn-outline-default-active-bg:       $supporting-orange !default; // Boosted mod
+$btn-outline-default-active-border:   $supporting-orange !default; // Boosted mod
 $btn-outline-default-active-color:    $black !default; // Boosted mod
 $btn-outline-default-disabled-bg:     transparent !default; // Boosted mod
 $btn-outline-default-disabled-border: var(--#{$prefix}disabled-color) !default; // Boosted mod
@@ -1058,7 +1059,7 @@ $btn-social-networks: (
     "icon": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><path d='M27.3 4.7a15.9 15.9 0 00-25 19.1L.1 32l8.4-2.2A15.9 15.9 0 0027.3 4.7zM16 29c-2.4 0-4.7-.6-6.7-1.8l-.5-.3-5 1.3 1.3-4.8-.3-.5A13.2 13.2 0 1116.1 29zm7.2-9.8l-2.7-1.3c-.3-.1-.6-.2-1 .2l-1.2 1.5c-.2.3-.4.3-.8.1s-1.7-.6-3.2-2c-1.2-1-2-2.3-2.2-2.7s0-.6.2-.8l.6-.7.4-.6v-.7l-1.3-3c-.3-.7-.6-.6-.9-.7h-.7c-.2 0-.7.1-1.1.5C9 9.4 8 10.4 8 12.3s1.4 3.9 1.6 4.1c.2.3 2.8 4.3 6.8 6l2.3.9c.9.3 1.8.2 2.4.1.8-.1 2.4-1 2.7-1.9s.4-1.7.3-1.9l-.8-.4z'/></svg>"
   ),
   "mail": (
-    "color": $brand-orange,
+    "color": $supporting-orange,
     "icon": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><path d='M3.2 14.3c0 9.5 0 9 .2 9.5.3.8 1 1.4 1.7 1.7l12.2.1h11.5v-8.8c0-9.3 0-8.9-.2-9.3-.2-.7-.7-1.2-1.3-1.6l-.8-.3H3.2v8.7zm22.9-2.4a246.2 246.2 0 01-4.9 4.7l-.8.7-.5.6-.7.6c-.6.6-1 .9-1.3 1a4 4 0 01-1.8.5 4 4 0 01-2.4-.6 13 13 0 01-1.9-1.7l-2.4-2.4-.6-.6-1.4-1.3L6.1 12l-.5-.5V8.9l.6.5L7.9 11l1.4 1.4 1.3 1.2 1.3 1.3a195 195 0 012.6 2.4c.4.3 1 .5 1.6.4.5 0 1-.1 1.4-.4L19 16l1-1 1-1a214.7 214.7 0 012.2-2l1-1 2-2 .2-.2v2.8l-.3.3z'/></svg>",
     "size": 1.5rem
   ),
@@ -1261,8 +1262,8 @@ $form-switch-checked-bg-size:     add(map-get($spacers, 2), map-get($spacers, 1)
 $form-switch-checked-bg-position: calc(var(--#{$prefix}border-width) * 3) 50% !default; // Boosted mod
 
 $form-switch-checked-square-bg:     var(--#{$prefix}body-bg) !default; // Boosted mod
-$form-switch-checked-bg:            $brand-orange !default; // Boosted mod
-$form-switch-checked-border-color:  $brand-orange !default; // Boosted mod
+$form-switch-checked-bg:            $supporting-orange !default; // Boosted mod
+$form-switch-checked-border-color:  $supporting-orange !default; // Boosted mod
 $form-switch-checked-filter:        none !default; // Boosted mod
 $form-switch-checked-focus-inner:   var(--#{$prefix}focus-visible-inner-color) !default; // Boosted mod
 $form-switch-checked-focus-outer:   var(--#{$prefix}focus-visible-outer-color) !default; // Boosted mod
@@ -1564,8 +1565,8 @@ $navbar-badge-margin-top:                   .375rem !default;
 
 $navbar-dark-border-color:          $gray-700 !default; // Boosted mod
 $navbar-dark-color:                 $white !default; // Boosted mod: instead of `rgba($white, .55)`
-$navbar-dark-hover-color:           $brand-orange !default; // Boosted mod: instead of `rgba($white, .75)`
-$navbar-dark-active-color:          $brand-orange !default; // Boosted mod: instead of `$white`
+$navbar-dark-hover-color:           $supporting-orange !default; // Boosted mod: instead of `rgba($white, .75)`
+$navbar-dark-active-color:          $supporting-orange !default; // Boosted mod: instead of `$white`
 $navbar-dark-disabled-color:        $gray-700 !default; // Boosted mod: instead of `rgba($white, .25)`
 // Boosted mod: no $navbar-dark-icon-color
 // Boosted mod: no $navbar-dark-toggler-icon-bg since dark toggler are handled with filter
@@ -1681,7 +1682,7 @@ $pagination-icon-size:              subtract($spacer * 2, calc(var(--#{$prefix}b
 $pagination-icon-width:             add(.5rem, 1px) !default;
 $pagination-icon-height:            subtract(1rem, 1px) !default;
 
-$pagination-active-item-bg:         $brand-orange !default;
+$pagination-active-item-bg:         $supporting-orange !default;
 $pagination-active-item-color:      $black !default;
 $pagination-active-item-border:     $pagination-active-item-bg !default;
 // End mod
@@ -2222,7 +2223,7 @@ $btn-close-white-color:               $white !default; // Boosted mod
 $btn-close-white-bg:                  transparent !default; // Boosted mod
 $btn-close-white-border-color:        transparent !default; // Boosted mod
 $btn-close-white-hover-color:         $btn-close-white-color !default; // Boosted mod
-$btn-close-white-active-color:        $brand-orange !default; // Boosted mod
+$btn-close-white-active-color:        $supporting-orange !default; // Boosted mod
 $btn-close-white-active-border-color: $gray-700 !default; // Boosted mod
 $btn-close-white-disabled-color:      $gray-700 !default; // Boosted mod
 
@@ -2301,7 +2302,7 @@ $step-item-padding-end:       $step-item-padding * 2 !default; // Deprecated in 
 // fusv-enable
 $step-item-margin-end:        var(--#{$prefix}border-width) !default;
 $step-item-bg:                var(--#{$prefix}highlight-bg) !default;
-$step-item-active-bg:         $brand-orange !default;
+$step-item-active-bg:         $supporting-orange !default;
 $step-item-next-bg:           var(--#{$prefix}border-color-translucent) !default;
 $step-item-shadow-size:       calc(var(--#{$prefix}border-width) * 1.5) !default; // stylelint-disable-line function-disallowed-list
 $step-item-drop-shadow:       drop-shadow($step-item-shadow-size 0 0 var(--#{$prefix}stepped-process-bg)) #{"/* rtl:"} drop-shadow(calc(-1 * #{$step-item-shadow-size}) 0 0 var(--#{$prefix}stepped-process-bg)) #{"*/"} !default; // stylelint-disable-line function-disallowed-list
@@ -2324,7 +2325,7 @@ $step-link-text-decoration:   $link-decoration !default;
 //// Sticker
 // scss-docs-start sticker
 $sticker-color:                         $black !default;
-$sticker-background-color:              $brand-orange !default;
+$sticker-background-color:              $supporting-orange !default;
 $sticker-font-weight:                   $font-weight-bold !default;
 
 $sticker-size-sm:                       $spacer * 7 !default;

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -137,7 +137,7 @@
   &:required {
     ~ .form-check-label::after {
       margin-left: $form-label-required-margin-left;
-      color: $accessible-orange;
+      color: $primary;
       content: "*";
     }
   }
@@ -275,7 +275,7 @@
 
   &:hover + .btn,
   + .btn:hover {
-    color: $accessible-orange;
+    color: $primary;
     background-color: $white;
     border-color: $gray-500;
   }
@@ -303,7 +303,7 @@
     + .btn-no-outline {
       &,
       &:hover {
-        color: $accessible-orange;
+        color: $primary;
         background-color: transparent;
       }
     }
@@ -318,11 +318,11 @@
   &:active + .btn,
   + .btn:active,
   + .btn.active {
-    color: color-contrast($brand-orange);
-    background-color: $brand-orange;
+    color: color-contrast($supporting-orange);
+    background-color: $supporting-orange;
     // Remove CSS gradients if they're enabled
     background-image: if($enable-gradients, none, null);
-    border-color: $brand-orange;
+    border-color: $supporting-orange;
   }
   // End mod
 
@@ -380,7 +380,7 @@
     }
 
     &:active {
-      color: $accessible-orange;
+      color: $primary;
       background-color: transparent;
     }
   }

--- a/site/assets/scss/_boosted.scss
+++ b/site/assets/scss/_boosted.scss
@@ -69,6 +69,6 @@ body {
     width: 100%;
     height: 4px;
     content: "";
-    background-color: $accessible-orange;
+    background-color: $primary;
   }
 }

--- a/site/assets/scss/_colors.scss
+++ b/site/assets/scss/_colors.scss
@@ -156,7 +156,7 @@
 .bd-black { color: color-contrast($black); background-color: $black; }
 
 // Boosted mod
-.bd-accessible-orange { color: color-contrast($accessible-orange); background-color: $accessible-orange; }
+.bd-primary-color { color: color-contrast($primary); background-color: $primary; }
 .bd-supporting-yellow { color: color-contrast($supporting-yellow); background-color: $supporting-yellow; }
 
 @function wcag-level($contrast-ratio) {
@@ -177,7 +177,7 @@
   @return $level;
 }
 
-@each $color, $value in map-merge($colors, map-merge($grays, ("supporting-yellow": $supporting-yellow, "accessible-orange": $accessible-orange, "black": $black))) {
+@each $color, $value in map-merge($colors, map-merge($grays, ("supporting-yellow": $supporting-yellow, "primary": $primary, "black": $black))) {
   .a11y-swatch-#{$color} {
     color: color-contrast($value);
     background-color: #{$value};

--- a/site/assets/scss/_variables.scss
+++ b/site/assets/scss/_variables.scss
@@ -2,7 +2,7 @@
 // stylelint-disable-next-line function-disallowed-list
 $bd-primary-light: lighten(saturate($primary, 5%), 15%); // Boosted mod
 // stylelint-disable-next-line function-disallowed-list
-$bd-primary-dark:  darken(saturate($brand-orange, 5%), 15%); // Boosted mod
+$bd-primary-dark:  darken(saturate($supporting-orange, 5%), 15%); // Boosted mod
 $bd-purple:        #4c0bce;
 $bd-violet:        lighten(saturate($bd-purple, 5%), 15%); // stylelint-disable-line function-disallowed-list
 // Boosted mod: np $bd-purple-light

--- a/site/content/docs/5.3/customize/color.md
+++ b/site/content/docs/5.3/customize/color.md
@@ -562,8 +562,8 @@ Be sure to monitor contrast ratios as you customize colors. As shown below, we'v
   {{< /theme-colors.inline >}}
 
   <div class="col-md-4 mb-3">
-    <div class="p-3 mb-2 bd-accessible-orange">
-      <strong class="d-block">$accessible-orange</strong>
+    <div class="p-3 mb-2 bd-primary-color">
+      <strong class="d-block">$primary</strong>
       #f16e00
     </div>
     <div class="p-3 mb-2 bd-supporting-yellow">

--- a/site/content/docs/5.3/utilities/colors.md
+++ b/site/content/docs/5.3/utilities/colors.md
@@ -127,9 +127,9 @@ Consider our default `.text-primary` utility.
 }
 ```
 
-We use an RGB version of our `$accessible-orange` (with the value of `241, 110, 0`) Sass variable as a CSS variable and attached a second CSS variable, `--bs-text-opacity`, for the alpha transparency (with a default value `1` thanks to a local CSS variable). That means anytime you use `.text-primary` now, your computed `color` value is `rgba(241, 110, 0, 1)`. The local CSS variable inside each `.text-*` class avoids inheritance issues so nested instances of the utilities don't automatically have a modified alpha transparency.
+We use an RGB version of our `$primary` (with the value of `241, 110, 0`) Sass variable as a CSS variable and attached a second CSS variable, `--bs-text-opacity`, for the alpha transparency (with a default value `1` thanks to a local CSS variable). That means anytime you use `.text-primary` now, your computed `color` value is `rgba(241, 110, 0, 1)`. The local CSS variable inside each `.text-*` class avoids inheritance issues so nested instances of the utilities don't automatically have a modified alpha transparency.
 
-When used in a dark variant context, `--bs-primary-text-rgb` will use the value of `$brand-orange` (with the value of `255, 121, 0`).
+When used in a dark variant context, `--bs-primary-text-rgb` will use the value of `$supporting-orange` (with the value of `255, 121, 0`).
 
 ### Example
 

--- a/site/data/palette.yml
+++ b/site/data/palette.yml
@@ -9,14 +9,14 @@
       class: black
       hex: "#000"
       variable: $secondary
-    - name: Accessible orange
+    - name: Primary
       class: orange
       hex: "#f16e00"
-      variable: $accessible-orange
-    - name: Brand orange
+      variable: $primary
+    - name: Supporting orange
       class: orange-2
       hex: "#ff7900"
-      variable: $brand-orange
+      variable: $supporting-orange
 - category: Supporting colors
   name: "Supporting colors"
   colors:


### PR DESCRIPTION
This makes the following changes to respect the new rules about the orange colors:
- `$accessible-orange` doesn't exist anymore and is replaced by `$ods-orange-100` in the color palette and then by the use of `$primary` in the rest of the code. Impacts for users: use `$primary` instead of `$accessible-orange`.
- `$brand-orange` doesn't exist anymore and is replaced by `$ods-orange-200` in the color palette and then by the use of `$supporting-orange` in the rest of the code. Impacts for users: use `$supporting-orange` instead of `$brand-orange`.

Please note that `$ods-orange-200` is used in 2 cases:
- as the primary color in dark mode (`$primary-dark`)
- as the supporting orange color which doesn't change in light or dark mode (like other supporting colors)