### PR TITLE
[OUDS] Change `boosted.orange.com` to `orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web`

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,7 +5,7 @@
 <link href="https://cdn.jsdelivr.net/npm/boosted/dist/css/boosted.min.css" rel="stylesheet" crossorigin="anonymous">
 
 <!-- Boosted site CSS -->
-<link href="https://boosted.orange.com/docs/5.3/assets/css/docs.css" rel="stylesheet" crossorigin="anonymous">
+<link href="https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs/5.3/assets/css/docs.css" rel="stylesheet" crossorigin="anonymous">
 
 <!-- Boosted Js: Use of defer because it allows to load only once the bundle (Storybook issue) -->
 <script src="https://cdn.jsdelivr.net/npm/boosted/dist/js/boosted.bundle.min.js" crossorigin="anonymous" defer></script>

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3,7 +3,7 @@ Copyright (C) 2016 - 2024 Orange SA All rights reserved
 
 The following parts are proprietary information of Orange.
 You shall not use or display any trade names, trademarks, service marks, products names, illustrations or designs used within the software
-or displayed on this website (https://boosted.orange.com) and owned by Orange SA and its subsidiaries,
+or displayed on this website (https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web) and owned by Orange SA and its subsidiaries,
 in whole or part of, in any medium, except as required for reasonable and customary use in describing the origin of the software
 and reproducing the content of the NOTICE and DOCUMENTATION files.
 Any use or displaying shall constitute an infringement under intellectual property laws of France and international conventions.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   Boosted is a fork of Bootstrap. Bootstrap is a sleek, intuitive, and powerful front-end framework for faster and easier web development.
   <br>
-  <a href="https://boosted.orange.com/docs/"><strong>Visit Boosted</strong></a>
+  <a href="https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web"><strong>Visit Boosted</strong></a>
   <br>
   <br>
   <a href="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/new?assignees=-&labels=bug&template=bug_report.yml">Report bug</a>
@@ -37,7 +37,7 @@ Several quick start options are available:
 - Install with [Composer](https://getcomposer.org/): `composer require Orange-OpenSource/Orange-Boosted-Bootstrap:5.3.3`
 - Install with [NuGet](https://www.nuget.org/): CSS: `Install-Package boosted` Sass: `Install-Package boosted.sass`
 
-Read the [Getting started page](https://boosted.orange.com/docs/getting-started/introduction/) for information on the framework contents, templates, examples, and more.
+Read the [Getting started page](https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs/getting-started/introduction/) for information on the framework contents, templates, examples, and more.
 
 
 ## Status
@@ -121,7 +121,7 @@ Have a bug or a feature request? Please first read the [issue guidelines](https:
 
 ## Documentation
 
-Boosted's documentation, included in this repo in the root directory, is built with [Hugo](https://gohugo.io/) and publicly hosted on GitHub Pages at <https://boosted.orange.com/>. The docs may also be run locally.
+Boosted's documentation, included in this repo in the root directory, is built with [Hugo](https://gohugo.io/) and publicly hosted on GitHub Pages at <https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/>. The docs may also be run locally.
 
 Documentation search is powered by [Algolia's DocSearch](https://docsearch.algolia.com/).
 
@@ -136,7 +136,7 @@ Learn more about using Hugo by reading its [documentation](https://gohugo.io/doc
 
 ### Documentation for previous releases
 
-You can find all our previous releases docs on <https://boosted.orange.com/docs/versions/>.
+You can find all our previous releases docs on <https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs/versions/>.
 
 [Previous releases](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases) and their documentation are also available for download.
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "bootstrap",
     "Orange"
   ],
-  "homepage": "https://boosted.orange.com/",
+  "homepage": "https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/",
   "authors": [
     {
       "name": "Mark Otto",

--- a/hugo.yml
+++ b/hugo.yml
@@ -1,6 +1,6 @@
 languageCode:                       "en"
 title:                              "OUDS Web"
-baseURL:                            "https://boosted.orange.com"
+baseURL:                            "https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web"
 
 security:
   enableInlineShortcodes: true

--- a/nuget/boosted.nuspec
+++ b/nuget/boosted.nuspec
@@ -11,7 +11,7 @@
     <releaseNotes>https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases</releaseNotes>
     <summary>Boosted framework in CSS. Includes JavaScript.</summary>
     <language>en-us</language>
-    <projectUrl>https://boosted.orange.com/</projectUrl>
+    <projectUrl>https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web</projectUrl>
     <repository type="git" url="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap.git" branch="main" />
     <icon>boosted.png</icon>
     <license type="expression">MIT</license>

--- a/nuget/boosted.sass.nuspec
+++ b/nuget/boosted.sass.nuspec
@@ -11,7 +11,7 @@
     <releaseNotes>https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases</releaseNotes>
     <summary>Boosted framework in Sass. Includes JavaScript</summary>
     <language>en-us</language>
-    <projectUrl>https://boosted.orange.com/</projectUrl>
+    <projectUrl>https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/</projectUrl>
     <repository type="git" url="https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap.git" branch="main" />
     <icon>boosted.png</icon>
     <license type="expression">MIT</license>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bootstrap",
     "Orange"
   ],
-  "homepage": "https://boosted.orange.com/",
+  "homepage": "https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/",
   "author": "The Boosted Authors (https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/graphs/contributors)",
   "contributors": [
     "Orange SA"
@@ -73,7 +73,7 @@
     "docs-compile": "npm run docs-build",
     "docs-vnu": "node build/vnu-jar.mjs",
     "docs-lint": "npm run docs-vnu",
-    "docs-pa11y": "pa11y-ci --config build/.pa11yci.json --sitemap http://localhost:9001/sitemap.xml --sitemap-find https://boosted.orange.com --sitemap-replace http://localhost:9001",
+    "docs-pa11y": "pa11y-ci --config build/.pa11yci.json --sitemap http://localhost:9001/sitemap.xml --sitemap-find https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web --sitemap-replace http://localhost:9001",
     "docs-accessibility": "npm-run-all --parallel --race docs-serve-only docs-pa11y",
     "docs-serve": "hugo server --port 9001 --disableFastRender --noHTTPCache --renderToMemory --printPathWarnings --printUnusedTemplates",
     "docs-serve-only": "sirv _site --no-clear --port 9001",

--- a/scss/mixins/_banner.scss
+++ b/scss/mixins/_banner.scss
@@ -1,6 +1,6 @@
 @mixin bsBanner($file) {
   /*!
-   * Boosted #{$file} v5.3.3 (https://boosted.orange.com/)
+   * Boosted #{$file} v5.3.3 (https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/)
    * Copyright 2014-2024 The Boosted Authors
    * Copyright 2014-2024 Orange SA
    * Licensed under MIT (https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/LICENSE)

--- a/site/assets/js/color.js
+++ b/site/assets/js/color.js
@@ -3,7 +3,7 @@
 // ++++++++++++++++++++++++++++++++++++++++++
 
 /*
- * JavaScript for Boosted's docs (https://boosted.orange.com/)
+ * JavaScript for Boosted's docs (https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/)
  * Copyright 2015-2024 The Boosted Authors
  * Copyright 2015-2024 Orange
  * Licensed under MIT (https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/LICENSE)

--- a/site/assets/js/partials/back-to-top.js
+++ b/site/assets/js/partials/back-to-top.js
@@ -3,7 +3,7 @@
 // ++++++++++++++++++++++++++++++++++++++++++
 
 /*
- * JavaScript for Boosted's docs (https://boosted.orange.com/)
+ * JavaScript for Boosted's docs (https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/)
  * Copyright 2015-2024 The Boosted Authors
  * Copyright 2015-2024 Orange
  * Licensed under MIT (https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/LICENSE)

--- a/site/assets/js/search.js
+++ b/site/assets/js/search.js
@@ -33,7 +33,7 @@ import { appId, apiKey, indexName } from '@params';
     },
     transformItems(items) {
       return items.map(item => {
-        const liveUrl = 'https://boosted.orange.com/'
+        const liveUrl = 'https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/'
 
         item.url = window.location.origin.startsWith(liveUrl) ?
           // On production, return the result as is

--- a/site/assets/js/stackblitz.js
+++ b/site/assets/js/stackblitz.js
@@ -39,7 +39,7 @@ const openBoostedSnippet = (htmlSnippet, jsSnippet, classes) => {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="${cssCdn}" rel="stylesheet">
-  <link href="https://boosted.orange.com/docs/${docsVersion}/assets/css/docs.css" rel="stylesheet">
+  <link href="https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs/${docsVersion}/assets/css/docs.css" rel="stylesheet">
   <title>Boosted Example</title>
   <${'script'} defer src="${jsBundleCdn}"></${'script'}>
 </head>

--- a/site/content/docs/0.1/examples/download-app/index.html
+++ b/site/content/docs/0.1/examples/download-app/index.html
@@ -394,7 +394,7 @@ aliases:
       <li class="fw-bold">© Orange {{< year >}}</li>
       <li><a class="nav-link" href="https://system.design.orange.com/0c1af118d/p/0127c5-the-orange-design-system/b/135b17" target="_blank" rel="noopener">Terms and conditions</a></li>
       <li><a class="nav-link" href="https://system.design.orange.com/" target="_blank" rel="noopener">Orange Design System website</a></li>
-      <li><a class="nav-link" href="https://boosted.orange.com/">Boosted</a></li>
+      <li><a class="nav-link" href="https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/">Boosted</a></li>
       <li><a class="nav-link" href="https://brand.orange.com/" target="_blank" rel="noopener">Orange Brand website</a></li>
       <li><a class="nav-link" href="https://developer.orange.com/" target="_blank" rel="noopener">Orange developer website</a></li>
     </ul>

--- a/site/data/docs-versions.yml
+++ b/site/data/docs-versions.yml
@@ -1,12 +1,12 @@
 - group: v3.x
-  baseurl: "https://boosted.orange.com/docs"
+  baseurl: "https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs"
   description: "Every minor release from v3 is listed below. Last update was v3.4.1."
   versions:
     - "3.3"
     - "3.4"
 
 - group: v4.x
-  baseurl: "https://boosted.orange.com/docs"
+  baseurl: "https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs"
   description: "Our previous major release with its minor releases. Last update was v4.6.2."
   versions:
     - "4.0"
@@ -18,7 +18,7 @@
     - "4.6"
 
 - group: v5.x
-  baseurl: "https://boosted.orange.com/docs"
+  baseurl: "https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs"
   description: "Current major release. Last update was v5.3.3"
   versions:
     - "5.0"

--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -3,7 +3,7 @@
     <div class="container-xxl d-flex justify-content-center">
       <ul class="navbar-nav">
         <li class="nav-item">
-          <a class="nav-link" href="https://boosted.orange.com">There's a newer version of Boosted!</a>
+          <a class="nav-link" href="https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web">There's a newer version of Boosted!</a>
         </li>
       </ul>
     </div>

--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -30,27 +30,27 @@
       {{- if ($added_in_53) }}
         <div class="dropdown-item disabled">v5.2.3</div>
       {{- else }}
-        <a class="dropdown-item" href="https://boosted.orange.com/docs/5.2/{{ $versions_link }}">v5.2.3</a>
+        <a class="dropdown-item" href="https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs/5.2/{{ $versions_link }}">v5.2.3</a>
       {{- end }}
     </li>
     <li>
       {{- if (or $added_in_52 $added_in_53) }}
         <div class="dropdown-item disabled">v5.1.3</div>
       {{- else }}
-        <a class="dropdown-item" href="https://boosted.orange.com/docs/5.1/{{ $versions_link }}">v5.1.3</a>
+        <a class="dropdown-item" href="https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs/5.1/{{ $versions_link }}">v5.1.3</a>
       {{- end }}
     </li>
     <li>
       {{- if (or $added_in_51 $added_in_52 $added_in_53) }}
         <div class="dropdown-item disabled">v5.0.2</div>
       {{- else }}
-        <a class="dropdown-item" href="https://boosted.orange.com/docs/5.0/{{ $versions_link }}">v5.0.2</a>
+        <a class="dropdown-item" href="https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs/5.0/{{ $versions_link }}">v5.0.2</a>
       {{- end }}
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><h6 class="dropdown-header">Previous releases</h6></li>
-    <li><a class="dropdown-item" href="https://boosted.orange.com/docs/4.6/">v4.6.x</a></li>
-    <li><a class="dropdown-item" href="https://boosted.orange.com/docs/3.4/">v3.4.1</a></li>
+    <li><a class="dropdown-item" href="https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs/4.6/">v4.6.x</a></li>
+    <li><a class="dropdown-item" href="https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web/docs/3.4/">v3.4.1</a></li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="/docs/versions/">All versions</a></li>
   </ul>


### PR DESCRIPTION
### Description

This PR changes all `https://boosted.orange.com` to `https://orange-opensource.github.io/Orange-Boosted-Bootstrap/ouds-web` as we don't have yet any `orange.com` official URL for OUDS Web.