### PR TITLE
Dark mode: add a warning callout to Orange's colors section

### DIFF
--- a/site/content/docs/5.3/components/orange-navbar.md
+++ b/site/content/docs/5.3/components/orange-navbar.md
@@ -384,6 +384,8 @@ You can add a mode selector control into your Global header.
 In this section, the dropdown menu items are not functional because the JavaScript is linked to the documentation mode selector; the active state and the tick icon are not rendered correctly. But don't worry, it'll work perfectly in your project.
 
 Don't forget to import the [corresponding color modes JavaScript]({{< docsref "/customize/color-modes#javascript" >}}) in your project.
+
+To easily integrate it in your project, you can start from our [Navbar mode selector example]({{< docsref "/examples/navbar-mode-selector" >}}).
 {{< /callout >}}
 
 <div class="bd-example-snippet">

--- a/site/content/docs/5.3/utilities/colors.md
+++ b/site/content/docs/5.3/utilities/colors.md
@@ -62,9 +62,13 @@ To be sure to respect the specifications, it is necessary to define `color`, `ba
 Thus, the `.text-primary` color on white background (`#f16e00`) can only be used in a font size greater than 24px (using for example `.fs-3` utility), or 19px bold (using for example `.fs-4` and `.fw-bold` utilities).
 The `.text-primary` color on dark background (`#ff7900`) can be used in any size, and it shouldn't be used on light grey backgrounds at all.
 
+{{< callout warning >}}
+When the texts can be shown on both light and dark backgrounds (when there is a mode selector for instance), the light mode stricter restrictions must be applied!
+{{< /callout >}}
+
 Here are some compliant combinations examples for texts:
 
-  {{< example >}}
+{{< example >}}
 <div class="p-1" data-bs-theme="light">
   <p>regular text</p>
   <p class="text-primary fs-3">regular primary text with minimum font-size for contrast with .fs-3 (restrictive because of the light mode)</p>

--- a/site/content/docs/5.3/utilities/colors.md
+++ b/site/content/docs/5.3/utilities/colors.md
@@ -63,7 +63,7 @@ Thus, the `.text-primary` color on white background (`#f16e00`) can only be used
 The `.text-primary` color on dark background (`#ff7900`) can be used in any size, and it shouldn't be used on light grey backgrounds at all.
 
 {{< callout warning >}}
-When the texts can be shown on both light and dark backgrounds (when there is a mode selector for instance), the light mode stricter restrictions must be applied!
+When the interface allows to switch between light and dark backgrounds, the light mode stricter restrictions must be applied!
 {{< /callout >}}
 
 Here are some compliant combinations examples for texts:


### PR DESCRIPTION
### Description

This PR adds a warning callout to the "Orange's colors" section to precise that the light mode rules must be applied when a text can be seen on both light and dark backgrounds.

This was a sub-task identified in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2223:

> Colors: Rework docs/5.3/utilities/colors/#oranges-colors to explain it clearly

### Live previews

- https://deploy-preview-2444--boosted.netlify.app/docs/5.3/utilities/colors/#oranges-colors