### PR TITLE
fix(examples): drop underline of hovered footer links in Download page example

### DIFF
--- a/site/content/docs/5.3/examples/download-app/download-app.css
+++ b/site/content/docs/5.3/examples/download-app/download-app.css
@@ -78,10 +78,6 @@ iframe {
   min-height: 10.625rem;
 }
 
-footer .nav-link:hover {
-  text-decoration: underline;
-}
-
 .carousel-inner.showcase-images {
   min-height: calc(216vw - 208px);
 }


### PR DESCRIPTION
### Description

As decided this 14th of December during the core team meeting by designers, a11y team, and developers, this PR removes the underlined hovered effect of the footer links in our Download page example for consistency.

This implementation will be done via https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2407 in the future if this is accepted as the right solution.

### Live previews

- https://deploy-preview-2415--boosted.netlify.app/docs/5.3/examples/download-app/

### After the merge

- [ ] Update the description of https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2407 to only explain the choice we have to make in the future between the 2 versions.