### PR TITLE
UI Kit v6: Update font-sizes

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -307,6 +307,9 @@ small {
   // Boosted mod
   font-weight: $font-weight-normal;
   line-height: $line-height-sm;
+
+  /* rtl:remove */
+  letter-spacing: 0;
   // End mod
 }
 

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -34,33 +34,35 @@
   @extend %heading;
 }
 
-.display-1 {
-  @include font-size($h2-font-size);
-  line-height: $h2-line-height;
+h1 {
+  @include font-size(1.875rem);
+  line-height: calc(32 / 30); // stylelint-disable-line function-disallowed-list
 
   /* rtl:remove */
-  letter-spacing: $h2-spacing;
+  letter-spacing: -.8px;
 }
 
-h1,
-.display-2,
-.display-3 {
+h2,
+.display-1 {
   @include font-size($h3-font-size);
   line-height: $h3-line-height;
 
   /* rtl:remove */
-  letter-spacing: $mid-spacing;
-}
-
-/* rtl:begin:remove */
-.display-2 {
   letter-spacing: $h3-spacing;
 }
 
-/* rtl:end:remove */
+.display-2 {
+  @include font-size($h4-font-size);
+  line-height: $h4-line-height;
 
-h2,
-.display-4 {
+  /* rtl:remove */
+  letter-spacing: $h4-spacing;
+}
+
+h3,
+.display-3,
+.body-lg,
+.label-lg {
   @include font-size($h5-font-size);
   line-height: $h5-line-height;
 
@@ -68,109 +70,77 @@ h2,
   letter-spacing: $h5-spacing;
 }
 
-.lead {
-  @include font-size($h6-font-size);
-  font-weight: $lead-font-weight;
-  line-height: $lead-line-height;
+.body-md,
+.label-md {
+  @include font-size($font-size-base);
+  line-height: $line-height-base;
 
   /* rtl:remove */
-  letter-spacing: $h6-spacing;
+  letter-spacing: $letter-spacing-base;
 }
 
-@include media-breakpoint-up(sm) {
-  h1,
-  .display-1,
-  .display-2,
-  .display-3 {
-    line-height: $display-line-height;
+.body-sm,
+.label-sm {
+  @include font-size($font-size-sm);
+  line-height: $line-height-sm;
+
+  /* rtl:remove */
+  letter-spacing: 0;
+}
+
+.body-lg {
+  line-height: calc(26 / 18); // stylelint-disable-line function-disallowed-list
+}
+
+.body-md {
+  line-height: 1.5;
+}
+
+.body-sm {
+  line-height: calc(20 / 14); // stylelint-disable-line function-disallowed-list
+}
+
+.lead {
+  @include font-size($h5-font-size);
+  font-weight: $lead-font-weight;
+  line-height: calc(26 / 18); // stylelint-disable-line function-disallowed-list
+
+  /* rtl:remove */
+  letter-spacing: $h5-spacing;
+}
+
+@include media-breakpoint-up(md) {
+  h1 {
+    @include font-size($h1-font-size);
+    line-height: $h1-line-height;
+
+    /* rtl:remove */
+    letter-spacing: $h1-spacing;
   }
 
   .display-1 {
-    @include font-size($display2-size);
+    @include font-size(2.5rem);
+    line-height: $display-line-height;
 
     /* rtl:remove */
-    letter-spacing: $display2-spacing;
-  }
-
-  .display-2 {
-    @include font-size($display3-size);
-
-    /* rtl:remove */
-    letter-spacing: $display3-spacing;
-  }
-
-  h1,
-  .display-3 {
-    @include font-size($display4-size);
-
-    /* rtl:remove */
-    letter-spacing: $display4-spacing;
+    letter-spacing: -1px;
   }
 
   h2,
-  h3,
-  .display-4 {
-    @include font-size($h3-font-size);
-    line-height: $h3-line-height;
-
-    /* rtl:remove */
-    letter-spacing: $h3-spacing;
-  }
-
-  h4,
-  h5,
-  h6 {
-    @include font-size($h5-font-size);
-    line-height: $h5-line-height;
-
-    /* rtl:remove */
-    letter-spacing: $h5-spacing;
-  }
-
-  .lead {
-    @include font-size($h5-font-size);
-
-    /* rtl:remove */
-    letter-spacing: $h5-spacing;
-  }
-}
-
-@include media-breakpoint-up(lg) {
-  .display-1 {
-    @include font-size($display1-size);
-
-    /* rtl:remove */
-    letter-spacing: $display1-spacing;
-  }
-
   .display-2 {
-    @include font-size($display2-size);
-
-    /* rtl:remove */
-    letter-spacing: $display2-spacing;
-  }
-
-  .display-3 {
-    @include font-size($display3-size);
-
-    /* rtl:remove */
-    letter-spacing: $display3-spacing;
-  }
-
-  .display-4 {
-    @include font-size($display4-size);
-    line-height: $display-line-height;
-
-    /* rtl:remove */
-    letter-spacing: $display4-spacing;
-  }
-
-  h2 {
     @include font-size($h2-font-size);
     line-height: $h2-line-height;
 
     /* rtl:remove */
     letter-spacing: $h2-spacing;
+  }
+
+  .display-3 {
+    @include font-size($display3-size);
+    line-height: $display-line-height;
+
+    /* rtl:remove */
+    letter-spacing: $display3-spacing;
   }
 
   h3 {
@@ -181,6 +151,53 @@ h2,
     letter-spacing: $h3-spacing;
   }
 
+  h4,
+  h5 {
+    @include font-size($h5-font-size);
+    line-height: $h5-line-height;
+
+    /* rtl:remove */
+    letter-spacing: $h5-spacing;
+  }
+
+  .body-lg {
+    @include font-size($font-size-xlg);
+    line-height: 1.5;
+  }
+
+  .body-md {
+    @include font-size($font-size-lg);
+    line-height: calc(26 / 18); // stylelint-disable-line function-disallowed-list
+
+    /* rtl:remove */
+    letter-spacing: $h5-spacing;
+  }
+
+  .body-sm {
+    @include font-size($font-size-base);
+    line-height: 1.5;
+
+    /* rtl:remove */
+    letter-spacing: $letter-spacing-base;
+  }
+
+  .lead {
+    @include font-size($lead-font-size);
+    line-height: $lead-line-height;
+
+    /* rtl:remove */
+    letter-spacing: $lead-letter-spacing;
+  }
+}
+
+@include media-breakpoint-up(xl) {
+  .display-1 {
+    @include font-size($display1-size);
+
+    /* rtl:remove */
+    letter-spacing: $display1-spacing;
+  }
+
   h4 {
     @include font-size($h4-font-size);
     line-height: $h4-line-height;
@@ -189,20 +206,12 @@ h2,
     letter-spacing: $h4-spacing;
   }
 
-  h5,
-  h6 {
+  h5 {
     @include font-size($h5-font-size);
     line-height: $h5-line-height;
 
     /* rtl:remove */
     letter-spacing: $h5-spacing;
-  }
-
-  .lead {
-    @include font-size($lead-font-size);
-
-    /* rtl:remove */
-    letter-spacing: $lead-letter-spacing;
   }
 }
 // End mod

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -754,8 +754,8 @@ $line-length-md:              80ch !default;
 
 $letter-spacing-base:         $spacer * -.005 !default; // -0.1px
 
-$h1-font-size:                $font-size-base * 2.125 !default;   // 34px
-$h2-font-size:                $font-size-base * 1.875 !default;   // 30px
+$h1-font-size:                $font-size-base * 3.125 !default;   // 50px
+$h2-font-size:                $font-size-base * 2.125 !default;   // 34px
 $h3-font-size:                $font-size-base * 1.5 !default;     // 24px
 $h4-font-size:                $font-size-xlg !default;            // 20px
 $h5-font-size:                $font-size-lg !default;             // 18px
@@ -774,19 +774,19 @@ $font-sizes: (
 // scss-docs-end font-sizes
 
 // scss-docs-start letter-spacing
-$h1-spacing:                  $letter-spacing-base * 10 !default; // -1px
-$h2-spacing:                  $letter-spacing-base * 8 !default;  // -0.8px
+$h1-spacing:                  $letter-spacing-base * 16 !default; // -1.6px
+$h2-spacing:                  $letter-spacing-base * 10 !default; // -0.8px
 $mid-spacing:                 $letter-spacing-base * 6 !default;  // -0.6px
 $h3-spacing:                  $letter-spacing-base * 5 !default;  // -0.5px
-$h4-spacing:                  $letter-spacing-base * 4 !default;  // -0.4px
+$h4-spacing:                  $letter-spacing-base * 2 !default;  // -0.2px
 $h5-spacing:                  $letter-spacing-base * 2 !default;  // -0.2px
-$h6-spacing:                  $letter-spacing-base !default;
+// $h6-spacing:                  $letter-spacing-base !default;
 // scss-docs-end letter-spacing
 
 // stylelint-disable function-disallowed-list
 // scss-docs-start line-height
 $h1-line-height:              1 !default;
-$h2-line-height:              calc(32 / 30) !default;
+$h2-line-height:              1 !default;
 $h3-line-height:              calc(26 / 24) !default;
 $h4-line-height:              calc(22 / 20) !default;
 $h5-line-height:              calc(20 / 18) !default;
@@ -804,14 +804,12 @@ $headings-color:              inherit !default;
 // scss-docs-end headings-variables
 
 // scss-docs-start display-headings
-$display1-size:               $font-size-xlg * 3 !default;        // 60px
-$display2-size:               $font-size-xlg * 2.5 !default;      // 50px
-$display3-size:               $font-size-xlg * 2 !default;        // 40px
-$display4-size:               $h1-font-size !default;             // 34px
-$display1-spacing:            $letter-spacing-base * 20 !default; // -2px
-$display2-spacing:            $letter-spacing-base * 16 !default; // -1.6px
-$display3-spacing:            $h1-spacing !default;               // -1px
-$display4-spacing:            $h1-spacing !default;               // -1px
+$display1-size:               $font-size-base * 3.125 !default;   // 50px
+$display2-size:               $font-size-base * 2.125 !default;   // 34px
+$display3-size:               $font-size-base * 1.75 !default;    // 28px
+$display1-spacing:            $letter-spacing-base * 16 !default; // -1.6px
+$display2-spacing:            $letter-spacing-base * 10 !default; // -1px
+$display3-spacing:            $mid-spacing !default;              // -0.6px
 $display-line-height:         $h1-line-height !default;
 // scss-docs-end display-headings
 
@@ -819,7 +817,7 @@ $display-line-height:         $h1-line-height !default;
 $lead-font-size:              $font-size-xlg !default;
 $lead-font-weight:            400 !default;
 $lead-line-height:            1.5 !default;
-$lead-letter-spacing:         $letter-spacing-base * 4 !default;
+$lead-letter-spacing:         $letter-spacing-base * 2 !default;
 
 $small-font-size:             .875rem !default;
 

--- a/site/assets/scss/_tarteaucitron.scss
+++ b/site/assets/scss/_tarteaucitron.scss
@@ -110,7 +110,7 @@
 
 @include tac("H3", true) {
   font-size: $h6-font-size;
-  letter-spacing: $h6-spacing;
+  letter-spacing: $letter-spacing-base;
 }
 
 @include tac("Info") {

--- a/site/content/docs/5.3/content/typography.md
+++ b/site/content/docs/5.3/content/typography.md
@@ -8,6 +8,28 @@ aliases:
 toc: true
 ---
 
+
+| Design side                                           | Boosted side                                              |
+| :---------------------------------------------------- | :-------------------------------------------------------- |
+| Headline large - `ods.web.sys.font.headline.l`        | `.display-1`                                              |
+| Headline medium - `ods.web.sys.font.headline.m`       | `.display-2`                                              |
+| Headline small - `ods.web.sys.font.headline.s`        | `.display-3`                                              |
+| Title large - `ods.web.sys.font.title.l`              | `h1` or `.h1`                                             |
+| Title medium - `ods.web.sys.font.title.m`             | `h2` or `.h2`                                             |
+| Title small - `ods.web.sys.font.title.s`              | `h3` or `.h3`                                             |
+| Body large bold - `ods.web.sys.font.body.l.bold`      | `.body-lg.fw-bold` or `.lead.fw-bold`                     |
+| Body large - `ods.web.sys.font.body.l`                | `.body-lg` or `.lead`                                     |
+| Body medium bold - `ods.web.sys.font.body.m.bold`     | `.body-md.fw-bold`                                        |
+| Body medium - `ods.web.sys.font.body.m`               | `.body-md`                                                |
+| Body small bold - `ods.web.sys.font.body.s.bold`      | `.body-sm.fw-bold`                                        |
+| Body small - `ods.web.sys.font.body.s`                | `.body-sm`                                                |
+| Label large - `ods.web.sys.font.label.l`              | `label-lg.fw-bold`                                        |
+| Label medium bold - `ods.web.sys.font.label.m.bold`   | `label-md.fw-bold` or `.lh-base.fw-bold`                  |
+| Label medium - `ods.web.sys.font.label.m`             | `label-md` or `.lh-base`                                  |
+| Label small bold - `ods.web.sys.font.label.s.bold`    | `label-sm.fw-bold` or `small.fw-bold` or `.small.fw-bold` |
+| Label small - `ods.web.sys.font.label.s`              | `label-sm` or `small` or `.small`                         |
+
+
 ## Global settings
 
 Boosted sets basic global display, typography, and link styles. Please refer to [**our brand**]({{< param ods.web >}}) to use it carefully. When more control is needed, check out the [textual utility classes]({{< docsref "/utilities/text" >}}).
@@ -50,12 +72,43 @@ All HTML headings, `<h1>` through `<h6>`, are available.
 `.h1` through `.h6` classes are also available, for when you want to match the font styling of a heading but cannot use the associated HTML element.
 
 {{< example >}}
-<p class="h1">h1. Boosted heading</p>
-<p class="h2">h2. Boosted heading</p>
-<p class="h3">h3. Boosted heading</p>
-<p class="h4">h4. Boosted heading</p>
-<p class="h5">h5. Boosted heading</p>
-<p class="h6">h6. Boosted heading</p>
+<p class="display-1">display-1. Headline</p>
+<p class="display-2">display-2. Headline</p>
+<p class="display-3">display-3. Headline</p>
+<p class="display-4">display-4. Headline</p>
+<p class="display-5">display-5. Headline</p>
+<p class="display-6">display-6. Headline</p>
+<p class="h1 mb-0">h1. Boosted title</p>
+<h1>h1. Boosted title</h1>
+<p class="h2 mb-0">h2. Boosted title</p>
+<h2>h2. Boosted title</h2>
+<p class="h3 mb-0">h3. Boosted title</p>
+<h3>h3. Boosted title</h3>
+<p class="h4 mb-0">h4. Boosted title</p>
+<h4>h4. Boosted title</h4>
+<p class="h5 mb-0">h5. Boosted title</p>
+<h5>h5. Boosted title</h5>
+<p class="h6 mb-0">h6. Boosted title</p>
+<h6>h6. Boosted title</h6>
+<p class="body-lg fw-bold mb-0">.body-lg</p>
+<p class="lead fw-bold">.body-lg (.lead)</p>
+<p class="body-lg mb-0">.body-lg</p>
+<p class="lead">.body-lg (.lead)</p>
+<p class="body-md fw-bold">.body-md</p>
+<p class="body-md">.body-md</p>
+<p class="body-sm fw-bold">.body-sm</p>
+<p class="body-sm">.body-sm</p>
+<p class="label-lg fw-bold">.label-lg</p>
+<p class="label-md fw-bold mb-0">.label-md</p>
+<p class="lh-base fw-bold">.label-md (.lh-base)</p>
+<p class="label-md mb-0">.label-md</p>
+<p class="lh-base">.label-md (.lh-base)</p>
+<p class="label-sm fw-bold mb-0">.label-sm</p>
+<small class="fw-bold">.label-sm</small>
+<p class="small fw-bold">.label-sm</p>
+<p class="label-sm mb-0">.label-sm</p>
+<small>.label-sm</small>
+<p class="small">.label-sm</p>
 {{< /example >}}
 
 ### Customizing headings


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Closes #2504.

### Description

Changes and aligns all the `.display-*`, `h*`, `.lead`, `small` and introduces `.body-*` and `.label-*`.
Removes `.display-4` since it was never used here.
Kept `h4/5/6` for consistency.

⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ Issues or questions ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️
- Should we keep all the classes coming from Bootstrap and provide a table resuming the compatibility between design and Boosted ?
- Should we provide more styles than the design for `h4/5/6` or set them as `Title small`?
- Should we try to use `.lead`, `.small`, etc ... to provide the styles ? It seems quite hard since we have many body and label styles.

Remaining things to do:
- [ ] There are still some Sass variables to create/reuse/deprecate
- [ ] There is the migration guide to do
- [ ] Should we introduce CSS variables in order to have some references that people could reuse ?
- [ ] Many dependencies between font sizes: for example `h1` on mobile depends on `h2` desktop or `.body-lg` depends on the `h5` desktop font-size. Could be great to undupe all this, use clear variables and multiples but it could be quite heavy
- [ ] Refactor the typography page to make sure it follows the design guidelines
- [ ] Check all components regarding the new font-sizes, there might be many tweaks compared to v5 of the kit

### Motivation & Context

UI Kit v6 changes many things regarding font sizes.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/docs/content/typography>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- (NA) I have added JavaScript unit tests to cover my changes
- (NA) I have added SCSS unit tests to cover my changes

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)