### PR TITLE
Dark mode: fix black card in masonry example

### DIFF
--- a/site/content/docs/5.3/examples/masonry/index.html
+++ b/site/content/docs/5.3/examples/masonry/index.html
@@ -57,12 +57,12 @@ aliases:
       </div>
     </div>
     <div class="col-sm-6 col-lg-4 mb-4">
-      <div class="card bg-black border-dark text-center p-3" data-bs-theme="dark">
+      <div class="card text-bg-secondary border-dark text-center p-3">
         <figure class="mb-0">
           <blockquote class="blockquote">
             <p>A well-known quote, contained in a blockquote element.</p>
           </blockquote>
-          <figcaption class="blockquote-footer mb-0">
+          <figcaption class="blockquote-footer mb-0 text-body-tertiary">
             Someone famous in <cite title="Source Title">Source Title</cite>
           </figcaption>
         </figure>


### PR DESCRIPTION
### Description

This PR tackles the following sub-task defined in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2223 description:

> The rendering is rather clear on the whole page except maybe the black card. Let's use a `.text-bg-secondary` and a `.text-tertiary` for the fig caption

Note: There was a typo so I used `.text-body-tertiary` instead.

#### Live preview

- https://deploy-preview-2408--boosted.netlify.app/docs/5.3/examples/masonry/