### PR TITLE
chore(deps): bump tarteaucitronjs from 1.16.1 to 1.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "storybook": "^7.6.17",
         "stylelint": "^16.2.1",
         "stylelint-config-twbs-bootstrap": "^14.0.0",
-        "tarteaucitronjs": "^1.16.1",
+        "tarteaucitronjs": "^1.17.0",
         "terser": "^5.27.1",
         "vnu-jar": "^23.4.11"
       },
@@ -20026,9 +20026,9 @@
       "dev": true
     },
     "node_modules/tarteaucitronjs": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.16.1.tgz",
-      "integrity": "sha512-NJlXrdpxPE0Da9VHdXVYbOQ31kHNtZkcosSzfzLe0iMu3kDtW4/BdvmFe0E/WkNq7X3CcqG1wiPHcfybgOVLTw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.17.0.tgz",
+      "integrity": "sha512-cjd6Y7I0+8DIcC1xsUYdRc8Y154MUi4trzX6vujux+cKudQv+px99i8Hampu5HLvQM7NcNrO/f7Ityvw4tWl4Q==",
       "dev": true
     },
     "node_modules/telejson": {
@@ -35877,9 +35877,9 @@
       }
     },
     "tarteaucitronjs": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.16.1.tgz",
-      "integrity": "sha512-NJlXrdpxPE0Da9VHdXVYbOQ31kHNtZkcosSzfzLe0iMu3kDtW4/BdvmFe0E/WkNq7X3CcqG1wiPHcfybgOVLTw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.17.0.tgz",
+      "integrity": "sha512-cjd6Y7I0+8DIcC1xsUYdRc8Y154MUi4trzX6vujux+cKudQv+px99i8Hampu5HLvQM7NcNrO/f7Ityvw4tWl4Q==",
       "dev": true
     },
     "telejson": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "storybook": "^7.6.17",
     "stylelint": "^16.2.1",
     "stylelint-config-twbs-bootstrap": "^14.0.0",
-    "tarteaucitronjs": "^1.16.1",
+    "tarteaucitronjs": "^1.17.0",
     "terser": "^5.27.1",
     "vnu-jar": "^23.4.11"
   },

--- a/site/assets/js/tac.js
+++ b/site/assets/js/tac.js
@@ -99,7 +99,7 @@ if (typeof tarteaucitron !== 'undefined') {
     handleBrowserDNTRequest: true,
     useExternalCss: true,
     mandatory: false,
-    googleConsentMode: true,
+    googleConsentMode: false,
     partnersList: true
   })
 

--- a/site/assets/js/tac.js
+++ b/site/assets/js/tac.js
@@ -40,6 +40,8 @@
 
   window.addEventListener('tac.open_panel',
     () => {
+      document.getElementById('tarteaucitronSaveButton').classList.add('btn', 'btn-sm', 'btn-secondary', 'mt-2')
+
       document.querySelectorAll('#tarteaucitronServices_api button').forEach(button => {
         button.classList.add('btn', 'btn-sm', 'ms-2')
       })

--- a/site/assets/js/tac.js
+++ b/site/assets/js/tac.js
@@ -40,7 +40,7 @@
 
   window.addEventListener('tac.open_panel',
     () => {
-      document.getElementById('tarteaucitronSaveButton').classList.add('btn', 'btn-sm', 'btn-secondary', 'mt-2')
+      document.getElementById('tarteaucitronSaveButton').classList.add('btn', 'btn-secondary', 'd-flex', 'mt-3', 'mx-auto')
 
       document.querySelectorAll('#tarteaucitronServices_api button').forEach(button => {
         button.classList.add('btn', 'btn-sm', 'ms-2')

--- a/site/assets/js/tac.js
+++ b/site/assets/js/tac.js
@@ -98,7 +98,9 @@ if (typeof tarteaucitron !== 'undefined') {
     showIcon: false,
     handleBrowserDNTRequest: true,
     useExternalCss: true,
-    mandatory: false
+    mandatory: false,
+    googleConsentMode: true,
+    partnersList: true
   })
 
   tarteaucitron.user.googletagmanagerId = 'GTM-P6H78BQ';


### PR DESCRIPTION
### Description

This PR bumps tarteaucitronjs dependency from 1.16.1 to 1.17.0.
This new version brings some new features that are mentioned in the [corresponding release note](https://github.com/AmauriC/tarteaucitron.js/releases/tag/v1.17.0).
From this changelog, some elements to look at precisely.

#### Google Consent Mode v2 natively supported for GA4 and Google Ads

This PR adds the new `googleConsentMode` parameter and set it to `false`. With `true` (default value), the cookies are not stored anymore.

#### New parameter to show the number of partners on the banner `partnersList`

This PR adds the new `partnersList` parameter and set it to `true`. With Google Tag Manager, it doesn't seem to display more information, but it could be useful in the future if we add other services.

#### Function `tarteaucitron.setConsent(id, status);`

We apparently don't need to call it ourselves since it's used by the new save button already.

#### Add a save button at the bottom of the control panel

This new save button needed to have a Boosted-style so this PR adds some classes to it.

<img width="1206" alt="Screenshot 2024-03-08 at 11 35 24" src="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/assets/17381666/0dbb2146-1494-4bc4-8463-10bfb4895088">