### PR TITLE
fix: change Solaris icons URLs in previous versions

### DIFF
--- a/docs/5.0/examples/cheatsheet/cheatsheet.css
+++ b/docs/5.0/examples/cheatsheet/cheatsheet.css
@@ -4,7 +4,7 @@ body {
 
 /**
  * Solaris "Book" icon
- * @link https://design.orange.com/icons-libraries/
+ * @link https://oran.ge/icons
  */
 .bd-heading a::before {
   display: inline-block;

--- a/docs/5.0/examples/cheatsheet/cheatsheet.rtl.css
+++ b/docs/5.0/examples/cheatsheet/cheatsheet.rtl.css
@@ -4,7 +4,7 @@ body {
 
 /**
  * Solaris "Book" icon
- * @link https://design.orange.com/icons-libraries/
+ * @link https://oran.ge/icons
  */
 .bd-heading a::before {
   display: inline-block;

--- a/docs/5.0/extend/icons/index.html
+++ b/docs/5.0/extend/icons/index.html
@@ -412,7 +412,7 @@
 <h2 id="solaris">Solaris</h2>
 <p>Solaris is a growing library of SVG icons that are designed by <a href="https://design.orange.com/">Orange&rsquo;s Global Design Language Team</a>.</p>
 <p>They are not open-source though and should only be used for Orange branded projects. Please refer to our <a href="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/v5.0.2/NOTICE.txt"><code>NOTICE.txt</code> file for legal informations</a>.</p>
-<p><a href="https://design.orange.com/icons-libraries/">Learn more about Solaris</a> (requires an <code>@orange.com</code> email to sign-up).</p>
+<p><a href="https://oran.ge/icons">Learn more about Solaris</a> (requires an <code>@orange.com</code> email to sign-up).</p>
 <h3 id="use-solaris-icons">Use Solaris icons</h3>
 <!-- NOTE: this is partially copied from bootstrap Icons homepage → https://icons.getbootstrap.com -->
 <p>Solaris provides both PNGs and SVGs, but we strongly recommend to use SVGs. There are quite a few ways to include SVG icons into your HTML—depending on how your project is setup.</p>

--- a/docs/5.1/examples/cheatsheet/cheatsheet.css
+++ b/docs/5.1/examples/cheatsheet/cheatsheet.css
@@ -4,7 +4,7 @@ body {
 
 /**
  * Solaris "Book" icon
- * @link https://design.orange.com/icons-libraries/
+ * @link https://oran.ge/icons
  */
 .bd-heading a::before {
   display: inline-block;

--- a/docs/5.1/examples/cheatsheet/cheatsheet.rtl.css
+++ b/docs/5.1/examples/cheatsheet/cheatsheet.rtl.css
@@ -4,7 +4,7 @@ body {
 
 /**
  * Solaris "Book" icon
- * @link https://design.orange.com/icons-libraries/
+ * @link https://oran.ge/icons
  */
 .bd-heading a::before {
   display: inline-block;

--- a/docs/5.1/extend/icons/index.html
+++ b/docs/5.1/extend/icons/index.html
@@ -417,7 +417,7 @@
 <h2 id="solaris">Solaris</h2>
 <p>Solaris is a growing library of SVG icons that are designed by <a href="https://design.orange.com/">Orange&rsquo;s Global Design Language Team</a>.</p>
 <p>They are not open-source though and should only be used for Orange branded projects. Please refer to our <a href="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/v5.1.3/NOTICE.txt"><code>NOTICE.txt</code> file for legal information</a>.</p>
-<p><a href="https://design.orange.com/icons-libraries/">Learn more about Solaris</a> (requires an <code>@orange.com</code> email to sign-up).</p>
+<p><a href="https://oran.ge/icons">Learn more about Solaris</a> (requires an <code>@orange.com</code> email to sign-up).</p>
 <h3 id="use-solaris-icons">Use Solaris icons</h3>
 <!-- NOTE: this is partially copied from bootstrap Icons homepage → https://icons.getbootstrap.com -->
 <p>Solaris provides both PNGs and SVGs, but we strongly recommend to use SVGs. There are quite a few ways to include SVG icons into your HTML—depending on how your project is setup.</p>

--- a/docs/5.2/extend/icons/index.html
+++ b/docs/5.2/extend/icons/index.html
@@ -521,7 +521,7 @@
 <h2 id="solaris">Solaris <a class="anchor-link" href="#solaris" aria-label="Link to this section: Solaris"></a></h2>
 <p>Solaris is a growing library of SVG icons that are designed by <a href="https://design.orange.com/">Orange&rsquo;s Global Design Language Team</a>.</p>
 <p>They are not open-source though and should only be used for Orange branded projects. Please refer to our <a href="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/v5.2.3/NOTICE.txt"><code>NOTICE.txt</code> file for legal information</a>.</p>
-<p><a href="https://system.design.orange.com/0c1af118d/p/847054-solaris-icons/b/84c5ca">Learn more about Solaris</a>.</p>
+<p><a href="https://oran.ge/icons">Learn more about Solaris</a>.</p>
 <h3 id="use-solaris-icons">Use Solaris icons <a class="anchor-link" href="#use-solaris-icons" aria-label="Link to this section: Use Solaris icons"></a></h3>
 <!-- NOTE: this is partially copied from bootstrap Icons homepage → https://icons.getbootstrap.com -->
 <p>Solaris provides both PNGs and SVGs, but we strongly recommend to use SVGs. There are quite a few ways to include SVG icons into your HTML—depending on how your project is setup.</p>

--- a/docs/5.3/extend/icons/index.html
+++ b/docs/5.3/extend/icons/index.html
@@ -542,7 +542,7 @@
 <h2 id="solaris">Solaris <a class="anchor-link" href="#solaris" aria-label="Link to this section: Solaris"></a></h2>
 <p>Solaris is a growing library of SVG icons that are designed by <a href="https://design.orange.com/">Orange&rsquo;s Global Design Language Team</a>.</p>
 <p>They are not open-source though and should only be used for Orange branded projects. Please refer to our <a href="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/v5.3.2/NOTICE.txt"><code>NOTICE.txt</code> file for legal information</a>.</p>
-<p><a href="https://system.design.orange.com/0c1af118d/p/65c68d-solaris-icon-library">Learn more about Solaris</a>.</p>
+<p><a href="https://oran.ge/icons">Learn more about Solaris</a>.</p>
 <h3 id="use-solaris-icons">Use Solaris icons <a class="anchor-link" href="#use-solaris-icons" aria-label="Link to this section: Use Solaris icons"></a></h3>
 <!-- NOTE: this is partially copied from bootstrap Icons homepage → https://icons.getbootstrap.com -->
 <p>Solaris provides both PNGs and SVGs, but we strongly recommend to use SVGs. There are quite a few ways to include SVG icons into your HTML—depending on how your project is setup.</p>


### PR DESCRIPTION
### Description

This PR follows up https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2396 by fixing the Solaris icons URL by replacing the old ones with the new generic one.