### PR TITLE
Dark mode: add badge in /dark-mode page

### DIFF
--- a/site/content/docs/5.3/dark-mode.md
+++ b/site/content/docs/5.3/dark-mode.md
@@ -526,6 +526,153 @@ sitemap_exclude: true
   </nav>
 </div>
 
+### Badge
+
+<h4 class="mt-3">No theme</h4>
+
+<div class="d-flex gap-2 flex-wrap border p-3">
+  <h6>Example heading <span class="badge text-bg-secondary">New</span></h6>
+  <button type="button" class="btn btn-primary">
+    Notifications <span class="badge text-bg-dark">4</span>
+  </button>
+  <a href="#" class="position-relative">
+    <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
+      <use xlink:href="/docs/5.3/assets/img/boosted-sprite.svg#buy"/>
+    </svg>
+    <span class="visually-hidden">Shopping basket</span>
+    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
+      99+
+      <span class="visually-hidden">shopping basket items</span>
+    </span>
+  </a>
+  <div>
+    <span class="badge text-bg-primary">Primary</span>
+    <span class="badge text-bg-secondary">Secondary</span>
+    <span class="badge text-bg-success">Success</span>
+    <span class="badge text-bg-danger">Danger</span>
+    <span class="badge text-bg-warning">Warning</span>
+    <span class="badge text-bg-info">Info</span>
+    <span class="badge text-bg-light">Light</span>
+    <span class="badge text-bg-dark">Dark</span>
+  </div>
+</div>
+
+<h4 class="mt-3">Dark theme on container</h4>
+
+<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="dark">
+  <h6>Example heading <span class="badge text-bg-secondary">New</span></h6>
+  <button type="button" class="btn btn-primary">
+    Notifications <span class="badge text-bg-dark">4</span>
+  </button>
+  <a href="#" class="position-relative">
+    <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
+      <use xlink:href="/docs/5.3/assets/img/boosted-sprite.svg#buy"/>
+    </svg>
+    <span class="visually-hidden">Shopping basket</span>
+    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
+      99+
+      <span class="visually-hidden">shopping basket items</span>
+    </span>
+  </a>
+  <div>
+    <span class="badge text-bg-primary">Primary</span>
+    <span class="badge text-bg-secondary">Secondary</span>
+    <span class="badge text-bg-success">Success</span>
+    <span class="badge text-bg-danger">Danger</span>
+    <span class="badge text-bg-warning">Warning</span>
+    <span class="badge text-bg-info">Info</span>
+    <span class="badge text-bg-light">Light</span>
+    <span class="badge text-bg-dark">Dark</span>
+  </div>
+</div>
+
+<h4 class="mt-3">Light theme on container</h4>
+
+<div class="d-flex gap-2 flex-wrap border p-3 bg-body" data-bs-theme="light">
+  <h6>Example heading <span class="badge text-bg-secondary">New</span></h6>
+  <button type="button" class="btn btn-primary">
+    Notifications <span class="badge text-bg-dark">4</span>
+  </button>
+  <a href="#" class="position-relative">
+    <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
+      <use xlink:href="/docs/5.3/assets/img/boosted-sprite.svg#buy"/>
+    </svg>
+    <span class="visually-hidden">Shopping basket</span>
+    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
+      99+
+      <span class="visually-hidden">shopping basket items</span>
+    </span>
+  </a>
+  <div>
+    <span class="badge text-bg-primary">Primary</span>
+    <span class="badge text-bg-secondary">Secondary</span>
+    <span class="badge text-bg-success">Success</span>
+    <span class="badge text-bg-danger">Danger</span>
+    <span class="badge text-bg-warning">Warning</span>
+    <span class="badge text-bg-info">Info</span>
+    <span class="badge text-bg-light">Light</span>
+    <span class="badge text-bg-dark">Dark</span>
+  </div>
+</div>
+
+<h4 class="mt-3">Dark theme on component</h4>
+
+<div class="d-flex gap-2 flex-wrap border p-3" style="background-color: #282d55;">
+  <h6 data-bs-theme="dark">Example heading <span class="badge text-bg-secondary">New</span></h6>
+  <button type="button" class="btn btn-primary" data-bs-theme="dark">
+    Notifications <span class="badge text-bg-dark">4</span>
+  </button>
+  <a href="#" class="position-relative" data-bs-theme="dark">
+    <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
+      <use xlink:href="/docs/5.3/assets/img/boosted-sprite.svg#buy"/>
+    </svg>
+    <span class="visually-hidden">Shopping basket</span>
+    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
+      99+
+      <span class="visually-hidden">shopping basket items</span>
+    </span>
+  </a>
+  <div>
+    <span class="badge text-bg-primary" data-bs-theme="dark">Primary</span>
+    <span class="badge text-bg-secondary" data-bs-theme="dark">Secondary</span>
+    <span class="badge text-bg-success" data-bs-theme="dark">Success</span>
+    <span class="badge text-bg-danger" data-bs-theme="dark">Danger</span>
+    <span class="badge text-bg-warning" data-bs-theme="dark">Warning</span>
+    <span class="badge text-bg-info" data-bs-theme="dark">Info</span>
+    <span class="badge text-bg-light" data-bs-theme="dark">Light</span>
+    <span class="badge text-bg-dark" data-bs-theme="dark">Dark</span>
+  </div>
+</div>
+
+<h4 class="mt-3">Light theme on component</h4>
+
+<div class="d-flex gap-2 flex-wrap border p-3" style="background-color: #b5e8f7">
+  <h6 data-bs-theme="light">Example heading <span class="badge text-bg-secondary">New</span></h6>
+  <button type="button" class="btn btn-primary" data-bs-theme="light">
+    Notifications <span class="badge text-bg-dark">4</span>
+  </button>
+  <a href="#" class="position-relative" data-bs-theme="light">
+    <svg width="2rem" height="2rem" fill="currentColor" aria-hidden="true" focusable="false" class="overflow-visible">
+      <use xlink:href="/docs/5.3/assets/img/boosted-sprite.svg#buy"/>
+    </svg>
+    <span class="visually-hidden">Shopping basket</span>
+    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-info">
+      99+
+      <span class="visually-hidden">shopping basket items</span>
+    </span>
+  </a>
+  <div>
+    <span class="badge text-bg-primary" data-bs-theme="light">Primary</span>
+    <span class="badge text-bg-secondary" data-bs-theme="light">Secondary</span>
+    <span class="badge text-bg-success" data-bs-theme="light">Success</span>
+    <span class="badge text-bg-danger" data-bs-theme="light">Danger</span>
+    <span class="badge text-bg-warning" data-bs-theme="light">Warning</span>
+    <span class="badge text-bg-info" data-bs-theme="light">Info</span>
+    <span class="badge text-bg-light" data-bs-theme="light">Light</span>
+    <span class="badge text-bg-dark" data-bs-theme="light">Dark</span>
+  </div>
+</div>
+
 ### Breadcrumb
 
 <h4 class="mt-3">No theme</h4>


### PR DESCRIPTION
### Description

This PR adds the badge component in the /dark-mode page as a sub-task listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2223.

Note: Setting `data-bs-theme` directly onto the component when only defined as a `<span>` + `.text-bg-{color}` doesn't work at all times; the text color is not always the right color. This is due to the fact that, at the time of the creation of this PR, the color and background color are not automatically changed with `data-bs-theme`.

### Live previews

- https://deploy-preview-2387--boosted.netlify.app/docs/5.3/dark-mode/#badge