### PR TITLE
Dark mode: revert some changes linked to `main` temporary `.text-*` utilities usage before dark mode

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -839,7 +839,7 @@ $blockquote-line-height:      1.5 !default; // Boosted mod
 $blockquote-letter-spacing:   $letter-spacing-base * .25 !default; // Boosted mod
 
 $hr-margin-y:                 $spacer !default;
-$hr-color:                    var(--#{$prefix}heading-color) !default; // Boosted mod: instead of `inherit`
+$hr-color:                    inherit !default;
 
 // fusv-disable
 $hr-bg-color:                 null !default; // Deprecated in v5.2.0

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -839,7 +839,7 @@ $blockquote-line-height:      1.5 !default; // Boosted mod
 $blockquote-letter-spacing:   $letter-spacing-base * .25 !default; // Boosted mod
 
 $hr-margin-y:                 $spacer !default;
-$hr-color:                    var(--#{$prefix}heading-color) !default; // Boosted mod
+$hr-color:                    var(--#{$prefix}heading-color) !default; // Boosted mod: instead of `inherit`
 
 // fusv-disable
 $hr-bg-color:                 null !default; // Deprecated in v5.2.0

--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -140,7 +140,6 @@
 
   .dropdown-menu {
     --bs-dropdown-bg: #{mix($blue-500, $blue-600)};
-    --bs-dropdown-link-color: var(--bs-white);
     --bs-dropdown-link-active-color: var(--bs-white);
     --bs-dropdown-link-active-bg: #{$blue-700};
     --bs-dropdown-link-hover-color: var(--bs-white);
@@ -148,7 +147,6 @@
   }
 
   .btn-dropdown {
-    --bs-btn-color: var(--bs-white);
     --bs-btn-bg: #{mix($gray-600, $blue-400, .5)};
     --bs-btn-border-color: #{rgba($white, .25)};
     --bs-btn-hover-bg: #{darken(mix($gray-600, $blue-400, .5), 5%)};

--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -140,9 +140,7 @@
 
   .dropdown-menu {
     --bs-dropdown-bg: #{mix($blue-500, $blue-600)};
-    --bs-dropdown-link-active-color: var(--bs-white);
     --bs-dropdown-link-active-bg: #{$blue-700};
-    --bs-dropdown-link-hover-color: var(--bs-white);
     --bs-dropdown-link-hover-bg: #{$blue-600};
   }
 
@@ -150,10 +148,8 @@
     --bs-btn-bg: #{mix($gray-600, $blue-400, .5)};
     --bs-btn-border-color: #{rgba($white, .25)};
     --bs-btn-hover-bg: #{darken(mix($gray-600, $blue-400, .5), 5%)};
-    --bs-btn-hover-color: inherit;
     --bs-btn-hover-border-color: #{rgba($white, .25)};
     --bs-btn-active-bg: #{darken(mix($gray-600, $blue-400, .5), 10%)};
-    --bs-btn-active-color: inherit;
     --bs-btn-active-border-color: #{rgba($white, .5)};
     --bs-btn-focus-border-color: #{rgba($white, .5)};
     --bs-btn-focus-box-shadow: 0 0 0 .25rem rgba(255, 255, 255, .2);

--- a/site/content/docs/5.3/components/spinners.md
+++ b/site/content/docs/5.3/components/spinners.md
@@ -43,7 +43,7 @@ The border spinner uses `currentColor` for its `border-color`, meaning you can c
 <div class="spinner-border text-primary" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
-<div class="spinner-border" role="status">
+<div class="spinner-border text-secondary" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
 {{< /example >}}
@@ -72,7 +72,7 @@ Once again, this spinner is built with `currentColor`, so you can easily change 
 <div class="spinner-grow text-primary" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
-<div class="spinner-grow" role="status">
+<div class="spinner-grow text-secondary" role="status">
   <span class="visually-hidden">Loading...</span>
 </div>
 {{< /example >}}


### PR DESCRIPTION
### Description

This PR tackles the following sub-task identified in #2140:

> Check modifications in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2030 (most of the one linked to the text colors must be reverted)

This PR contains the only elements I've found to modify that were extra temporary elements coming from this PR. The dark mode implementation already took care of the majority of them by removing mostly extra `.text-*` classes.

### Live previews

- https://deploy-preview-2414--boosted.netlify.app/docs/5.3/customize/color-modes/#custom-color-modes