### PR TITLE
Dark mode: remove `$accessible-orange`

### DIFF
--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -110,7 +110,6 @@ $utilities-colors: $theme-colors-rgb !default;
 $utilities-text: map-merge(
   $utilities-colors,
   (
-    "primary": to-rgb($accessible-orange), // Boosted mod
     "black": to-rgb($black),
     "white": to-rgb($white),
     "body": to-rgb($body-color)

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -42,7 +42,6 @@ $grays: (
 // Boosted mod
 // scss-docs-start brand-colors
 //// Core colors
-$accessible-orange: #f16e00 !default;
 $brand-orange:      #ff7900 !default;
 //// Functional colors
 $functional-green:  $ods-forest-200 !default;
@@ -65,7 +64,7 @@ $indigo:  $supporting-purple !default;
 $purple:  $supporting-purple !default;
 $pink:    $supporting-pink !default;
 $red:     $functional-red !default;
-$orange:  $accessible-orange !default;
+$orange:  $ods-orange-200 !default;
 $yellow:  $functional-yellow !default;
 $green:   $functional-green !default;
 $teal:    $supporting-green !default;
@@ -525,7 +524,7 @@ $body-emphasis-color:       $black !default;
 $link-color:                              $black !default; // Boosted mod
 $link-decoration:                         underline !default;
 $link-shade-percentage:                   20% !default;
-$link-hover-color:                        $accessible-orange !default; // Boosted mod
+$link-hover-color:                        $primary !default; // Boosted mod
 $link-hover-decoration:                   null !default;
 
 $stretched-link-pseudo-element:           after !default;

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -137,7 +137,7 @@
   &:required {
     ~ .form-check-label::after {
       margin-left: $form-label-required-margin-left;
-      color: $accessible-orange;
+      color: $primary;
       content: "*";
     }
   }

--- a/site/assets/scss/_colors.scss
+++ b/site/assets/scss/_colors.scss
@@ -174,7 +174,7 @@
   @return $level;
 }
 
-@each $color, $value in map-merge($colors, map-merge($grays, ("supporting-yellow": $supporting-yellow, "accessible-orange": $accessible-orange, "black": $black))) {
+@each $color, $value in map-merge($colors, map-merge($grays, ("supporting-yellow": $supporting-yellow, "black": $black))) {
   .a11y-swatch-#{$color} {
     color: color-contrast($value);
     background-color: #{$value};

--- a/site/content/docs/5.3/utilities/colors.md
+++ b/site/content/docs/5.3/utilities/colors.md
@@ -127,9 +127,9 @@ Consider our default `.text-primary` utility.
 }
 ```
 
-We use an RGB version of our `$accessible-orange` (with the value of `241, 110, 0`) Sass variable as a CSS variable and attached a second CSS variable, `--bs-text-opacity`, for the alpha transparency (with a default value `1` thanks to a local CSS variable). That means anytime you use `.text-primary` now, your computed `color` value is `rgba(241, 110, 0, 1)`. The local CSS variable inside each `.text-*` class avoids inheritance issues so nested instances of the utilities don't automatically have a modified alpha transparency.
+We use an RGB version of our `$primary` (with the value of `241, 110, 0`) Sass variable as a CSS variable and attached a second CSS variable, `--bs-text-opacity`, for the alpha transparency (with a default value `1` thanks to a local CSS variable). That means anytime you use `.text-primary` now, your computed `color` value is `rgba(241, 110, 0, 1)`. The local CSS variable inside each `.text-*` class avoids inheritance issues so nested instances of the utilities don't automatically have a modified alpha transparency.
 
-When used in a dark variant context, `--bs-primary-text-rgb` will use the value of `$brand-orange` (with the value of `255, 121, 0`).
+When used in dark mode, `--bs-primary-text-rgb` will use the value of `$brand-orange` (with the value of `255, 121, 0`).
 
 ### Example
 


### PR DESCRIPTION
⚠️ To be rebased and merged after https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2382

This PR replaces `$accessible-orange` with `$primary`. Its value is defined by `$ods-orange-200`.

### Live previews

- N/A