### PR TITLE
Use constant to define play/pause css class names for caroussel

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -42,11 +42,11 @@
     },
     {
       "path": "./dist/js/boosted.esm.js",
-      "maxSize": "33.0 kB"
+      "maxSize": "33.25 kB"
     },
     {
       "path": "./dist/js/boosted.esm.min.js",
-      "maxSize": "20.25 kB"
+      "maxSize": "20.5 kB"
     },
     {
       "path": "./dist/js/boosted.js",

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -55,6 +55,8 @@ const CLASS_NAME_NEXT = 'carousel-item-next'
 const CLASS_NAME_PREV = 'carousel-item-prev'
 const CLASS_NAME_PAUSED = 'is-paused' // Boosted mod: used for progress indicators
 const CLASS_NAME_DONE = 'is-done' // Boosted mod: used for progress indicators
+const CLASS_NAME_PAUSE = 'pause' // Boosted mod: used for pause button
+const CLASS_NAME_PLAY = 'play' // Boosted mod: used for play button
 
 const SELECTOR_ACTIVE = '.active'
 const SELECTOR_ITEM = '.carousel-item'
@@ -164,9 +166,9 @@ class Carousel extends BaseComponent {
     // End mod
 
     // Boosted mod: if a play-pause button is present, set the button to play
-    if (this._playPauseButton !== null && this._playPauseButton.classList.contains('pause')) {
-      this._playPauseButton.classList.remove('pause')
-      this._playPauseButton.classList.add('play')
+    if (this._playPauseButton !== null && this._playPauseButton.classList.contains(CLASS_NAME_PAUSE)) {
+      this._playPauseButton.classList.remove(CLASS_NAME_PAUSE)
+      this._playPauseButton.classList.add(CLASS_NAME_PLAY)
 
       if (this._playPauseButton.getAttribute(SELECTOR_CAROUSEL_PLAY_TEXT)) {
         this._playPauseButton.setAttribute('title', this._playPauseButton.getAttribute(SELECTOR_CAROUSEL_PLAY_TEXT))
@@ -195,9 +197,9 @@ class Carousel extends BaseComponent {
     // End mod
 
     // Boosted mod: if a play-pause button is present, reset the button to pause
-    if (this._playPauseButton !== null && this._playPauseButton.classList.contains('play')) {
-      this._playPauseButton.classList.remove('play')
-      this._playPauseButton.classList.add('pause')
+    if (this._playPauseButton !== null && this._playPauseButton.classList.contains(CLASS_NAME_PLAY)) {
+      this._playPauseButton.classList.remove(CLASS_NAME_PLAY)
+      this._playPauseButton.classList.add(CLASS_NAME_PAUSE)
 
       if (this._playPauseButton.getAttribute(SELECTOR_CAROUSEL_PAUSE_TEXT)) {
         this._playPauseButton.setAttribute('title', this._playPauseButton.getAttribute(SELECTOR_CAROUSEL_PAUSE_TEXT))
@@ -548,7 +550,7 @@ class Carousel extends BaseComponent {
     const pauseButton = event.target
     const pauseButtonAttribute = pauseButton.getAttribute(SELECTOR_CAROUSEL_TO_PAUSE)
     const carouselToPause = Carousel.getOrCreateInstance(document.querySelector(pauseButtonAttribute))
-    if (pauseButton.classList.contains('pause')) {
+    if (pauseButton.classList.contains(CLASS_NAME_PAUSE)) {
       carouselToPause.pause()
     } else {
       carouselToPause.cycle()


### PR DESCRIPTION

### Related issues

(NA)

### Description

To align with the way Bootstrap handle and manage CSS class names in JS, I propose to add dedicated variable for boosted mod play/pause CLASS_NAME_PAUSE
CLASS_NAME_PLAY

### Motivation & Context

Would help if a custom project wants to prefix his CSS classes _for example_

### Types of change
- Refactoring (non-breaking change)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2502--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-2502--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)

<!------------------------>
<!-- /!\ Core Team Only -->
<!------------------------>

<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `hugo.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
    - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
- [ ] if the year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities, and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc, and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (e.g. for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] Commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] Merge (on `v4-dev` or `main`)
- [ ] Tag your version, and push your tag
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in to NPM (with a personal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you're releasing a pre-release, use `--tag`, e.g. for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch (don't forget to update Storybook as well)
  - [ ] check every `index.html` used as redirections to redirect to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurrences
- [ ] make an announcement in [GitHub Discussions](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/discussions/categories/announcements) (+ pin the new GH Discussion)
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach the zip file
  - paste the CHANGELOG / Ship list in the release's description
- [ ] make an announcement on internal communication channels :tada:
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
-->
