### PR TITLE
fix(docs): figure caption of About > Brand logos is rendered

### DIFF
--- a/site/assets/scss/_boosted.scss
+++ b/site/assets/scss/_boosted.scss
@@ -50,6 +50,14 @@ body {
   text-rendering: optimizelegibility;
 }
 
+#orange-logo ~ .row .ratio .figure-caption {
+  bottom: -#{$spacer * 1.5};
+
+  @include media-breakpoint-up(lg) {
+    bottom: -#{$spacer};
+  }
+}
+
 // Back to top offset
 [id="#{$back-to-top-target-id}"]:target {
   @include media-breakpoint-up(md) {


### PR DESCRIPTION
### Description

This PR fixes the rendering of About > Brand logos figure captions that were written in black within the black area. They are now rendered correctly as in v5.2 under the figures.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>