### PR TITLE
fix(docs): remove extra 'new version' messages in Orange navbar examples from the v5.2

### DIFF
--- a/docs/5.2/components/navbar/index.html
+++ b/docs/5.2/components/navbar/index.html
@@ -671,16 +671,6 @@ The animation effect of this component is dependent on the <code>prefers-reduced
   </nav>
 </header>
 
-<nav role="navigation" class="navbar navbar-expand-md py-0 fixed-top navbar-dark pe-none shadow-none" aria-label="Complementary navigation">
-  <div class="container-fluid nav-item justify-content-center">
-    <ul class="navbar-nav">
-      <li class="nav-item border-0">
-        <a href="https://boosted.orange.com" class="nav-link pe-auto"><span class="d-none d-sm-block fs-6">There's a newer version of Boosted!</span><span class="d-sm-none fs-6">Newer version of Boosted!</span></a>
-      </li>
-    </ul>
-  </div>
-</nav>
-
 <!-- As a heading -->
 <header class="mt-3">
   <nav class="navbar navbar-dark bg-dark">
@@ -694,16 +684,6 @@ The animation effect of this component is dependent on the <code>prefers-reduced
     </div>
   </nav>
 </header>
-
-<nav role="navigation" class="navbar navbar-expand-md py-0 fixed-top navbar-dark pe-none shadow-none" aria-label="Complementary navigation">
-  <div class="container-fluid nav-item justify-content-center">
-    <ul class="navbar-nav">
-      <li class="nav-item border-0">
-        <a href="https://boosted.orange.com" class="nav-link pe-auto"><span class="d-none d-sm-block fs-6">There's a newer version of Boosted!</span><span class="d-sm-none fs-6">Newer version of Boosted!</span></a>
-      </li>
-    </ul>
-  </div>
-</nav>
 </div>
       
       <div class="d-flex align-items-baseline highlight-toolbar ps-3 pe-2 py-1">

--- a/docs/5.2/components/orange-navbar/index.html
+++ b/docs/5.2/components/orange-navbar/index.html
@@ -631,16 +631,6 @@
 </nav>
 
   </header>
-
-<nav role="navigation" class="navbar navbar-expand-md py-0 fixed-top navbar-dark pe-none shadow-none" aria-label="Complementary navigation">
-  <div class="container-fluid nav-item justify-content-center">
-    <ul class="navbar-nav">
-      <li class="nav-item border-0">
-        <a href="https://boosted.orange.com" class="nav-link pe-auto"><span class="d-none d-sm-block fs-6">There's a newer version of Boosted!</span><span class="d-sm-none fs-6">Newer version of Boosted!</span></a>
-      </li>
-    </ul>
-  </div>
-</nav>
 </div></div>
 
 <p>For more examples, visit our <a href="/docs/5.2/examples/navbars/">examples page</a>.</p>
@@ -805,16 +795,6 @@ This component should be:</p>
 </nav>
 
   </header>
-
-<nav role="navigation" class="navbar navbar-expand-md py-0 fixed-top navbar-dark pe-none shadow-none" aria-label="Complementary navigation">
-  <div class="container-fluid nav-item justify-content-center">
-    <ul class="navbar-nav">
-      <li class="nav-item border-0">
-        <a href="https://boosted.orange.com" class="nav-link pe-auto"><span class="d-none d-sm-block fs-6">There's a newer version of Boosted!</span><span class="d-sm-none fs-6">Newer version of Boosted!</span></a>
-      </li>
-    </ul>
-  </div>
-</nav>
 </div>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">header</span><span class="p">&gt;</span>
 </span></span><span class="line"><span class="cl">  <span class="c">&lt;!-- Supra bar --&gt;</span>
@@ -923,16 +903,6 @@ This component should be:</p>
 </nav>
 
   </header>
-
-<nav role="navigation" class="navbar navbar-expand-md py-0 fixed-top navbar-dark pe-none shadow-none" aria-label="Complementary navigation">
-  <div class="container-fluid nav-item justify-content-center">
-    <ul class="navbar-nav">
-      <li class="nav-item border-0">
-        <a href="https://boosted.orange.com" class="nav-link pe-auto"><span class="d-none d-sm-block fs-6">There's a newer version of Boosted!</span><span class="d-sm-none fs-6">Newer version of Boosted!</span></a>
-      </li>
-    </ul>
-  </div>
-</nav>
 </div>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">header</span><span class="p">&gt;</span>
 </span></span><span class="line"><span class="cl">  <span class="p">&lt;</span><span class="nt">nav</span> <span class="na">class</span><span class="o">=</span><span class="s">&#34;navbar navbar-dark bg-dark navbar-expand-lg&#34;</span> <span class="na">aria-label</span><span class="o">=</span><span class="s">&#34;Global navigation - Standard example&#34;</span><span class="p">&gt;</span>
@@ -1056,17 +1026,6 @@ This component should be:</p>
 </nav>
 
   </header>
-
-<nav role="navigation" class="navbar navbar-expand-md py-0 fixed-top navbar-dark pe-none shadow-none" aria-label="Complementary navigation">
-  <div class="container-fluid nav-item justify-content-center">
-    <ul class="navbar-nav">
-      <li class="nav-item border-0">
-        <a href="https://boosted.orange.com" class="nav-link pe-auto"><span class="d-none d-sm-block fs-6">There's a newer version of Boosted!</span><span class="d-sm-none fs-6">Newer version of Boosted!</span></a>
-      </li>
-    </ul>
-  </div>
-</nav>
-</div>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">header</span><span class="p">&gt;</span>
 </span></span><span class="line"><span class="cl">  <span class="p">&lt;</span><span class="nt">nav</span> <span class="na">class</span><span class="o">=</span><span class="s">&#34;navbar navbar-dark bg-dark navbar-expand-lg&#34;</span> <span class="na">aria-label</span><span class="o">=</span><span class="s">&#34;Global navigation - With custom logo example&#34;</span><span class="p">&gt;</span>
 </span></span><span class="line"><span class="cl">    <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">&#34;container-xxl&#34;</span><span class="p">&gt;</span>
@@ -1147,17 +1106,6 @@ This component should be:</p>
 </nav>
 
   </header>
-
-<nav role="navigation" class="navbar navbar-expand-md py-0 fixed-top navbar-dark pe-none shadow-none" aria-label="Complementary navigation">
-  <div class="container-fluid nav-item justify-content-center">
-    <ul class="navbar-nav">
-      <li class="nav-item border-0">
-        <a href="https://boosted.orange.com" class="nav-link pe-auto"><span class="d-none d-sm-block fs-6">There's a newer version of Boosted!</span><span class="d-sm-none fs-6">Newer version of Boosted!</span></a>
-      </li>
-    </ul>
-  </div>
-</nav>
-</div>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">header</span><span class="p">&gt;</span>
 </span></span><span class="line"><span class="cl">  <span class="p">&lt;</span><span class="nt">nav</span> <span class="na">class</span><span class="o">=</span><span class="s">&#34;navbar navbar-dark bg-dark navbar-expand-lg&#34;</span> <span class="na">aria-label</span><span class="o">=</span><span class="s">&#34;Global navigation - With one line title example&#34;</span><span class="p">&gt;</span>
 </span></span><span class="line"><span class="cl">    <span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">&#34;container-xxl&#34;</span><span class="p">&gt;</span>
@@ -1239,16 +1187,6 @@ This component should be:</p>
 </nav>
 
   </header>
-
-<nav role="navigation" class="navbar navbar-expand-md py-0 fixed-top navbar-dark pe-none shadow-none" aria-label="Complementary navigation">
-  <div class="container-fluid nav-item justify-content-center">
-    <ul class="navbar-nav">
-      <li class="nav-item border-0">
-        <a href="https://boosted.orange.com" class="nav-link pe-auto"><span class="d-none d-sm-block fs-6">There's a newer version of Boosted!</span><span class="d-sm-none fs-6">Newer version of Boosted!</span></a>
-      </li>
-    </ul>
-  </div>
-</nav>
 </div>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">header</span><span class="p">&gt;</span>
 </span></span><span class="line"><span class="cl">  <span class="p">&lt;</span><span class="nt">nav</span> <span class="na">class</span><span class="o">=</span><span class="s">&#34;navbar navbar-dark bg-dark navbar-expand-lg&#34;</span> <span class="na">aria-label</span><span class="o">=</span><span class="s">&#34;Global navigation - With two lines title example&#34;</span><span class="p">&gt;</span>
@@ -1317,16 +1255,6 @@ This component should be:</p>
 </nav>
 
   </header>
-
-<nav role="navigation" class="navbar navbar-expand-md py-0 fixed-top navbar-dark pe-none shadow-none" aria-label="Complementary navigation">
-  <div class="container-fluid nav-item justify-content-center">
-    <ul class="navbar-nav">
-      <li class="nav-item border-0">
-        <a href="https://boosted.orange.com" class="nav-link pe-auto"><span class="d-none d-sm-block fs-6">There's a newer version of Boosted!</span><span class="d-sm-none fs-6">Newer version of Boosted!</span></a>
-      </li>
-    </ul>
-  </div>
-</nav>
 </div>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">header</span><span class="p">&gt;</span>
 </span></span><span class="line"><span class="cl">  <span class="p">&lt;</span><span class="nt">nav</span> <span class="na">class</span><span class="o">=</span><span class="s">&#34;navbar navbar-dark bg-dark navbar-expand-lg&#34;</span> <span class="na">aria-label</span><span class="o">=</span><span class="s">&#34;Global navigation - With search box example&#34;</span><span class="p">&gt;</span>
@@ -1442,16 +1370,6 @@ Refer to <a href="/docs/5.2/customize/optimize/#lean-javascript">Lean JavaScript
 </nav>
 
   </header>
-
-<nav role="navigation" class="navbar navbar-expand-md py-0 fixed-top navbar-dark pe-none shadow-none" aria-label="Complementary navigation">
-  <div class="container-fluid nav-item justify-content-center">
-    <ul class="navbar-nav">
-      <li class="nav-item border-0">
-        <a href="https://boosted.orange.com" class="nav-link pe-auto"><span class="d-none d-sm-block fs-6">There's a newer version of Boosted!</span><span class="d-sm-none fs-6">Newer version of Boosted!</span></a>
-      </li>
-    </ul>
-  </div>
-</nav>
 </div>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">header</span><span class="p">&gt;</span>
 </span></span><span class="line"><span class="cl">  <span class="p">&lt;</span><span class="nt">nav</span> <span class="na">class</span><span class="o">=</span><span class="s">&#34;navbar navbar-dark bg-dark navbar-expand-lg&#34;</span> <span class="na">aria-label</span><span class="o">=</span><span class="s">&#34;Global navigation - Standard example with nav-under&#34;</span><span class="p">&gt;</span>


### PR DESCRIPTION
### Description

As you can see in https://boosted.orange.com/docs/5.2/components/orange-navbar/, we can observe some "There's a newer version of Boosted!" messages directly into the Orange navbar examples:

![Screenshot 2024-02-08 at 10 58 27](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/00cf99da-c81f-40fa-b5a7-2e8b598d015a)
![Screenshot 2024-02-08 at 10 58 22](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/eb3d2c1a-ca03-4aff-b9e1-6ab920fd4ce2)

This was introduced with the big global modification in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2147/files#diff-5b9361e477624c95d541b93c9998e5d724eac117b7e31273dae93593cfdd2932.

I haven't found any other occurrences in other versions of our documentation.