### PR TITLE
Solaris icons: Change the access url.

### DIFF
--- a/hugo.yml
+++ b/hugo.yml
@@ -70,7 +70,7 @@ params:
   repo:                             "https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap"
   twitter:                          "getbootstrap"
   blog:                             "https://blog.getbootstrap.com/"
-  icons:                            "https://system.design.orange.com/0c1af118d/p/65c68d-solaris-icon-library"
+  icons:                            "https://oran.ge/icons"
   bootstrap:                        "https://getbootstrap.com"
   ods:
     web:                            "https://system.design.orange.com/0c1af118d/n/76065f"

--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -36,6 +36,9 @@
           <li class="nav-item">
             <a class="nav-link{{ if eq .Page.Title "Orange Design System for web" }} active" aria-current="page{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/guidelines/" onclick="dataLayer.push({'event': 'clic', 'site_name':'accessibility-boosted', 'phase':'prod', 'track_category':'navbar', 'track_name':'guidelines'});">Design guidelines</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ .Site.Params.icons }}" target="_blank" rel="noopener" onclick="dataLayer.push({'event': 'clic', 'site_name':'accessibility-boosted', 'phase':'prod', 'track_category':'navbar', 'track_name':'icons'});">Solaris icons</a>
+          </li>
         </ul>
       </div>
       <div id="bd-navbar2" class="navbar-collapse collapse bd-navbar border-0">

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -20,6 +20,7 @@
               <li><a class="nav-link{{ if (and (eq .Page.Layout "docs") (ne $category_slug "getting-started")) }} active" aria-current="true{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/" aria-describedby="headingLinks">Docs</a></li>
               <li><a class="nav-link{{ if eq .Page.Title "Examples" }} active" aria-current="page{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/examples/" aria-describedby="headingLinks">Examples</a></li>
               <li><a class="nav-link{{ if eq .Page.Title "Orange Design System for web" }} active" aria-current="page{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/guidelines/" aria-describedby="headingLinks">Design guidelines</a></li>
+              <li><a class="nav-link" href="{{ .Site.Params.icons }}" aria-describedby="headingLinks" target="_blank" rel="noopener">Solaris icons</a></li>
               <!-- Boosted mod: removed .Site.Params.themes|.blog|.swag -->
             </ul>
           </div>
@@ -53,7 +54,6 @@
               <li><a class="nav-link" href="{{ .Site.Params.repo }}/tree/v4-dev" aria-describedby="headingProjects" target="_blank" rel="noopener">Boosted 4</a></li>
               <li><a class="nav-link" href="{{ .Site.Params.bootstrap }}" aria-describedby="headingProjects" target="_blank" rel="noopener">Bootstrap</a></li>
               <li><a class="nav-link" href="https://boosted.netlify.app" aria-describedby="headingProjects" target="_blank" rel="noopener">Pre-release on Netlify</a></li>
-              <li><a class="nav-link" href="{{ .Site.Params.icons }}" aria-describedby="headingLinks" target="_blank" rel="noopener">Solaris icons</a></li>
             </ul>
           </div>
         </div>

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -20,7 +20,6 @@
               <li><a class="nav-link{{ if (and (eq .Page.Layout "docs") (ne $category_slug "getting-started")) }} active" aria-current="true{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/" aria-describedby="headingLinks">Docs</a></li>
               <li><a class="nav-link{{ if eq .Page.Title "Examples" }} active" aria-current="page{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/examples/" aria-describedby="headingLinks">Examples</a></li>
               <li><a class="nav-link{{ if eq .Page.Title "Orange Design System for web" }} active" aria-current="page{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/guidelines/" aria-describedby="headingLinks">Design guidelines</a></li>
-              <li><a class="nav-link" href="{{ .Site.Params.icons }}" aria-describedby="headingLinks" target="_blank" rel="noopener">Solaris icons</a></li>
               <!-- Boosted mod: removed .Site.Params.themes|.blog|.swag -->
             </ul>
           </div>

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -20,7 +20,8 @@
               <li><a class="nav-link{{ if (and (eq .Page.Layout "docs") (ne $category_slug "getting-started")) }} active" aria-current="true{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/" aria-describedby="headingLinks">Docs</a></li>
               <li><a class="nav-link{{ if eq .Page.Title "Examples" }} active" aria-current="page{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/examples/" aria-describedby="headingLinks">Examples</a></li>
               <li><a class="nav-link{{ if eq .Page.Title "Orange Design System for web" }} active" aria-current="page{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/guidelines/" aria-describedby="headingLinks">Design guidelines</a></li>
-              <!-- Boosted mod: removed .Site.Params.icons|themes|blog|swag -->
+              <li><a class="nav-link" href="{{ .Site.Params.icons }}" aria-describedby="headingLinks" target="_blank" rel="noopener">Solaris icons</a></li>
+              <!-- Boosted mod: removed .Site.Params.themes|.blog|.swag -->
             </ul>
           </div>
         </div>
@@ -53,6 +54,7 @@
               <li><a class="nav-link" href="{{ .Site.Params.repo }}/tree/v4-dev" aria-describedby="headingProjects" target="_blank" rel="noopener">Boosted 4</a></li>
               <li><a class="nav-link" href="{{ .Site.Params.bootstrap }}" aria-describedby="headingProjects" target="_blank" rel="noopener">Bootstrap</a></li>
               <li><a class="nav-link" href="https://boosted.netlify.app" aria-describedby="headingProjects" target="_blank" rel="noopener">Pre-release on Netlify</a></li>
+              <li><a class="nav-link" href="{{ .Site.Params.icons }}" aria-describedby="headingLinks" target="_blank" rel="noopener">Solaris icons</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
### Description

This PR changes the URL of the Solaris icons to `https://oran.ge/icons` which was broken, but also adds this link in the header and footer of our documentation.

Since the link was broken, a follow-up PR will be created targeting _gh-pages_ to fix this issue.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2396--boosted.netlify.app/docs/extend/icons>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- (NA) I have added JavaScript unit tests to cover my changes
- (NA) I have added SCSS unit tests to cover my changes

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-2396--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)

<!------------------------>
<!-- /!\ Core Team Only -->
<!------------------------>

<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `hugo.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
    - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
- [ ] if the year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities, and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc, and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (e.g. for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] merge (on `v4-dev` or `main`)
- [ ] tag your version, and push your tag
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach the zip file
  - paste the CHANGELOG / Ship list in the release's description
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in to NPM (with a personal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you're releasing a pre-release, use `--tag`, e.g. for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch (don't forget to update Storybook as well)
  - [ ] check every `index.html` used as redirections to redirect to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurrences
- [ ] make an announcement in [GitHub Discussions](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/discussions/categories/announcements) (+ pin the new GH Discussion) and internal communication channels :tada:
-->
