### PR TITLE
Dark mode: Spinners doc fix

### DIFF
--- a/site/content/docs/5.3/components/spinners.md
+++ b/site/content/docs/5.3/components/spinners.md
@@ -160,22 +160,22 @@ Use spinners within buttons to indicate an action is currently processing or tak
 
 {{< example >}}
 <button class="btn btn-primary" type="button" disabled>
-  <span class="spinner-border spinner-border-sm" aria-hidden="true" data-bs-theme="dark"></span>
+  <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
   <span class="visually-hidden" role="status">Loading...</span>
 </button>
 <button class="btn btn-primary" type="button" disabled>
-  <span class="spinner-border spinner-border-sm me-2" aria-hidden="true" data-bs-theme="dark"></span>
+  <span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>
   <span role="status">Loading...</span>
 </button>
 {{< /example >}}
 
 {{< example >}}
 <button class="btn btn-primary" type="button" disabled>
-  <span class="spinner-grow spinner-grow-sm" aria-hidden="true" data-bs-theme="dark"></span>
+  <span class="spinner-grow spinner-grow-sm" aria-hidden="true"></span>
   <span class="visually-hidden" role="status">Loading...</span>
 </button>
 <button class="btn btn-primary" type="button" disabled>
-  <span class="spinner-grow spinner-grow-sm me-2" aria-hidden="true" data-bs-theme="dark"></span>
+  <span class="spinner-grow spinner-grow-sm me-2" aria-hidden="true"></span>
   <span role="status">Loading...</span>
 </button>
 {{< /example >}}


### PR DESCRIPTION
### Description

This PR tackles the following sub-task defined in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2223 description:

> Remove `data-bs-theme="dark"` for buttons containing spinners. This should go if we modify `color:` automatically with `[data-bs-theme]`. Otherwise, the only solution would be to have something like `.text-body-inverted` that we want to avoid.


#### Live preview

- https://deploy-preview-2410--boosted.netlify.app/docs/components/spinners/#buttons