### PR TITLE
Docs: Use oran.ge links when they exist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,7 +43,7 @@ _Note: Please transform `- [ ]` into `- (NA)` in the description when things are
 
 #### Design
 
-- [ ] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
+- [ ] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
 - [ ] My change is compatible with a responsive display
 
 #### Development

--- a/hugo.yml
+++ b/hugo.yml
@@ -73,7 +73,7 @@ params:
   icons:                            "https://oran.ge/icons"
   bootstrap:                        "https://getbootstrap.com"
   ods:
-    web:                            "https://system.design.orange.com/0c1af118d/n/76065f"
+    web:                            "https://oran.ge/dsweb"
 
   download:
     source:                         "https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/archive/v5.3.2.zip"

--- a/site/content/docs/5.3/guidelines/_index.md
+++ b/site/content/docs/5.3/guidelines/_index.md
@@ -17,7 +17,7 @@ aliases:
         <div class="card border-1 mb-2 mb-md-3 mb-lg-0">
           <img class="card-img-top" src="/docs/{{ $.Site.Params.docs_version }}/{{.image}}" alt="">
           <div class="card-body ps-2 pt-2">
-            <a href="{{.link}}" class="stretched-link text-decoration-none h4" aria-label="{{.description}}" title="{{.description}}">{{.name}}</a>
+            <a href="{{.link}}" class="stretched-link text-decoration-none h4" aria-label="{{.description}}" title="{{.description}}" target="_blank" rel="noopener">{{.name}}</a>
           </div>
         </div>
       </div>

--- a/site/data/design-guidelines.yml
+++ b/site/data/design-guidelines.yml
@@ -1,11 +1,11 @@
 - name: "Android"
   description: "Design system for Android"
-  link: "https://system.design.orange.com/0c1af118d/n/40c8b1"
+  link: "https://oran.ge/dsandroid"
   image: "assets/img/platforms/android.png"
 
 - name: "iOS"
   description: "Design system for iOS"
-  link: "https://system.design.orange.com/0c1af118d/n/24511f"
+  link: "https://oran.ge/dsios"
   image: "assets/img/platforms/iOS.png"
 
 - name: "Extended Reality"

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -25,7 +25,7 @@
             </div>
             {{ else if eq .Title "Orange Design System for web" }}
             <div class="d-flex flex-column flex-sm-row">
-              <a href="{{ .Site.Params.ods.web }}" class="btn btn-primary" aria-label="Design system for web" title="Design system for web">Visit system.design.orange.com</a>
+              <a href="{{ .Site.Params.ods.web }}" class="btn btn-primary" aria-label="Design system for web" title="Design system for web" target="_blank" rel="noopener">Visit system.design.orange.com</a>
             </div>
             {{ end }}
           </div>

--- a/site/layouts/partials/home/orange-design-system.html
+++ b/site/layouts/partials/home/orange-design-system.html
@@ -8,7 +8,7 @@
       Streamline your workflow and improve experience consistency with this cross-platform, scalable and inspiring design system. Designers, developers, marketers and partners, start your digital creations from the ready-to-use resources here!
     </p>
     <p class="d-flex align-items-start flex-column lead fw-normal mb-0">
-      <a href="https://system.design.orange.com/0c1af118d/n/76065f" class="icon-link icon-link-hover fw-semibold" target="_blank" rel="noopener">
+      <a href="https://oran.ge/dsweb" class="icon-link icon-link-hover fw-semibold" target="_blank" rel="noopener">
         Visit system.design.orange.com
         <svg class="bi"><use xlink:href="#arrow-right"></use></svg>
       </a>

--- a/site/layouts/partials/home/orange-design-system.html
+++ b/site/layouts/partials/home/orange-design-system.html
@@ -8,7 +8,7 @@
       Streamline your workflow and improve experience consistency with this cross-platform, scalable and inspiring design system. Designers, developers, marketers and partners, start your digital creations from the ready-to-use resources here!
     </p>
     <p class="d-flex align-items-start flex-column lead fw-normal mb-0">
-      <a href="https://oran.ge/dsweb" class="icon-link icon-link-hover fw-semibold" target="_blank" rel="noopener">
+      <a href="{{ .Site.Params.ods.web }}" class="icon-link icon-link-hover fw-semibold" target="_blank" rel="noopener">
         Visit system.design.orange.com
         <svg class="bi"><use xlink:href="#arrow-right"></use></svg>
       </a>


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

NA

### Description

Use `oran.ge/*` links when possible.

### Motivation & Context

Being more flexible to changes inside the DSM and so avoid broken links.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2488--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- (NA) I have added JavaScript unit tests to cover my changes
- (NA) I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- (NA) My change introduces changes to the migration guide
- (NA) My new component is well displayed in [Storybook](https://deploy-preview-2488--boosted.netlify.app/storybook)
- (NA) My new component is compatible with RTL
- (NA) Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- (NA) Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)

<!------------------------>
<!-- /!\ Core Team Only -->
<!------------------------>

<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `hugo.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
    - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
- [ ] if the year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities, and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc, and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (e.g. for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] merge (on `v4-dev` or `main`)
- [ ] tag your version, and push your tag
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach the zip file
  - paste the CHANGELOG / Ship list in the release's description
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in to NPM (with a personal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you're releasing a pre-release, use `--tag`, e.g. for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch (don't forget to update Storybook as well)
  - [ ] check every `index.html` used as redirections to redirect to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurrences
- [ ] make an announcement in [GitHub Discussions](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/discussions/categories/announcements) (+ pin the new GH Discussion) and internal communication channels :tada:
-->