### PR TITLE
chore(deps-dev): bump tarteaucitronjs from 1.18.0 to 1.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "storybook": "^8.1.5",
         "stylelint": "^16.6.1",
         "stylelint-config-twbs-bootstrap": "^14.1.0",
-        "tarteaucitronjs": "^1.18.0",
+        "tarteaucitronjs": "^1.19.0",
         "terser": "^5.31.0",
         "vnu-jar": "^23.4.11"
       },
@@ -18794,9 +18794,9 @@
       "dev": true
     },
     "node_modules/tarteaucitronjs": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.18.0.tgz",
-      "integrity": "sha512-u/n/Ivh16vMotcbQyGz5ofzj7tYNcBv9JKFPSEry/hCRY9IYx5VBFxUKY34ScrJFPjBYWRnKrjUVBoKq0Hlc5Q==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.19.0.tgz",
+      "integrity": "sha512-UGk0EY1//N/cEcs1hhxE627/7i2uLnbuzJNVmwh097d1u376Qbmz41Qwb3Of3JI97QTRsH5+K2BNU39WjsuSOQ==",
       "dev": true
     },
     "node_modules/telejson": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "storybook": "^8.1.5",
     "stylelint": "^16.6.1",
     "stylelint-config-twbs-bootstrap": "^14.1.0",
-    "tarteaucitronjs": "^1.18.0",
+    "tarteaucitronjs": "^1.19.0",
     "terser": "^5.31.0",
     "vnu-jar": "^23.4.11"
   },


### PR DESCRIPTION
### Description

Based on https://github.com/AmauriC/tarteaucitron.js/releases/tag/v1.19.0:

#### NEW FEATURES

- [x] ~https://github.com/AmauriC/tarteaucitron.js/commit/aeec8e4bd9ecbdc8b65a8ffd3a9dc38e6a5ee572 Google Consent Mode fallback for the multiple gtag service~ → doesn't seem to have an impact on our configuration

#### FIXES

- [x] ~https://github.com/AmauriC/tarteaucitron.js/commit/92c16a32023061ffedb37093dff65a85fd516fa7 Catalan translation~
- [x] ~https://github.com/AmauriC/tarteaucitron.js/commit/7c7392a6fb21a2299bea724a502c2b39871b5200 Cookies used by Clarity~
- [x] ~https://github.com/AmauriC/tarteaucitron.js/commit/307e32a8c2ed347e66fe67c81e4e3a2440bdde33 Undefined key when service automatically approved~ → no impact on what's done on our side

#### NEW SERVICE
 
- [x] ~https://github.com/AmauriC/tarteaucitron.js/commit/5f26ad5cd644a7d73ceb88d91bf3496a5b8ce4bf Tolk.ai Genii~

#### NEW LOCALES

- [x] ~https://github.com/AmauriC/tarteaucitron.js/commit/92c16a32023061ffedb37093dff65a85fd516fa7 Croate~
- [x] ~https://github.com/AmauriC/tarteaucitron.js/commit/92c16a32023061ffedb37093dff65a85fd516fa7 Korean~