### PR TITLE
Docs: Add and hide callout from the documentation

### DIFF
--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -54,12 +54,7 @@
 
   > details {
     padding: 5px 10px; // static even when zoomed
-    border: transparent solid calc(var(--bs-border-width) * .5); // stylelint-disable-line function-disallowed-list
-
-    // stylelint-disable-next-line selector-no-qualifying-type
-    &[open] {
-      border-color: var(--bs-border-color);
-    }
+    border: var(--bs-border-color) dashed calc(var(--bs-border-width) * .5); // stylelint-disable-line function-disallowed-list
   }
   // End mod
 }

--- a/site/content/docs/5.3/components/badge.md
+++ b/site/content/docs/5.3/components/badge.md
@@ -39,7 +39,7 @@ Badges can be used as part of links or buttons to provide a counter.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect in the Orange Design System specifications.
+This variant should not be used because it does not respect in the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -60,7 +60,7 @@ Unless the context is clear (as with the "Notifications" example, where it is un
 Use utilities to modify a `.badge` and position it in the corner of a link with an icon.
 
 {{< design-callout-alert >}}
-These variants should be used **only** inside a header component.
+This variant should be used **only** inside a header component.
 
 Please refer to our [Boosted Navbars examples]({{< docsref "/examples/navbars" >}}). You can also refer to the [Global headers guidelines](https://system.design.orange.com/0c1af118d/p/37609b-global-headers/b/366c91) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/badge.md
+++ b/site/content/docs/5.3/components/badge.md
@@ -39,7 +39,7 @@ Badges can be used as part of links or buttons to provide a counter.
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This component should not be used because it does not exist in the Orange Design System specifications.
+This component should not be used because it does not respect in the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -60,7 +60,7 @@ Unless the context is clear (as with the "Notifications" example, where it is un
 Use utilities to modify a `.badge` and position it in the corner of a link with an icon.
 
 {{< design-callout-alert >}}
-This component variant should be used **only** inside a header component.
+This variant should be used **only** inside a header component.
 
 Please refer to our [Boosted Navbars examples]({{< docsref "/examples/navbars" >}}). You can also refer to the [Global headers guidelines](https://system.design.orange.com/0c1af118d/p/37609b-global-headers/b/366c91) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -92,7 +92,7 @@ Set a `background-color` with contrasting foreground `color` with [our `.text-bg
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These component variants should not be used because they do not exist in the Orange Design System specifications.
+These variants should not be used because they do not exist in the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -117,7 +117,7 @@ Consider using our [Boosted Tags]({{< docsref "/components/tags" >}}) instead.
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This component should not be used because it does not exist in the Orange Design System specifications.
+This component should not be used because it does not respect in the Orange Design System specifications.
 
 Instead, consider using our [Tags component]({{< docsref "/components/tags" >}}). You can also refer to the [Tags guidelines](https://system.design.orange.com/0c1af118d/p/975c09-tags/b/24dde8) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/badge.md
+++ b/site/content/docs/5.3/components/badge.md
@@ -92,7 +92,7 @@ Set a `background-color` with contrasting foreground `color` with [our `.text-bg
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not exist in the Orange Design System specifications.
+These variants should not be used because they do not respect in the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/badge.md
+++ b/site/content/docs/5.3/components/badge.md
@@ -18,7 +18,7 @@ Badges scale to match the size of the immediate parent element by using relative
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This component variant should not be used because it does not exist in the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -62,7 +62,7 @@ Use utilities to modify a `.badge` and position it in the corner of a link with 
 {{< design-callout-alert >}}
 This component variant should be used **only** inside a header component.
 
-Please refer to our [Boosted Navbars examples]({{< docsref "/examples/navbars" >}}). You can also refer to the [Global headers](https://system.design.orange.com/0c1af118d/p/37609b-global-headers/b/366c91) guidelines on the Orange Design System website.
+Please refer to our [Boosted Navbars examples]({{< docsref "/examples/navbars" >}}). You can also refer to the [Global headers guidelines](https://system.design.orange.com/0c1af118d/p/37609b-global-headers/b/366c91) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -86,7 +86,7 @@ Please refer to our [Boosted Navbars examples]({{< docsref "/examples/navbars" >
 
 {{< added-in "5.2.0" >}}
 
-Set a `background-color` with contrasting foreground `color` with [our `.text-bg-{color}` helpers]({{< docsref "helpers/color-background" >}}). Previously it was required to manually pair your choice of [`.text-{color}`]({{< docsref "/utilities/colors" >}}) and [`.bg-{color}`]({{< docsref "/utilities/background" >}}) utilities for styling, which you still may use if you prefer.
+Set a `background-color` with contrasting foreground `color` with [our `.text-bg-{color}` helpers]({{< docsref "helpers/color-background" >}}). Previously it was required to manually pair your choice of [`.text-{color}` utilities]({{< docsref "/utilities/colors" >}}) and [`.bg-{color}` utilities]({{< docsref "/utilities/background" >}}) for styling, which you still may use if you prefer.
 
 <details>
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
@@ -119,7 +119,7 @@ Consider using our [Boosted Tags]({{< docsref "/components/tags" >}}) instead.
 {{< design-callout-alert >}}
 This component should not be used because it does not exist in the Orange Design System specifications.
 
-Instead, consider using our Boosted [Tags]({{< docsref "/components/tags" >}}). You can also refer to the [Tags](https://system.design.orange.com/0c1af118d/p/975c09-tags/b/24dde8) guidelines on the Orange Design System website.
+Instead, consider using our [Tags component]({{< docsref "/components/tags" >}}). You can also refer to the [Tags guidelines](https://system.design.orange.com/0c1af118d/p/975c09-tags/b/24dde8) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/badge.md
+++ b/site/content/docs/5.3/components/badge.md
@@ -18,7 +18,7 @@ Badges scale to match the size of the immediate parent element by using relative
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -39,7 +39,7 @@ Badges can be used as part of links or buttons to provide a counter.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect in the Orange Design System specifications.
+These variants should not be used because they do not respect in the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -60,7 +60,7 @@ Unless the context is clear (as with the "Notifications" example, where it is un
 Use utilities to modify a `.badge` and position it in the corner of a link with an icon.
 
 {{< design-callout-alert >}}
-This variant should be used **only** inside a header component.
+These variants should be used **only** inside a header component.
 
 Please refer to our [Boosted Navbars examples]({{< docsref "/examples/navbars" >}}). You can also refer to the [Global headers guidelines](https://system.design.orange.com/0c1af118d/p/37609b-global-headers/b/366c91) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -86,7 +86,7 @@ Please refer to our [Boosted Navbars examples]({{< docsref "/examples/navbars" >
 
 {{< added-in "5.2.0" >}}
 
-Set a `background-color` with contrasting foreground `color` with [our `.text-bg-{color}` helpers]({{< docsref "helpers/color-background" >}}). Previously it was required to manually pair your choice of [`.text-{color}` utilities]({{< docsref "/utilities/colors" >}}) and [`.bg-{color}` utilities]({{< docsref "/utilities/background" >}}) for styling, which you still may use if you prefer.
+Set a `background-color` with contrasting foreground `color` with [our `.text-bg-{color}` helpers]({{< docsref "helpers/color-background" >}}). Previously it was required to manually pair your choice of [`.text-{color}`]({{< docsref "/utilities/colors" >}}) utilities and [`.bg-{color}`]({{< docsref "/utilities/background" >}}) utilities for styling, which you still may use if you prefer.
 
 <details>
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
@@ -117,7 +117,7 @@ Consider using our [Boosted Tags]({{< docsref "/components/tags" >}}) instead.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect in the Orange Design System specifications.
+These variants should not be used because they do not respect in the Orange Design System specifications.
 
 Instead, consider using our [Tags component]({{< docsref "/components/tags" >}}). You can also refer to the [Tags guidelines](https://system.design.orange.com/0c1af118d/p/975c09-tags/b/24dde8) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/badge.md
+++ b/site/content/docs/5.3/components/badge.md
@@ -111,7 +111,7 @@ These variants should not be used because they do not respect in the Orange Desi
 
 Use the `.rounded-pill` utility class to make badges more rounded with a larger `border-radius`.
 
-Consider using our [Boosted Tags]({{< docsref "/components/tags" >}}) instead.
+Consider using our [Tags component]({{< docsref "/components/tags" >}}) instead.
 
 <details>
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>

--- a/site/content/docs/5.3/components/badge.md
+++ b/site/content/docs/5.3/components/badge.md
@@ -39,7 +39,7 @@ Badges can be used as part of links or buttons to provide a counter.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect in the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/badge.md
+++ b/site/content/docs/5.3/components/badge.md
@@ -15,7 +15,7 @@ Badges scale to match the size of the immediate parent element by using relative
 ### Headings
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -36,10 +36,10 @@ This variant should not be used because it does not respect the Orange Design Sy
 Badges can be used as part of links or buttons to provide a counter.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This component should not be used because it does not respect in the Orange Design System specifications.
+This variant should not be used because it does not respect in the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -89,7 +89,7 @@ Please refer to our [Boosted Navbars examples]({{< docsref "/examples/navbars" >
 Set a `background-color` with contrasting foreground `color` with [our `.text-bg-{color}` helpers]({{< docsref "helpers/color-background" >}}). Previously it was required to manually pair your choice of [`.text-{color}` utilities]({{< docsref "/utilities/colors" >}}) and [`.bg-{color}` utilities]({{< docsref "/utilities/background" >}}) for styling, which you still may use if you prefer.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants should not be used because they do not respect in the Orange Design System specifications.
@@ -114,10 +114,10 @@ Use the `.rounded-pill` utility class to make badges more rounded with a larger 
 Consider using our [Boosted Tags]({{< docsref "/components/tags" >}}) instead.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This component should not be used because it does not respect in the Orange Design System specifications.
+This variant should not be used because it does not respect in the Orange Design System specifications.
 
 Instead, consider using our [Tags component]({{< docsref "/components/tags" >}}). You can also refer to the [Tags guidelines](https://system.design.orange.com/0c1af118d/p/975c09-tags/b/24dde8) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/breadcrumb.md
+++ b/site/content/docs/5.3/components/breadcrumb.md
@@ -77,7 +77,7 @@ $breadcrumb-divider: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant **without the breadcrumb dividers** should not be used because it does not respect the Orange Design System specifications.
+These variants **without the breadcrumb dividers** should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Local Headers/Breadcrumb guidelines](https://system.design.orange.com/0c1af118d/p/774477-local-headers/b/743cd0/i/66611057) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/breadcrumb.md
+++ b/site/content/docs/5.3/components/breadcrumb.md
@@ -77,7 +77,7 @@ $breadcrumb-divider: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants **without the breadcrumb dividers** should not be used because they do not respect the Orange Design System specifications.
+This variant **without the breadcrumb dividers** should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Local Headers/Breadcrumb guidelines](https://system.design.orange.com/0c1af118d/p/774477-local-headers/b/743cd0/i/66611057) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/breadcrumb.md
+++ b/site/content/docs/5.3/components/breadcrumb.md
@@ -79,7 +79,7 @@ $breadcrumb-divider: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/
 {{< design-callout-alert >}}
 This variant **without the breadcrumb dividers** should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Local Headers/Breadcrumb](https://system.design.orange.com/0c1af118d/p/774477-local-headers/b/743cd0/i/66611057) guidelines on the Orange Design System website.
+Please refer to the [Local Headers/Breadcrumb guidelines](https://system.design.orange.com/0c1af118d/p/774477-local-headers/b/743cd0/i/66611057) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 You can also remove the divider setting `--bs-breadcrumb-divider: '';` (empty strings in CSS custom properties counts as a value), or setting the Sass variable to `$breadcrumb-divider: none;`.

--- a/site/content/docs/5.3/components/breadcrumb.md
+++ b/site/content/docs/5.3/components/breadcrumb.md
@@ -74,7 +74,7 @@ $breadcrumb-divider: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/
 ```
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant **without the breadcrumb dividers** should not be used because it does not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -183,7 +183,7 @@ Instead of applying button sizing classes to every button in a group, just add `
 {{< design-callout-alert >}}
 The **first size variant (50px height) and the last one (30px height)** should not be used because they do not respect the Orange Design System specifications.
 
-Please refer to the [Toggle buttons](https://system.design.orange.com/0c1af118d/p/59c349-toggle-buttons/b/91bf23) guidelines on the Orange Design System website.
+Please refer to the [Toggle buttons guidelines](https://system.design.orange.com/0c1af118d/p/59c349-toggle-buttons/b/91bf23) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -42,7 +42,7 @@ These classes can also be added to groups of links, as an alternative to the [`.
 {{< design-callout-alert >}}
 This variant **using and mixing colored button backgrounds** should not be used because it does not respect the Orange Design System specifications. In button groups, you should only use the button variant that uses `.btn .btn-outline-secondary`.
 
-Please refer to our Boosted [Buttons]({{< docsref "/components/buttons#examples" >}}) secondary variant component. You can also refer to the [Buttons: standard](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/539dce) guidelines on the Orange Design System website.
+Please refer to our Boosted [Buttons secondary variant component]({{< docsref "/components/buttons#examples" >}}). You can also refer to the [Buttons: standard guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/539dce) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -74,7 +74,7 @@ Combine button-like checkbox and radio [toggle buttons]({{< docsref "/forms/chec
 {{< design-callout-alert >}}
 This **checkbox** variant should not be used because it does not respect the Orange Design System specifications.
 
-From the Orange Design System point of view, checkboxes should be represented like in our Boosted [Checks]({{< docsref "/forms/checks-radios#checks" >}}) component. You can also refer to the [Checkbox](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459/i/48901789) guidelines on the Orange Design System website.
+From the Orange Design System point of view, checkboxes should be represented like in our Boosted [Checks component]({{< docsref "/forms/checks-radios#checks" >}}). You can also refer to the [Checkbox guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459/i/48901789) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -101,8 +101,8 @@ From the Orange Design System point of view, checkboxes should be represented li
 
   <input type="radio" class="btn-check" name="btnradio" id="btnradio3" autocomplete="off">
   <label class="btn btn-toggle" for="btnradio3">Radio 3</label>
- </div>
- {{< /example >}}
+</div>
+{{< /example >}}
 
 ## Button toolbar
 
@@ -112,7 +112,7 @@ Combine sets of button groups into button toolbars for more complex components. 
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -170,6 +170,23 @@ Feel free to mix input groups with button groups in your toolbars. Similar to th
 Instead of applying button sizing classes to every button in a group, just add `.btn-group-*` to each `.btn-group`, including each one when nesting multiple groups.
 
 {{< example >}}
+<div class="btn-group" role="group" aria-label="Default button group">
+  <button type="button" class="btn btn-outline-secondary">Left</button>
+  <button type="button" class="btn btn-outline-secondary">Middle</button>
+  <button type="button" class="btn btn-outline-secondary">Right</button>
+</div>
+{{< /example >}}
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+The **first size variant (50px height) and the last one (30px height)** should not be used because they do not respect the Orange Design System specifications.
+
+Please refer to the [Toggle buttons](https://system.design.orange.com/0c1af118d/p/59c349-toggle-buttons/b/91bf23) guidelines on the Orange Design System website.
+{{< /design-callout-alert >}}
+
+{{< example >}}
 <div class="btn-group btn-group-lg" role="group" aria-label="Large button group">
   <button type="button" class="btn btn-outline-secondary">Left</button>
   <button type="button" class="btn btn-outline-secondary">Middle</button>
@@ -188,6 +205,7 @@ Instead of applying button sizing classes to every button in a group, just add `
   <button type="button" class="btn btn-outline-secondary">Right</button>
 </div>
 {{< /example >}}
+</details>
 
 ## Nesting
 

--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -42,7 +42,7 @@ These classes can also be added to groups of links, as an alternative to the [`.
 {{< design-callout-alert >}}
 This variant **using and mixing colored button backgrounds** should not be used because it does not respect the Orange Design System specifications. In button groups, you should only use the button variant that uses `.btn .btn-outline-secondary`.
 
-Please refer to our [Buttons secondary variant component]({{< docsref "/components/buttons#examples" >}}). You can also refer to the [Buttons: standard guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/539dce) on the Orange Design System website.
+Please refer to our [Outline buttons secondary variant]({{< docsref "/components/buttons#outline-buttons" >}}). You can also refer to the [Buttons: standard guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/539dce) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -112,7 +112,7 @@ Combine sets of button groups into button toolbars for more complex components. 
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -168,14 +168,6 @@ Feel free to mix input groups with button groups in your toolbars. Similar to th
 ## Sizing
 
 Instead of applying button sizing classes to every button in a group, just add `.btn-group-*` to each `.btn-group`, including each one when nesting multiple groups.
-
-{{< example >}}
-<div class="btn-group" role="group" aria-label="Default button group">
-  <button type="button" class="btn btn-outline-secondary">Left</button>
-  <button type="button" class="btn btn-outline-secondary">Middle</button>
-  <button type="button" class="btn btn-outline-secondary">Right</button>
-</div>
-{{< /example >}}
 
 <details>
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>

--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -37,7 +37,7 @@ These classes can also be added to groups of links, as an alternative to the [`.
 ## Mixed styles
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant **using and mixing colored button backgrounds** should not be used because it does not respect the Orange Design System specifications. In button groups, you should only use the button variant that uses `.btn .btn-outline-secondary`.
@@ -69,7 +69,7 @@ Please refer to our Boosted [Buttons secondary variant component]({{< docsref "/
 Combine button-like checkbox and radio [toggle buttons]({{< docsref "/forms/checks-radios" >}}) into a seamless looking button group.
 
 <details class="mb-3">
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This **checkbox** variant should not be used because it does not respect the Orange Design System specifications.
@@ -109,7 +109,7 @@ From the Orange Design System point of view, checkboxes should be represented li
 Combine sets of button groups into button toolbars for more complex components. Use utility classes as needed to space out groups, buttons, and more.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants should not be used because they do not respect the Orange Design System specifications.
@@ -178,7 +178,7 @@ Instead of applying button sizing classes to every button in a group, just add `
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 The **first size variant (50px height) and the last one (30px height)** should not be used because they do not respect the Orange Design System specifications.
@@ -212,7 +212,7 @@ Please refer to the [Toggle buttons guidelines](https://system.design.orange.com
 Place a `.btn-group` within another `.btn-group` when you want dropdown menus mixed with a series of buttons.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -242,7 +242,7 @@ This variant should not be used because it does not respect the Orange Design Sy
 Make a set of buttons appear vertically stacked rather than horizontally.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These 3 vertical variants should not be used because they do not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -40,7 +40,7 @@ These classes can also be added to groups of links, as an alternative to the [`.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants **using and mixing colored button backgrounds** should not be used because they do not respect the Orange Design System specifications. In button groups, you should only use the button variant that uses `.btn .btn-outline-secondary`.
+This variant **using and mixing colored button backgrounds** should not be used because it does not respect the Orange Design System specifications. In button groups, you should only use the button variant that uses `.btn .btn-outline-secondary`.
 
 Please refer to our [Buttons secondary variant component]({{< docsref "/components/buttons#examples" >}}). You can also refer to the [Buttons: standard guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/539dce) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -215,7 +215,7 @@ Place a `.btn-group` within another `.btn-group` when you want dropdown menus mi
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -112,7 +112,7 @@ Combine sets of button groups into button toolbars for more complex components. 
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -40,9 +40,9 @@ These classes can also be added to groups of links, as an alternative to the [`.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant **using and mixing colored button backgrounds** should not be used because it does not respect the Orange Design System specifications. In button groups, you should only use the button variant that uses `.btn .btn-outline-secondary`.
+These variants **using and mixing colored button backgrounds** should not be used because they do not respect the Orange Design System specifications. In button groups, you should only use the button variant that uses `.btn .btn-outline-secondary`.
 
-Please refer to our Boosted [Buttons secondary variant component]({{< docsref "/components/buttons#examples" >}}). You can also refer to the [Buttons: standard guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/539dce) on the Orange Design System website.
+Please refer to our [Buttons secondary variant component]({{< docsref "/components/buttons#examples" >}}). You can also refer to the [Buttons: standard guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/539dce) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -74,7 +74,7 @@ Combine button-like checkbox and radio [toggle buttons]({{< docsref "/forms/chec
 {{< design-callout-alert >}}
 This **checkbox** variant should not be used because it does not respect the Orange Design System specifications.
 
-From the Orange Design System point of view, checkboxes should be represented like in our Boosted [Checks component]({{< docsref "/forms/checks-radios#checks" >}}). You can also refer to the [Checkbox guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459/i/48901789) on the Orange Design System website.
+From the Orange Design System point of view, checkboxes should be represented like in our [Checks component]({{< docsref "/forms/checks-radios#checks" >}}). You can also refer to the [Checkbox guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459/i/48901789) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -215,7 +215,7 @@ Place a `.btn-group` within another `.btn-group` when you want dropdown menus mi
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/buttons.md
+++ b/site/content/docs/5.3/components/buttons.md
@@ -34,7 +34,7 @@ Boosted includes several button variants, each serving its own semantic purpose,
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Warning, info, light and dark variants should not be used because they do not respect the Orange Design System specifications as they are inherited from Bootstrap.
@@ -193,7 +193,7 @@ In need of a button, but not the hefty background colors they bring? Replace the
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 The only variant of outline buttons that should be used is the `.btn-outline-secondary` one. The other variants should not be used because they do not respect the Orange Design System specifications as they are inherited from Bootstrap.
@@ -231,7 +231,7 @@ Fancy larger or smaller buttons? Add `.btn-lg` or `.btn-sm` for additional sizes
 You can even roll your own custom sizing with CSS variables:
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -284,7 +284,7 @@ To cover cases where you have to keep the `href` attribute on a disabled link, t
 Create responsive stacks of full-width, "block buttons" like those in Boosted 4 with a mix of our display and gap utilities. By using utilities instead of button-specific classes, we have much greater control over spacing, alignment, and responsive behaviors.
 
 <details class="mb-3">
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These **full-width** buttons should not be used on desktop screens because they do not respect the Orange Design System specifications.
@@ -340,7 +340,7 @@ Visually, these toggle buttons are identical to the [checkbox toggle buttons]({{
 Add `data-bs-toggle="button"` to toggle a button's `active` state. If you're pre-toggling a button, you must manually add the `.active` class **and** `aria-pressed="true"` to ensure that it is conveyed appropriately to assistive technologies.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants with only **one toggle button** should not be used because they do not respect the Orange Design System specifications. From the Orange Design System point of view and for usability reasons, a toggle button should not be used alone.

--- a/site/content/docs/5.3/components/buttons.md
+++ b/site/content/docs/5.3/components/buttons.md
@@ -234,7 +234,7 @@ You can even roll your own custom sizing with CSS variables:
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Buttons guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/247486) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/buttons.md
+++ b/site/content/docs/5.3/components/buttons.md
@@ -39,7 +39,7 @@ Boosted includes several button variants, each serving its own semantic purpose,
 {{< design-callout-alert >}}
 Warning, info, light and dark variants should not be used because they do not respect the Orange Design System specifications as they are inherited from Bootstrap.
 
-Please refer to the [Buttons](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/247486) guidelines on the Orange Design System website.
+Please refer to the [Buttons guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/247486) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -198,7 +198,7 @@ In need of a button, but not the hefty background colors they bring? Replace the
 {{< design-callout-alert >}}
 The only variant of outline buttons that should be used is the `.btn-outline-secondary` one. The other variants should not be used because they do not respect the Orange Design System specifications as they are inherited from Bootstrap.
 
-Please refer to the [Buttons](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/247486) guidelines on the Orange Design System website.
+Please refer to the [Buttons guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/247486) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -236,7 +236,7 @@ You can even roll your own custom sizing with CSS variables:
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Buttons](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/247486) guidelines on the Orange Design System website.
+Please refer to the [Buttons guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/247486) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -289,7 +289,7 @@ Create responsive stacks of full-width, "block buttons" like those in Boosted 4 
 {{< design-callout-alert >}}
 These **full-width** buttons should not be used on desktop screens because they do not respect the Orange Design System specifications.
 
-Please refer to the [Buttons](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/247486) guidelines on the Orange Design System website.
+Please refer to the [Buttons guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/247486) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -345,7 +345,7 @@ Add `data-bs-toggle="button"` to toggle a button's `active` state. If you're pre
 {{< design-callout-alert >}}
 These variants with only **one toggle button** should not be used because they do not respect the Orange Design System specifications. From the Orange Design System point of view and for usability reasons, a toggle button should not be used alone.
 
-Instead, consider using our Boosted [Checks]({{< docsref "/forms/checks-radios#checks" >}}), [Radios]({{< docsref "/forms/checks-radios#radios" >}}) or [Radio toggle buttons]({{< docsref "/forms/checks-radios#radio-toggle-buttons" >}}) components.
+Instead, consider using our Boosted [Checks component]({{< docsref "/forms/checks-radios#checks" >}}), [Radios component]({{< docsref "/forms/checks-radios#radios" >}}) or [Radio toggle buttons component]({{< docsref "/forms/checks-radios#radio-toggle-buttons" >}}).
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/buttons.md
+++ b/site/content/docs/5.3/components/buttons.md
@@ -234,7 +234,7 @@ You can even roll your own custom sizing with CSS variables:
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Buttons guidelines](https://system.design.orange.com/0c1af118d/p/278ebc-buttons-standard/b/247486) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -345,7 +345,7 @@ Add `data-bs-toggle="button"` to toggle a button's `active` state. If you're pre
 {{< design-callout-alert >}}
 These variants with only **one toggle button** should not be used because they do not respect the Orange Design System specifications. From the Orange Design System point of view and for usability reasons, a toggle button should not be used alone.
 
-Instead, consider using our Boosted [Checks component]({{< docsref "/forms/checks-radios#checks" >}}), [Radios component]({{< docsref "/forms/checks-radios#radios" >}}) or [Radio toggle buttons component]({{< docsref "/forms/checks-radios#radio-toggle-buttons" >}}).
+Instead, consider using our [Checks component]({{< docsref "/forms/checks-radios#checks" >}}), [Radios component]({{< docsref "/forms/checks-radios#radios" >}}) or [Radio toggle buttons component]({{< docsref "/forms/checks-radios#radio-toggle-buttons" >}}).
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/card.md
+++ b/site/content/docs/5.3/components/card.md
@@ -199,7 +199,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant with its **centered layout** should not be used because it does not respect the Orange Design System specifications.
+These variants with its **centered layout** should not be used because they do not respect the Orange Design System specifications.
 Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
@@ -432,7 +432,7 @@ Turn an image into a card background and overlay your card's text. Depending on 
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications. Moreover, it might lead to accessibility issues. Instead, prefer using a card that includes a top image.
+These variants should not be used because they do not respect the Orange Design System specifications. Moreover, it might lead to accessibility issues. Instead, prefer using a card that includes a top image.
 
 Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -577,7 +577,7 @@ You can also change the borders on the card header and footer as needed, and eve
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/card.md
+++ b/site/content/docs/5.3/components/card.md
@@ -196,7 +196,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant with its **centered layout** should not be used because it does not respect the Orange Design System specifications.
@@ -302,7 +302,7 @@ You can quickly change the text alignment of any card—in its entirety or speci
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These second and third variants, **with centered and right-aligned layout**, should not be used because they do not respect the Orange Design System specifications.
@@ -342,7 +342,7 @@ Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118
 Add some navigation to a card's header (or block) with Boosted's [nav components]({{< docsref "/components/navs-tabs" >}}).
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants should not be used because they do not respect the Orange Design System specifications.
@@ -429,7 +429,7 @@ Similar to headers and footers, cards can include top and bottom "image caps"—
 Turn an image into a card background and overlay your card's text. Depending on the image, you may or may not need additional styles or utilities.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications. Moreover, it might lead to accessibility issues. Instead, prefer using a card that includes a top image.
@@ -502,7 +502,7 @@ Set a `background-color` with contrasting foreground `color` with [our `.text-bg
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants **with a colored background** should not be used because they do not respect the Orange Design System specifications.
@@ -546,7 +546,7 @@ Use [border utilities]({{< docsref "/utilities/borders" >}}) to change just the 
 <!-- End mod -->
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants, **with a colored border** should not be used because they do not respect the Orange Design System specifications.
@@ -574,7 +574,7 @@ Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118
 You can also change the borders on the card header and footer as needed, and even remove their `background-color` with `.bg-transparent`.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -603,7 +603,7 @@ In addition to styling the content within cards, Boosted includes a few options 
 Use card groups to render cards as a single, attached element with equal width and height columns. Card groups start off stacked and use `display: flex;` to become attached with uniform dimensions starting at the `sm` breakpoint.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants **with no spacing between cards** should not be used because they do not respect the Orange Design System specifications. Instead, prefer having a gap of at least 20px between cards.

--- a/site/content/docs/5.3/components/card.md
+++ b/site/content/docs/5.3/components/card.md
@@ -12,6 +12,18 @@ toc: true
 
 A **card** is a flexible and extensible content container. It includes options for headers and footers, a wide variety of content, contextual background colors, and powerful display options. If you're familiar with Boosted 3, cards replace our old panels, wells, and thumbnails. Similar functionality to those components is available as modifier classes for cards.
 
+{{< design-callout-alert info >}}
+<br>
+
+**On the Orange Design System website**, you'll find the [Cards](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) component guidelines describing how Orange designers want cards to be represented and used, mainly as static containers.
+<br><br>
+**In this Boosted cards component description page**, you'll find card variants that can be used as cards, but as some variants that are meant to be used as adjustable containers.
+<!--
+- **In the Orange Design System**, a card component is available in **3 sizes** that **can not be modified**. Depending on the size of your screen, you can adjust the cards layout by changing the cards size (choosing among the 3 existing sizes) and/or the number of cards to display on a single line.
+- **In Boosted**, as some card variants can be used as containers, more sizing possibilities are offered to adjust their sizes.
+-->
+{{< /design-callout-alert >}}
+
 ## Example
 
 Cards are built with as little markup and styles as possible, but still manage to deliver a ton of control and customization. Built with flexbox, they offer easy alignment and mix well with other Boosted components. They have no `margin` by default, so use [spacing utilities]({{< docsref "/utilities/spacing" >}}) as needed.
@@ -183,6 +195,14 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
 </div>
 {{< /example >}}
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This variant with its **centered layout** should not be used because it does not respect the Orange Design System specifications.
+Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
 {{< example >}}
 <div class="card text-center">
   <div class="card-header">
@@ -198,6 +218,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
   </div>
 </div>
 {{< /example >}}
+</details>
 
 ## Sizing
 
@@ -271,6 +292,25 @@ Use custom CSS in your stylesheets or as inline styles to set a width.
 You can quickly change the text alignment of any card—in its entirety or specific parts—with our [text align classes]({{< docsref "/utilities/text#text-alignment" >}}).
 
 {{< example >}}
+<div class="card" style="width: 18rem;">
+  <div class="card-body">
+    <h5 class="card-title">Special title treatment</h5>
+    <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
+    <a href="#" class="btn btn-primary">Go somewhere</a>
+  </div>
+</div>
+{{< /example >}}
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These second and third variants, **with centered and right-aligned layout**, should not be used because they do not respect the Orange Design System specifications.
+
+Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
+{{< example >}}
 <div class="card mb-3" style="width: 18rem;">
   <div class="card-body">
     <h5 class="card-title">Special title treatment</h5>
@@ -295,10 +335,20 @@ You can quickly change the text alignment of any card—in its entirety or speci
   </div>
 </div>
 {{< /example >}}
+</details>
 
 ## Navigation
 
 Add some navigation to a card's header (or block) with Boosted's [nav components]({{< docsref "/components/navs-tabs" >}}).
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These variants should not be used because they do not respect the Orange Design System specifications.
+
+Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
+{{< /design-callout-alert >}}
 
 {{< example >}}
 <div class="card text-center">
@@ -345,6 +395,7 @@ Add some navigation to a card's header (or block) with Boosted's [nav components
   </div>
 </div>
 {{< /example >}}
+</details>
 
 ## Images
 
@@ -377,6 +428,15 @@ Similar to headers and footers, cards can include top and bottom "image caps"—
 
 Turn an image into a card background and overlay your card's text. Depending on the image, you may or may not need additional styles or utilities.
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This variant should not be used because it does not respect the Orange Design System specifications. Moreover, it might lead to accessibility issues. Instead, prefer using a card that includes a top image.
+
+Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
 {{< example >}}
 <div class="card text-bg-dark">
   {{< placeholder width="100%" height="270" class="bd-placeholder-img-lg card-img" text="Card image" background="#000" >}}
@@ -391,6 +451,7 @@ Turn an image into a card background and overlay your card's text. Depending on 
 {{< callout info >}}
 Note that content should not be larger than the height of the image. If content is larger than the image the content will be displayed outside the image.
 {{< /callout >}}
+</details>
 
 ## Horizontal
 
@@ -424,6 +485,32 @@ Cards include various options for customizing their backgrounds, borders, and co
 Set a `background-color` with contrasting foreground `color` with [our `.text-bg-{color}` helpers]({{< docsref "helpers/color-background" >}}). Previously it was required to manually pair your choice of [`.text-{color}`]({{< docsref "/utilities/colors" >}}) and [`.bg-{color}`]({{< docsref "/utilities/background" >}}) utilities for styling, which you still may use if you prefer.
 
 {{< example >}}
+<div class="card text-bg-secondary mb-3" style="max-width: 18rem;">
+  <div class="card-header">Header</div>
+  <div class="card-body">
+    <h5 class="card-title">Secondary card title</h5>
+    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+  </div>
+</div>
+<div class="card text-bg-dark mb-3" style="max-width: 18rem;">
+  <div class="card-header">Header</div>
+  <div class="card-body">
+    <h5 class="card-title">Dark card title</h5>
+    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+  </div>
+</div>
+{{< /example >}}
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These variants **with a colored background** should not be used because they do not respect the Orange Design System specifications.
+
+Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
+{{< example >}}
 {{< card.inline >}}
 {{- range (index $.Site.Data "theme-colors") }}
 <div class="card text-bg-{{ .name }} mb-3" style="max-width: 18rem;">
@@ -440,10 +527,32 @@ Set a `background-color` with contrasting foreground `color` with [our `.text-bg
 {{< callout info >}}
 {{< partial "callouts/warning-color-assistive-technologies.md" >}}
 {{< /callout >}}
+</details>
 
 ### Border
 
 Use [border utilities]({{< docsref "/utilities/borders" >}}) to change just the `border-color` of a card. Note that you can put `.text-{color}` classes on the parent `.card` or a subset of the card's contents as shown below.
+
+<!-- Boosted mod -->
+{{< example >}}
+<div class="card border-0 mb-3" style="max-width: 18rem;">
+  <div class="card-header">Header</div>
+  <div class="card-body">
+    <h5 class="card-title">Borderless card title</h5>
+    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+  </div>
+</div>
+{{< /example >}}
+<!-- End mod -->
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These variants, **with a colored border** should not be used because they do not respect the Orange Design System specifications.
+
+Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
+{{< /design-callout-alert >}}
 
 {{< example >}}
 {{< card.inline >}}
@@ -456,21 +565,22 @@ Use [border utilities]({{< docsref "/utilities/borders" >}}) to change just the 
   </div>
 </div>
 {{- end }}
-<!-- Boosted mod -->
-<div class="card border-0 mb-3" style="max-width: 18rem;">
-  <div class="card-header">Header</div>
-  <div class="card-body">
-    <h5 class="card-title">Borderless card title</h5>
-    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-  </div>
-</div>
-<!-- End mod -->
 {{< /card.inline >}}
 {{< /example >}}
+</details>
 
 ### Mixins utilities
 
 You can also change the borders on the card header and footer as needed, and even remove their `background-color` with `.bg-transparent`.
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This variant should not be used because it does not respect the Orange Design System specifications.
+
+Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
+{{< /design-callout-alert >}}
 
 {{< example >}}
 <div class="card border-success mb-3" style="max-width: 18rem;">
@@ -482,6 +592,7 @@ You can also change the borders on the card header and footer as needed, and eve
   <div class="card-footer bg-transparent border-success">Footer</div>
 </div>
 {{< /example >}}
+</details>
 
 ## Card layout
 
@@ -490,6 +601,15 @@ In addition to styling the content within cards, Boosted includes a few options 
 ### Card groups
 
 Use card groups to render cards as a single, attached element with equal width and height columns. Card groups start off stacked and use `display: flex;` to become attached with uniform dimensions starting at the `sm` breakpoint.
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These variants **with no spacing between cards** should not be used because they do not respect the Orange Design System specifications. Instead, prefer having a gap of at least 20px between cards.
+
+Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
+{{< /design-callout-alert >}}
 
 {{< example >}}
 <div class="card-group">
@@ -556,6 +676,7 @@ When using card groups with footers, their content will automatically line up.
   </div>
 </div>
 {{< /example >}}
+</details>
 
 ### Grid cards
 

--- a/site/content/docs/5.3/components/card.md
+++ b/site/content/docs/5.3/components/card.md
@@ -19,7 +19,7 @@ A **card** is a flexible and extensible content container. It includes options f
 <br><br>
 **In this Boosted cards component description page**, you'll find card variants that can be used as cards, but as some variants that are meant to be used as adjustable containers.
 <!--
-- **In the Orange Design System**, a card component is available in **3 sizes** that **can not be modified**. Depending on the size of your screen, you can adjust the cards layout by changing the cards size (choosing among the 3 existing sizes) and/or the number of cards to display on a single line.
+- **In Orange Design System**, a card component is available in **3 sizes** that **can not be modified**. Depending on the size of your screen, you can adjust the cards layout by changing the cards size (choosing among the 3 existing sizes) and/or the number of cards to display on a single line.
 - **In Boosted**, as some card variants can be used as containers, more sizing possibilities are offered to adjust their sizes.
 -->
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/card.md
+++ b/site/content/docs/5.3/components/card.md
@@ -13,11 +13,10 @@ toc: true
 A **card** is a flexible and extensible content container. It includes options for headers and footers, a wide variety of content, contextual background colors, and powerful display options. If you're familiar with Boosted 3, cards replace our old panels, wells, and thumbnails. Similar functionality to those components is available as modifier classes for cards.
 
 {{< design-callout-alert info >}}
-<br>
-
-**On the Orange Design System website**, you'll find the [Cards](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) component guidelines describing how Orange designers want cards to be represented and used, mainly as static containers.
+The [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) defined on the Orange Design System website describe how cards need to be rendered and used, mainly as static containers with specific fixed sizes and spacings.
 <br><br>
-**In this Boosted cards component description page**, you'll find card variants that can be used as cards, but as some variants that are meant to be used as adjustable containers.
+**However, in Boosted**, as some card variants can be used as containers, **more sizing possibilities are offered to adjust their sizes**.
+
 {{< /design-callout-alert >}}
 
 ## Example
@@ -286,16 +285,6 @@ Use custom CSS in your stylesheets or as inline styles to set a width.
 ## Text alignment
 
 You can quickly change the text alignment of any card—in its entirety or specific parts—with our [text align classes]({{< docsref "/utilities/text#text-alignment" >}}).
-
-{{< example >}}
-<div class="card" style="width: 18rem;">
-  <div class="card-body">
-    <h5 class="card-title">Special title treatment</h5>
-    <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-    <a href="#" class="btn btn-primary">Go somewhere</a>
-  </div>
-</div>
-{{< /example >}}
 
 <details>
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>

--- a/site/content/docs/5.3/components/card.md
+++ b/site/content/docs/5.3/components/card.md
@@ -199,7 +199,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants with its **centered layout** should not be used because they do not respect the Orange Design System specifications.
+This variant with its **centered layout** should not be used because it does not respect the Orange Design System specifications.
 Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
@@ -432,7 +432,7 @@ Turn an image into a card background and overlay your card's text. Depending on 
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications. Moreover, it might lead to accessibility issues. Instead, prefer using a card that includes a top image.
+This variant should not be used because it does not respect the Orange Design System specifications. Moreover, it might lead to accessibility issues. Instead, prefer using a card that includes a top image.
 
 Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -577,7 +577,7 @@ You can also change the borders on the card header and footer as needed, and eve
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -606,7 +606,7 @@ Use card groups to render cards as a single, attached element with equal width a
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants **with no spacing between cards** should not be used because they do not respect the Orange Design System specifications. Instead, prefer having a gap of at least 20px between cards.
+This variant **with no spacing between cards** should not be used because it does not respect the Orange Design System specifications. Instead, prefer having a gap of at least 20px between cards.
 
 Please refer to the [Cards guidelines](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/card.md
+++ b/site/content/docs/5.3/components/card.md
@@ -18,10 +18,6 @@ A **card** is a flexible and extensible content container. It includes options f
 **On the Orange Design System website**, you'll find the [Cards](https://system.design.orange.com/0c1af118d/p/82eaf1-cards/b/69655e) component guidelines describing how Orange designers want cards to be represented and used, mainly as static containers.
 <br><br>
 **In this Boosted cards component description page**, you'll find card variants that can be used as cards, but as some variants that are meant to be used as adjustable containers.
-<!--
-- **In Orange Design System**, a card component is available in **3 sizes** that **can not be modified**. Depending on the size of your screen, you can adjust the cards layout by changing the cards size (choosing among the 3 existing sizes) and/or the number of cards to display on a single line.
-- **In Boosted**, as some card variants can be used as containers, more sizing possibilities are offered to adjust their sizes.
--->
 {{< /design-callout-alert >}}
 
 ## Example

--- a/site/content/docs/5.3/components/carousel.md
+++ b/site/content/docs/5.3/components/carousel.md
@@ -156,7 +156,7 @@ Pausing the carousel by hovering one slide should not be used.
 You can add captions to your slides with the `.carousel-caption` element within any `.carousel-item`. They can be easily hidden on smaller viewports, as shown below, with optional [display utilities]({{< docsref "/utilities/display" >}}). We hide them initially with `.d-none` and bring them back on medium-sized devices with `.d-md-block`.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 **Captions** should not be used because they do not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/components/carousel.md
+++ b/site/content/docs/5.3/components/carousel.md
@@ -161,7 +161,7 @@ You can add captions to your slides with the `.carousel-caption` element within 
 {{< design-callout-alert >}}
 **Captions** should not be used because they do not respect the Orange Design System specifications.
 
-Please refer to the [Carousel navigation](https://system.design.orange.com/0c1af118d/p/7773e1-carousel-navigation/b/99a7b7) guidelines on the Orange Design System website.
+Please refer to the [Carousel navigation guidelines](https://system.design.orange.com/0c1af118d/p/7773e1-carousel-navigation/b/99a7b7) or to the [Hero banners guidelines](https://system.design.orange.com/0c1af118d/p/925608-promotions/b/685a2d) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/dropdowns.md
+++ b/site/content/docs/5.3/components/dropdowns.md
@@ -65,7 +65,7 @@ While `<button>` is the recommended control for a dropdown toggle, there might b
 {{< design-callout-alert >}}
 Only the `.btn-dropdown` variant should be used because the other variants do not respect the Orange Design System specifications as they are inherited from Bootstrap.
 
-Please refer to the [Dropdowns](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) guidelines on the Orange Design System website.
+Please refer to the [Dropdowns guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 The best part is you can do this with any button variant, too:
@@ -178,7 +178,7 @@ We use this extra class to reduce the horizontal `padding` on either side of the
 {{< design-callout-alert >}}
 Only the `.btn-outline-secondary` variant should be used as a split dropdown because the other variants do not respect the Orange Design System specifications as they are inherited from Bootstrap.
 
-Please refer to the [Dropdowns](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) guidelines on the Orange Design System website.
+Please refer to the [Dropdowns guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 <div class="bd-example">
@@ -341,7 +341,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
 {{< design-callout-alert >}}
 This small variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Dropdown](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) guidelines on the Orange Design System website.
+Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 <div class="bd-example">
@@ -417,7 +417,7 @@ Make the dropdown menu centered below the toggle with `.dropdown-center` on the 
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Dropdown](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) guidelines on the Orange Design System website.
+Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -503,7 +503,7 @@ Make the dropup menu centered above the toggle with `.dropup-center` on the pare
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Dropdown](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) guidelines on the Orange Design System website.
+Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -870,7 +870,7 @@ Place any freeform text within a dropdown menu with text and use [spacing utilit
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Dropdown](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) guidelines on the Orange Design System website.
+Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -895,7 +895,7 @@ Put a form within a dropdown menu, or make it into a dropdown menu, and use [mar
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Dropdown](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) guidelines on the Orange Design System website.
+Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -960,6 +960,30 @@ Use `data-bs-offset` or `data-bs-reference` to change the location of the dropdo
 {{< example >}}
 <div class="d-flex">
   <div class="dropdown me-1">
+    <button type="button" class="btn btn-dropdown dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bs-offset="0,0">
+      Offset
+    </button>
+    <ul class="dropdown-menu">
+      <li><a class="dropdown-item" href="#">Action</a></li>
+      <li><a class="dropdown-item" href="#">Another action</a></li>
+      <li><a class="dropdown-item" href="#">Something else here</a></li>
+    </ul>
+  </div>
+</div>
+{{< /example >}}
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This variant with a `data-bs-offset` attribute having values different than `"0,0"` should not be used because it does not respect the Orange Design System specifications.
+
+Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
+{{< example >}}
+<div class="d-flex">
+  <div class="dropdown me-1">
     <button type="button" class="btn btn-dropdown dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bs-offset="10,20">
       Offset
     </button>
@@ -984,6 +1008,7 @@ Use `data-bs-offset` or `data-bs-reference` to change the location of the dropdo
   </div>
 </div>
 {{< /example >}}
+</details>
 
 ### Auto close behavior
 

--- a/site/content/docs/5.3/components/dropdowns.md
+++ b/site/content/docs/5.3/components/dropdowns.md
@@ -60,7 +60,7 @@ While `<button>` is the recommended control for a dropdown toggle, there might b
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Only the `.btn-dropdown` variant should be used because the other variants do not respect the Orange Design System specifications as they are inherited from Bootstrap.
@@ -173,7 +173,7 @@ We use this extra class to reduce the horizontal `padding` on either side of the
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Only the `.btn-outline-secondary` variant should be used as a split dropdown because the other variants do not respect the Orange Design System specifications as they are inherited from Bootstrap.
@@ -336,7 +336,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
 ```
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This small variant should not be used because it does not respect the Orange Design System specifications.
@@ -412,7 +412,7 @@ Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af
 Make the dropdown menu centered below the toggle with `.dropdown-center` on the parent element.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -498,7 +498,7 @@ Trigger dropdown menus above elements by adding `.dropup` to the parent element.
 Make the dropup menu centered above the toggle with `.dropup-center` on the parent element.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -865,7 +865,7 @@ Separate groups of related menu items with a divider.
 Place any freeform text within a dropdown menu with text and use [spacing utilities]({{< docsref "/utilities/spacing" >}}). Note that you'll likely need additional sizing styles to constrain the menu width.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -890,7 +890,7 @@ Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af
 Put a form within a dropdown menu, or make it into a dropdown menu, and use [margin or padding utilities]({{< docsref "/utilities/spacing" >}}) to give it the negative space you require.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -973,7 +973,7 @@ Use `data-bs-offset` or `data-bs-reference` to change the location of the dropdo
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant with a `data-bs-offset` attribute having values different than `"0,0"` should not be used because it does not respect the Orange Design System specifications.
@@ -1028,7 +1028,7 @@ By default, the dropdown menu is closed when clicking inside or outside the drop
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 The 3 last auto close behavior variants should not be used because featuring a single selection, they do no respect the Orange Design System specifications. They should be used only with multiple selections.

--- a/site/content/docs/5.3/components/dropdowns.md
+++ b/site/content/docs/5.3/components/dropdowns.md
@@ -415,7 +415,7 @@ Make the dropdown menu centered below the toggle with `.dropdown-center` on the 
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -501,7 +501,7 @@ Make the dropup menu centered above the toggle with `.dropup-center` on the pare
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -868,7 +868,7 @@ Place any freeform text within a dropdown menu with text and use [spacing utilit
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/dropdowns.md
+++ b/site/content/docs/5.3/components/dropdowns.md
@@ -957,26 +957,11 @@ Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af
 
 Use `data-bs-offset` or `data-bs-reference` to change the location of the dropdown.
 
-{{< example >}}
-<div class="d-flex">
-  <div class="dropdown me-1">
-    <button type="button" class="btn btn-dropdown dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bs-offset="0,0">
-      Offset
-    </button>
-    <ul class="dropdown-menu">
-      <li><a class="dropdown-item" href="#">Action</a></li>
-      <li><a class="dropdown-item" href="#">Another action</a></li>
-      <li><a class="dropdown-item" href="#">Something else here</a></li>
-    </ul>
-  </div>
-</div>
-{{< /example >}}
-
 <details>
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants with a `data-bs-offset` attribute having values different than `"0,0"` should not be used because they do not respect the Orange Design System specifications.
+These variants with a `data-bs-offset` attribute having values different than `"0,0"`, or a specific `data-bs-reference`, should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/dropdowns.md
+++ b/site/content/docs/5.3/components/dropdowns.md
@@ -415,7 +415,7 @@ Make the dropdown menu centered below the toggle with `.dropdown-center` on the 
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -501,7 +501,7 @@ Make the dropup menu centered above the toggle with `.dropup-center` on the pare
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -868,7 +868,7 @@ Place any freeform text within a dropdown menu with text and use [spacing utilit
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -893,7 +893,7 @@ Put a form within a dropdown menu, or make it into a dropdown menu, and use [mar
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -976,7 +976,7 @@ Use `data-bs-offset` or `data-bs-reference` to change the location of the dropdo
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant with a `data-bs-offset` attribute having values different than `"0,0"` should not be used because it does not respect the Orange Design System specifications.
+These variants with a `data-bs-offset` attribute having values different than `"0,0"` should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Dropdown guidelines](https://system.design.orange.com/0c1af118d/p/910b9b-dropdown/b/04c480) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/footer.md
+++ b/site/content/docs/5.3/components/footer.md
@@ -21,7 +21,7 @@ Our footer is basically a `<footer>` tag with `.footer` and `.navbar` classes. I
 
 You can choose to display each part or not, except the last one which is mandatory. No matter how many parts you use, they should follow the order listed above.
 
-If these available parts don't meet your specific needs, feel free to develop your own custom part accordingly to the Orange Design System.
+If these available parts don't meet your specific needs, feel free to develop your own custom part accordingly to Orange Design System.
 
 {{< callout warning >}}
 This footer component is based on the [navbar component]({{< docsref "/components/navbar" >}}). Don't forget to import the corresponding SCSS file if you're using [Lean Sass imports]({{< docsref "/customize/optimize#lean-sass-imports" >}}).

--- a/site/content/docs/5.3/components/list-group.md
+++ b/site/content/docs/5.3/components/list-group.md
@@ -148,7 +148,7 @@ Add `.list-group-horizontal` to change the layout of list group items from verti
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant is just an **example illustrating the use of the layout utility**. It should not be used because it does not respect the Orange Design System specifications.
+These variants are just **examples illustrating the use of the layout utility**. They should not be used because they do not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 **ProTip:** Want equal-width list group items when horizontal? Add `.flex-fill` to each list group item.
@@ -246,7 +246,7 @@ Add nearly any HTML within, even for linked list groups like the one below, with
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/list-group.md
+++ b/site/content/docs/5.3/components/list-group.md
@@ -145,7 +145,7 @@ These work great with custom content as well.
 Add `.list-group-horizontal` to change the layout of list group items from vertical to horizontal across all breakpoints. Alternatively, choose a responsive variant `.list-group-horizontal-{sm|md|lg|xl|xxl}` to make a list group horizontal starting at that breakpoint's `min-width`. Currently **horizontal list groups cannot be combined with flush list groups.**
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant is just an **example illustrating the use of the layout utility**. It should not be used because it does not respect the Orange Design System specifications.
@@ -243,7 +243,7 @@ Add badges to any list group item to show unread counts, activity, and more with
 Add nearly any HTML within, even for linked list groups like the one below, with the help of [flexbox utilities]({{< docsref "/utilities/flex" >}}).
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -284,7 +284,7 @@ This variant should not be used because it does not respect the Orange Design Sy
 Place Boosted's checkboxes and radios within list group items and customize as needed. You can use them without `<label>`s, but please remember to include an `aria-label` attribute and value for accessibility.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants should not be used because it does not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/components/list-group.md
+++ b/site/content/docs/5.3/components/list-group.md
@@ -287,7 +287,7 @@ Place Boosted's checkboxes and radios within list group items and customize as n
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/list-group.md
+++ b/site/content/docs/5.3/components/list-group.md
@@ -246,7 +246,7 @@ Add nearly any HTML within, even for linked list groups like the one below, with
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/modal.md
+++ b/site/content/docs/5.3/components/modal.md
@@ -543,7 +543,7 @@ Toggle between multiple modals with some clever placement of the `data-bs-target
 {{< design-callout-alert >}}
 This toggle behavior between multiple modals should not be used because it does not respect the Orange Design System specifications. It is not recommended for usability reasons.
 
-Please refer to the [Modals](https://system.design.orange.com/0c1af118d/p/16d9f3-modals/b/774d3d) guidelines on the Orange Design System website.
+Please refer to the [Modals guidelines](https://system.design.orange.com/0c1af118d/p/16d9f3-modals/b/774d3d) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 <!--Boosted mod: replace aria-label="Close" with a visually hidden span (a11y)-->
@@ -691,7 +691,7 @@ Another override is the option to pop up a modal that covers the user viewport, 
 {{< design-callout-alert >}}
 These **full screen** variants should not be used because they do not respect the Orange Design System specifications. Indeed, modals should always be placed in the center of a page and not be full screen.
 
-Please refer to the [Modals](https://system.design.orange.com/0c1af118d/p/16d9f3-modals/b/774d3d) guidelines on the Orange Design System website.
+Please refer to the [Modals guidelines](https://system.design.orange.com/0c1af118d/p/16d9f3-modals/b/774d3d) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< bs-table >}}

--- a/site/content/docs/5.3/components/modal.md
+++ b/site/content/docs/5.3/components/modal.md
@@ -538,7 +538,7 @@ Below is a live demo followed by example HTML and JavaScript. For more informati
 Toggle between multiple modals with some clever placement of the `data-bs-target` and `data-bs-toggle` attributes. For example, you could toggle a password reset modal from within an already open sign in modal. **Please note multiple modals cannot be open at the same time**—this method simply toggles between two separate modals.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This toggle behavior between multiple modals should not be used because it does not respect the Orange Design System specifications. It is not recommended for usability reasons.
@@ -686,7 +686,7 @@ Our default modal without modifier class constitutes the "medium" size modal.
 Another override is the option to pop up a modal that covers the user viewport, available via modifier classes that are placed on a `.modal-dialog`.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These **full screen** variants should not be used because they do not respect the Orange Design System specifications. Indeed, modals should always be placed in the center of a page and not be full screen.

--- a/site/content/docs/5.3/components/navbar.md
+++ b/site/content/docs/5.3/components/navbar.md
@@ -11,7 +11,7 @@ toc: true
 {{< design-callout-alert >}}
 This component explains the basic behavior, structure and concepts of navbars from a Bootstrap point of view. Some discrepancies exist with Boosted due to a different HTML structure. Moreover, Orange navbars have the same rendering in light and dark mode.
 
-In order to build an Orange navbar please refer to [Orange navbar component]({{< docsref "/components/orange-navbar" >}}).
+In order to build an Orange navbar please refer to the [Orange navbar component]({{< docsref "/components/orange-navbar" >}}).
 {{< /design-callout-alert >}}
 
 ## How it works

--- a/site/content/docs/5.3/components/navbar.md
+++ b/site/content/docs/5.3/components/navbar.md
@@ -11,7 +11,7 @@ toc: true
 {{< design-callout-alert >}}
 This component explains the basic behavior, structure and concepts of navbars from a Bootstrap point of view. Some discrepancies exist with Boosted due to a different HTML structure. Moreover, Orange navbars have the same rendering in light and dark mode.
 
-In order to build an Orange navbar please refer to [Orange navbar]({{< docsref "/components/orange-navbar" >}}).
+In order to build an Orange navbar please refer to [Orange navbar component]({{< docsref "/components/orange-navbar" >}}).
 {{< /design-callout-alert >}}
 
 ## How it works

--- a/site/content/docs/5.3/components/navs-tabs.md
+++ b/site/content/docs/5.3/components/navs-tabs.md
@@ -61,7 +61,7 @@ Change the style of `.nav`s component with modifiers and utilities. Mix and matc
 Change the horizontal alignment of your nav with [flexbox utilities]({{< docsref "/utilities/flex#justify-content" >}}). By default, navs are left-aligned, but you can easily change them to center or right-aligned.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These **centered** and **right aligned** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be left aligned.
@@ -113,7 +113,7 @@ Right-aligned with `.justify-content-end`:
 Stack your navigation by changing the flex item direction with the `.flex-column` utility. Need to stack them on some viewports but not others? Use the responsive versions (e.g., `.flex-sm-column`).
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These **vertical** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
@@ -176,7 +176,7 @@ Takes the basic nav from above and adds the `.nav-tabs` class to generate a tabb
 Take that same HTML, but use `.nav-pills` instead:
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -397,7 +397,7 @@ As a design recommendation, dropdowns are typically placed at the end of the nav
 ### Pills with dropdowns
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
@@ -625,7 +625,7 @@ The tabs plugin also works with underline.
 ```
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These **vertical** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.

--- a/site/content/docs/5.3/components/navs-tabs.md
+++ b/site/content/docs/5.3/components/navs-tabs.md
@@ -179,7 +179,7 @@ Take that same HTML, but use `.nav-pills` instead:
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -400,7 +400,7 @@ As a design recommendation, dropdowns are typically placed at the end of the nav
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 
 Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/navs-tabs.md
+++ b/site/content/docs/5.3/components/navs-tabs.md
@@ -64,9 +64,9 @@ Change the horizontal alignment of your nav with [flexbox utilities]({{< docsref
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These **centered** and **right aligned** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be left aligned.
+These **centered** and **right-aligned** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be left-aligned.
 
-Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 Centered with `.justify-content-center`:
@@ -118,7 +118,7 @@ Stack your navigation by changing the flex item direction with the `.flex-column
 {{< design-callout-alert >}}
 These **vertical** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
 
-Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -402,7 +402,7 @@ As a design recommendation, dropdowns are typically placed at the end of the nav
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
 
-Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 <!-- Boosted mod: dropdown nav-item moved at the end of the nav-item list to match the Orange Design System requirements -->
@@ -630,7 +630,7 @@ The tabs plugin also works with underline.
 {{< design-callout-alert >}}
 These **vertical** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
 
-Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 And with vertical pills. Ideally, for vertical tabs, you should also add `aria-orientation="vertical"` to the tab list container.

--- a/site/content/docs/5.3/components/navs-tabs.md
+++ b/site/content/docs/5.3/components/navs-tabs.md
@@ -66,7 +66,7 @@ Change the horizontal alignment of your nav with [flexbox utilities]({{< docsref
 {{< design-callout-alert >}}
 These **centered** and **right-aligned** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be left-aligned.
 
-Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to the [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 Centered with `.justify-content-center`:
@@ -118,7 +118,7 @@ Stack your navigation by changing the flex item direction with the `.flex-column
 {{< design-callout-alert >}}
 These **vertical** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
 
-Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to the [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -402,7 +402,7 @@ As a design recommendation, dropdowns are typically placed at the end of the nav
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
 
-Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to the [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 <!-- Boosted mod: dropdown nav-item moved at the end of the nav-item list to match the Orange Design System requirements -->
@@ -630,7 +630,7 @@ The tabs plugin also works with underline.
 {{< design-callout-alert >}}
 These **vertical** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
 
-Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+Instead, please consider using our [Tabs Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to the [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 And with vertical pills. Ideally, for vertical tabs, you should also add `aria-orientation="vertical"` to the tab list container.

--- a/site/content/docs/5.3/components/navs-tabs.md
+++ b/site/content/docs/5.3/components/navs-tabs.md
@@ -368,7 +368,7 @@ As a design recommendation, dropdowns are typically placed at the end of the nav
 {{< /callout >}}
 
 ### Tabs with dropdowns
-<!-- Boosted mod: dropdown nav-item moved at the end of the nav-item list to match the Orange design system requirements -->
+<!-- Boosted mod: dropdown nav-item moved at the end of the nav-item list to match the Orange Design System requirements -->
 {{< example >}}
 <ul class="nav nav-tabs">
   <li class="nav-item">
@@ -405,7 +405,7 @@ This variant should not be used because it does not respect the Orange Design Sy
 Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
-<!-- Boosted mod: dropdown nav-item moved at the end of the nav-item list to match the Orange design system requirements -->
+<!-- Boosted mod: dropdown nav-item moved at the end of the nav-item list to match the Orange Design System requirements -->
 {{< example >}}
 <ul class="nav nav-pills">
   <li class="nav-item">

--- a/site/content/docs/5.3/components/navs-tabs.md
+++ b/site/content/docs/5.3/components/navs-tabs.md
@@ -64,7 +64,7 @@ Change the horizontal alignment of your nav with [flexbox utilities]({{< docsref
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These **centered** and **right aligned** component variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be left aligned.
+These **centered** and **right aligned** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be left aligned.
 
 Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -116,7 +116,7 @@ Stack your navigation by changing the flex item direction with the `.flex-column
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These **vertical** component variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
+These **vertical** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
 
 Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -628,7 +628,7 @@ The tabs plugin also works with underline.
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These **vertical** component variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
+These **vertical** variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
 
 Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/navs-tabs.md
+++ b/site/content/docs/5.3/components/navs-tabs.md
@@ -179,7 +179,7 @@ Take that same HTML, but use `.nav-pills` instead:
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -400,7 +400,7 @@ As a design recommendation, dropdowns are typically placed at the end of the nav
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 
 Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/navs-tabs.md
+++ b/site/content/docs/5.3/components/navs-tabs.md
@@ -60,6 +60,15 @@ Change the style of `.nav`s component with modifiers and utilities. Mix and matc
 
 Change the horizontal alignment of your nav with [flexbox utilities]({{< docsref "/utilities/flex#justify-content" >}}). By default, navs are left-aligned, but you can easily change them to center or right-aligned.
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These **centered** and **right aligned** component variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be left aligned.
+
+Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
 Centered with `.justify-content-center`:
 
 {{< example >}}
@@ -97,10 +106,20 @@ Right-aligned with `.justify-content-end`:
   </li>
 </ul>
 {{< /example >}}
+</details>
 
 ### Vertical
 
 Stack your navigation by changing the flex item direction with the `.flex-column` utility. Need to stack them on some viewports but not others? Use the responsive versions (e.g., `.flex-sm-column`).
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These **vertical** component variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
+
+Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+{{< /design-callout-alert >}}
 
 {{< example >}}
 <ul class="nav flex-column">
@@ -129,6 +148,7 @@ As always, vertical navigation is possible without `<ul>`s, too.
   <a class="nav-link disabled" aria-disabled="true">Disabled</a>
 </nav>
 {{< /example >}}
+</details>
 
 ### Tabs
 
@@ -159,7 +179,7 @@ Take that same HTML, but use `.nav-pills` instead:
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used as is because it should use a `<button>` component as defined in the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -263,7 +283,7 @@ Nav tabs light is nested in a tab for adding a level of depth in information org
 Force your `.nav`'s contents to extend the full available width with one of two modifier classes. To proportionately fill all available space with your `.nav-item`s, use `.nav-fill`. Notice that all horizontal space is occupied, but not every nav item has the same width.
 
 {{< example >}}
-<ul class="nav nav-pills nav-fill">
+<ul class="nav nav-underline nav-fill">
   <li class="nav-item">
     <a class="nav-link active" aria-current="page" href="#">Active</a>
   </li>
@@ -282,7 +302,7 @@ Force your `.nav`'s contents to extend the full available width with one of two 
 When using a `<nav>`-based navigation, you can safely omit `.nav-item` as only `.nav-link` is required for styling `<a>` elements.
 
 {{< example >}}
-<nav class="nav nav-pills nav-fill">
+<nav class="nav nav-underline nav-fill">
   <a class="nav-link active" aria-current="page" href="#">Active</a>
   <a class="nav-link" href="#">Much longer nav link</a>
   <a class="nav-link" href="#">Link</a>
@@ -293,7 +313,7 @@ When using a `<nav>`-based navigation, you can safely omit `.nav-item` as only `
 For equal-width elements, use `.nav-justified`. All horizontal space will be occupied by nav links, but unlike the `.nav-fill` above, every nav item will be the same width.
 
 {{< example >}}
-<ul class="nav nav-pills nav-justified">
+<ul class="nav nav-underline nav-justified">
   <li class="nav-item">
     <a class="nav-link active" aria-current="page" href="#">Active</a>
   </li>
@@ -312,7 +332,7 @@ For equal-width elements, use `.nav-justified`. All horizontal space will be occ
 Similar to the `.nav-fill` example using a `<nav>`-based navigation.
 
 {{< example >}}
-<nav class="nav nav-pills nav-justified">
+<nav class="nav nav-underline nav-justified">
   <a class="nav-link active" aria-current="page" href="#">Active</a>
   <a class="nav-link" href="#">Much longer nav link</a>
   <a class="nav-link" href="#">Link</a>
@@ -325,7 +345,7 @@ Similar to the `.nav-fill` example using a `<nav>`-based navigation.
 If you need responsive nav variations, consider using a series of [flexbox utilities]({{< docsref "/utilities/flex" >}}). While more verbose, these utilities offer greater customization across responsive breakpoints. In the example below, our nav will be stacked on the lowest breakpoint, then adapt to a horizontal layout that fills the available width starting from the small breakpoint.
 
 {{< example >}}
-<nav class="nav nav-pills flex-column flex-sm-row">
+<nav class="nav nav-underline flex-column flex-sm-row">
   <a class="flex-sm-fill text-sm-center nav-link active" aria-current="page" href="#">Active</a>
   <a class="flex-sm-fill text-sm-center nav-link" href="#">Longer nav link</a>
   <a class="flex-sm-fill text-sm-center nav-link" href="#">Link</a>
@@ -380,7 +400,9 @@ As a design recommendation, dropdowns are typically placed at the end of the nav
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used as is because it should use a `<button>` component as defined in the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
+
+Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 <!-- Boosted mod: dropdown nav-item moved at the end of the nav-item list to match the Orange design system requirements -->
@@ -546,10 +568,10 @@ To help fit your needs, this works with `<ul>`-based markup, as shown above, or 
 </div>
 ```
 
-The tabs plugin also works with pills.
+The tabs plugin also works with underline.
 
 <div class="bd-example">
-  <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
+  <ul class="nav nav-underline mb-3" id="pills-tab" role="tablist">
     <li class="nav-item" role="presentation">
       <button class="nav-link active" id="pills-home-tab" data-bs-toggle="pill" data-bs-target="#pills-home" type="button" role="tab" aria-controls="pills-home" aria-selected="true">Home</button>
     </li>
@@ -602,6 +624,15 @@ The tabs plugin also works with pills.
 </div>
 ```
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These **vertical** component variants should not be used because they do not respect the Orange Design System specifications. Indeed, nav items should be displayed horizontally.
+
+Instead, please consider using our Boosted tabs [Underline variant]({{< docsref "/components/navs-tabs#underline" >}}). You can also refer to [Tabs guidelines](https://system.design.orange.com/0c1af118d/p/8630dc-tabs/b/4547ed) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
 And with vertical pills. Ideally, for vertical tabs, you should also add `aria-orientation="vertical"` to the tab list container.
 
 <div class="bd-example">
@@ -651,6 +682,7 @@ And with vertical pills. Ideally, for vertical tabs, you should also add `aria-o
   </div>
 </div>
 ```
+</details>
 
 ### Accessibility
 

--- a/site/content/docs/5.3/components/orange-navbar.md
+++ b/site/content/docs/5.3/components/orange-navbar.md
@@ -57,7 +57,7 @@ This component should be:
 - visible only for the **larger screens** (`lg` to `xxl` breakpoints) using `.navbar-expand-*`.
 - displayed inside the burger menu for **smaller screens**. There it has to be split in 2 parts.
 
-Refer to [Responsive behavior](#responsive-behavior) to have more details.
+Refer to the [Responsive behavior](#responsive-behavior) to have more details.
 
 ### Standard
 

--- a/site/content/docs/5.3/components/popovers.md
+++ b/site/content/docs/5.3/components/popovers.md
@@ -106,7 +106,7 @@ You can customize the appearance of popovers using [CSS variables](#variables). 
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This **customized** variant should not be used because it does not respect the Orange Design System specifications. More generally, customizing popover CSS might lead to mismatch the Orange Design System.
+This **customized** variant should not be used because it does not respect the Orange Design System specifications. More generally, customizing popover CSS might lead to mismatch Orange Design System.
 
 Please refer to the [Popover guidelines](https://system.design.orange.com/0c1af118d/p/644ffa-popovers) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/popovers.md
+++ b/site/content/docs/5.3/components/popovers.md
@@ -102,6 +102,15 @@ const popover = new boosted.Popover('.example-popover', {
 
 You can customize the appearance of popovers using [CSS variables](#variables). We set a custom class with `data-bs-custom-class="custom-popover"` to scope our custom appearance and use it to override some of the local CSS variables.
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This **customized** variant should not be used because it does not respect the Orange Design System specifications. More generally, customizing popover CSS might lead to mismatch the Orange Design System.
+
+Please refer to the [Popover guidelines](https://system.design.orange.com/0c1af118d/p/644ffa-popovers) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
 {{< scss-docs name="custom-popovers" file="site/assets/scss/_component-examples.scss" >}}
 
 {{< example class="custom-popover-demo" stackblitz_add_js="true" >}}
@@ -113,6 +122,7 @@ You can customize the appearance of popovers using [CSS variables](#variables). 
   Custom popover
 </button>
 {{< /example >}}
+</details>
 
 ### Dismiss on next click
 

--- a/site/content/docs/5.3/components/popovers.md
+++ b/site/content/docs/5.3/components/popovers.md
@@ -103,7 +103,7 @@ const popover = new boosted.Popover('.example-popover', {
 You can customize the appearance of popovers using [CSS variables](#variables). We set a custom class with `data-bs-custom-class="custom-popover"` to scope our custom appearance and use it to override some of the local CSS variables.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This **customized** variant should not be used because it does not respect the Orange Design System specifications. More generally, customizing popover CSS might lead to mismatch Orange Design System.

--- a/site/content/docs/5.3/components/progress.md
+++ b/site/content/docs/5.3/components/progress.md
@@ -240,7 +240,7 @@ The striped gradient can also be animated. Add `.progress-bar-animated` to `.pro
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Progress bar guidelines](https://system.design.orange.com/0c1af118d/p/080a7d-progress-bar/b/898b87) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/progress.md
+++ b/site/content/docs/5.3/components/progress.md
@@ -65,7 +65,7 @@ You only set a `height` value on the `.progress` container, so if you change tha
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 The **1px height** variant should not be used because it does not respect the Orange Design System specifications.
@@ -121,7 +121,7 @@ Boosted also provides size variants for progress bar: simply add `.progress-xs` 
 Use background utility classes to change the appearance of individual progress bars.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These backgrounds color variants should not be used because they do not respect the Orange Design System specifications. The only background color to use is the primary color.
@@ -179,7 +179,7 @@ Alternatively, you can use the new combined [color and background]({{< docsref "
 You can include multiple progress components inside a container with `.progress-stacked` to create a single stacked progress bar. Note that in this case, the styling to set the visual width of the progress bar *must* be applied to the `.progress` elements, rather than the `.progress-bar`s.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants should not be used because they do not respect the Orange Design System specifications.
@@ -205,7 +205,7 @@ These variants should not be used because they do not respect the Orange Design 
 Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gradient over the progress bar's background color.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants should not be used because they do not respect the Orange Design System specifications.
@@ -237,7 +237,7 @@ Please refer to the [Progress bar guidelines](https://system.design.orange.com/0
 The striped gradient can also be animated. Add `.progress-bar-animated` to `.progress-bar` to animate the stripes right to left via CSS3 animations.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/components/progress.md
+++ b/site/content/docs/5.3/components/progress.md
@@ -70,7 +70,7 @@ You only set a `height` value on the `.progress` container, so if you change tha
 {{< design-callout-alert >}}
 The **1px height** variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Progress bar](https://system.design.orange.com/0c1af118d/p/080a7d-progress-bar/b/898b87) guidelines on the Orange Design System website.
+Please refer to the [Progress bar guidelines](https://system.design.orange.com/0c1af118d/p/080a7d-progress-bar/b/898b87) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -126,7 +126,7 @@ Use background utility classes to change the appearance of individual progress b
 {{< design-callout-alert >}}
 These backgrounds color variants should not be used because they do not respect the Orange Design System specifications. The only background color to use is the primary color.
 
-Please refer to the [Progress bar](https://system.design.orange.com/0c1af118d/p/080a7d-progress-bar/b/898b87) guidelines on the Orange Design System website.
+Please refer to the [Progress bar guidelines](https://system.design.orange.com/0c1af118d/p/080a7d-progress-bar/b/898b87) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -178,6 +178,13 @@ Alternatively, you can use the new combined [color and background]({{< docsref "
 
 You can include multiple progress components inside a container with `.progress-stacked` to create a single stacked progress bar. Note that in this case, the styling to set the visual width of the progress bar *must* be applied to the `.progress` elements, rather than the `.progress-bar`s.
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These variants should not be used because they do not respect the Orange Design System specifications.
+{{< /design-callout-alert >}}
+
 {{< example >}}
 <div class="progress-stacked">
   <div class="progress" role="progressbar" aria-label="Segment one" aria-valuenow="15" aria-valuemin="0" aria-valuemax="100" style="width: 15%">
@@ -191,6 +198,7 @@ You can include multiple progress components inside a container with `.progress-
   </div>
 </div>
 {{< /example >}}
+</details>
 
 ## Striped
 
@@ -202,7 +210,7 @@ Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gra
 {{< design-callout-alert >}}
 These variants should not be used because they do not respect the Orange Design System specifications.
 
-Please refer to the [Progress bar](https://system.design.orange.com/0c1af118d/p/080a7d-progress-bar/b/898b87) guidelines on the Orange Design System website.
+Please refer to the [Progress bar guidelines](https://system.design.orange.com/0c1af118d/p/080a7d-progress-bar/b/898b87) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -234,7 +242,7 @@ The striped gradient can also be animated. Add `.progress-bar-animated` to `.pro
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Progress bar](https://system.design.orange.com/0c1af118d/p/080a7d-progress-bar/b/898b87) guidelines on the Orange Design System website.
+Please refer to the [Progress bar guidelines](https://system.design.orange.com/0c1af118d/p/080a7d-progress-bar/b/898b87) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/components/scrollspy.md
+++ b/site/content/docs/5.3/components/scrollspy.md
@@ -27,7 +27,7 @@ Scrollspy toggles the `.active` class on anchor (`<a>`) elements when the elemen
 {{< design-callout-alert >}}
 This navbar version of the Scrollspy component is incompatible with Orange Design System.
 
-Refer to [Orange navbar component]({{< docsref "/components/orange-navbar" >}}) and [Nav & tabs component]({{< docsref "/components/navs-tabs" >}}).
+Refer to the [Orange navbar component]({{< docsref "/components/orange-navbar" >}}) and [Nav & tabs component]({{< docsref "/components/navs-tabs" >}}).
 {{< /design-callout-alert >}}
 
 Scroll the area below the navbar and watch the active class change. Open the dropdown menu and watch the dropdown items be highlighted as well.

--- a/site/content/docs/5.3/components/scrollspy.md
+++ b/site/content/docs/5.3/components/scrollspy.md
@@ -10,7 +10,7 @@ toc: true
 
 ## How it works
 
-Scrollspy toggles the `.active` class on anchor (`<a>`) elements when the element with the `id` referenced by the anchor's `href` is scrolled into view. Scrollspy is best used in conjunction with a Boosted [nav component]({{< docsref "/components/navs-tabs" >}}) or [list group]({{< docsref "/components/list-group" >}}), but it will also work with any anchor elements in the current page. Here's how it works.
+Scrollspy toggles the `.active` class on anchor (`<a>`) elements when the element with the `id` referenced by the anchor's `href` is scrolled into view. Scrollspy is best used in conjunction with a [Nav component]({{< docsref "/components/navs-tabs" >}}) or [list group]({{< docsref "/components/list-group" >}}), but it will also work with any anchor elements in the current page. Here's how it works.
 
 - To start, scrollspy requires two things: a navigation, list group, or a simple set of links, plus a scrollable container. The scrollable container can be the `<body>` or a custom element with a set `height` and `overflow-y: scroll`.
 

--- a/site/content/docs/5.3/components/scrollspy.md
+++ b/site/content/docs/5.3/components/scrollspy.md
@@ -27,7 +27,7 @@ Scrollspy toggles the `.active` class on anchor (`<a>`) elements when the elemen
 {{< design-callout-alert >}}
 This navbar version of the Scrollspy component is incompatible with Orange Design System.
 
-Refer to [Orange navbar]({{< docsref "/components/orange-navbar" >}}) and [Nav & tabs]({{< docsref "/components/navs-tabs" >}}).
+Refer to [Orange navbar component]({{< docsref "/components/orange-navbar" >}}) and [Nav & tabs component]({{< docsref "/components/navs-tabs" >}}).
 {{< /design-callout-alert >}}
 
 Scroll the area below the navbar and watch the active class change. Open the dropdown menu and watch the dropdown items be highlighted as well.

--- a/site/content/docs/5.3/components/spinners.md
+++ b/site/content/docs/5.3/components/spinners.md
@@ -43,10 +43,10 @@ The border spinner uses `currentColor` for its `border-color`, meaning you can c
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This component contains some spinners that should not be used on Orange sites.
+This variant contains some spinners that should not be used on Orange sites.
 
 **Colored spinners** are incompatible with Orange Design System.
 {{< /design-callout-alert >}}
@@ -74,10 +74,10 @@ This component contains some spinners that should not be used on Orange sites.
 If you don't fancy a border spinner, switch to the grow spinner. While it doesn't technically spin, it does repeatedly grow!
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This component contains some spinners that should not be used on Orange sites.
+This variant contains some spinners that should not be used on Orange sites.
 
 **Growing spinner** and its examples are incompatible with Orange Design System.
 {{< /design-callout-alert >}}
@@ -173,10 +173,10 @@ Add `.spinner-border-sm` or `.spinner-border-lg` to make a smaller spinner that 
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This component contains some spinners that should not be used on Orange sites.
+This variant contains some spinners that should not be used on Orange sites.
 
 **Growing spinner** and its examples are incompatible with Orange Design System.
 {{< /design-callout-alert >}}
@@ -214,10 +214,10 @@ Use spinners within buttons to indicate an action is currently processing or tak
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This component contains some spinners that should not be used on Orange sites.
+This variant contains some spinners that should not be used on Orange sites.
 
 **Growing spinner** and its examples are incompatible with Orange Design System.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/spinners.md
+++ b/site/content/docs/5.3/components/spinners.md
@@ -46,7 +46,7 @@ The border spinner uses `currentColor` for its `border-color`, meaning you can c
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant contains some spinners that should not be used on Orange sites.
+These variants contain some spinners that should not be used on Orange sites.
 
 **Colored spinners** are incompatible with Orange Design System.
 {{< /design-callout-alert >}}
@@ -77,7 +77,7 @@ If you don't fancy a border spinner, switch to the grow spinner. While it doesn'
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant contains some spinners that should not be used on Orange sites.
+These variants contain some spinners that should not be used on Orange sites.
 
 **Growing spinner** and its examples are incompatible with Orange Design System.
 {{< /design-callout-alert >}}
@@ -176,7 +176,7 @@ Add `.spinner-border-sm` or `.spinner-border-lg` to make a smaller spinner that 
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant contains some spinners that should not be used on Orange sites.
+These variants contain some spinners that should not be used on Orange sites.
 
 **Growing spinner** and its examples are incompatible with Orange Design System.
 {{< /design-callout-alert >}}
@@ -217,7 +217,7 @@ Use spinners within buttons to indicate an action is currently processing or tak
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant contains some spinners that should not be used on Orange sites.
+These variants contain some spinners that should not be used on Orange sites.
 
 **Growing spinner** and its examples are incompatible with Orange Design System.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/components/tooltips.md
+++ b/site/content/docs/5.3/components/tooltips.md
@@ -73,7 +73,7 @@ You can customize the appearance of tooltips using [CSS variables](#variables). 
 {{< design-callout-alert >}}
 This **customized** variant should not be used because it does not respect the Orange Design System specifications. More generally, customizing tooltip CSS might lead to mismatch the Orange Design System.
 
-Please refer to the [Tooltip](https://system.design.orange.com/0c1af118d/p/932946-tooltip/b/417f3e) guidelines  on the Orange Design System website.
+Please refer to the [Tooltip guidelines](https://system.design.orange.com/0c1af118d/p/932946-tooltip/b/417f3e) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< scss-docs name="custom-tooltip" file="site/assets/scss/_component-examples.scss" >}}

--- a/site/content/docs/5.3/components/tooltips.md
+++ b/site/content/docs/5.3/components/tooltips.md
@@ -68,7 +68,7 @@ Hover over the links below to see tooltips:
 You can customize the appearance of tooltips using [CSS variables](#variables). We set a custom class with `data-bs-custom-class="custom-tooltip"` to scope our custom appearance and use it to override a local CSS variable.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This **customized** variant should not be used because it does not respect the Orange Design System specifications. More generally, customizing tooltip CSS might lead to mismatch the Orange Design System.

--- a/site/content/docs/5.3/content/reboot.md
+++ b/site/content/docs/5.3/content/reboot.md
@@ -134,7 +134,7 @@ The `<hr>` element has been simplified. Similar to browser defaults, `<hr>`s are
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These `<hr>` 2nd, 3rd and 4th variants can not be used because they do not respect the Orange Design System specifications. For the 2nd variant, it is because of its color. For the 3rd variant, it is because of its opacity. For the 4th variant, it is because of its height and its opacity.

--- a/site/content/docs/5.3/content/reboot.md
+++ b/site/content/docs/5.3/content/reboot.md
@@ -137,7 +137,7 @@ The `<hr>` element has been simplified. Similar to browser defaults, `<hr>`s are
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These `<hr>` 2nd, 3rd and 4th variants can not be used because they do not respect the Orange Design System specifications. For the 2nd variant, it is because of its color. For the 3rd variant, it is because of its opacity. For the 4th variant, it is because of its height and its opacity.
+These `<hr>` 2nd, 3rd and 4th variants should not be used because they do not respect the Orange Design System specifications. For the 2nd variant, it is because of its color. For the 3rd variant, it is because of its opacity. For the 4th variant, it is because of its height and its opacity.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/content/tables.md
+++ b/site/content/docs/5.3/content/tables.md
@@ -452,7 +452,7 @@ Border styles, active styles, and table variants are not inherited by nested tab
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These variants should not be used because they do not respect the Orange Design System specifications. It is not recommended for usability reasons.
+This variant should not be used because it does not respect the Orange Design System specifications. It is not recommended for usability reasons.
 {{< /design-callout-alert >}}
 
 <div class="bd-example">

--- a/site/content/docs/5.3/content/tables.md
+++ b/site/content/docs/5.3/content/tables.md
@@ -16,7 +16,7 @@ Using the most basic table markup, here's how `.table`-based tables look in Boos
 
 {{< design-callout-alert info >}}
 In order to get the row height recommended by Orange Design System, please use the `.table-sm` class in addition to `.table`.
-You can refer to [small tables paragraph]({{< docsref "/content/tables#small-tables" >}}).
+You can refer to the [small tables paragraph]({{< docsref "/content/tables#small-tables" >}}).
 {{< /design-callout-alert >}}
 
 {{< table class="table" simplified="false" caption="Boosted tables basic look" >}}

--- a/site/content/docs/5.3/content/tables.md
+++ b/site/content/docs/5.3/content/tables.md
@@ -40,7 +40,7 @@ Darker tables are allowed contextually. Add `data-bs-theme="dark"` to the `.tabl
 {{< /callout >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These colored tables should not be used because they do not respect the [Orange Design System]({{< param ods.web >}}) specifications as they are inherited from Bootstrap.
@@ -127,7 +127,7 @@ Use .table-striped-columns to add zebra-striping to any table column.
 {{< table class="table table-striped-columns" caption="Boosted striped columns table" >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These colored tables should not be used because they do not respect the [Orange Design System]({{< param ods.web >}}) specifications as they are inherited from Bootstrap.
@@ -151,7 +151,7 @@ Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
 {{< table class="table table-hover" caption="Boosted hoverable table" >}}
 
 <details class="mb-3">
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These colored tables should not be used because they do not respect the [Orange Design System]({{< param ods.web >}}) specifications as they are inherited from Bootstrap.
@@ -167,7 +167,7 @@ These hoverable rows can also be combined with the striped rows variant:
 {{< table class="table table-striped table-hover" caption="Boosted hoverable striped table" >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These colored tables should not be used because they do not respect the [Orange Design System]({{< param ods.web >}}) specifications as they are inherited from Bootstrap.
@@ -238,7 +238,7 @@ Highlight a table row or cell by adding a `.table-active` class.
 ```
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These colored tables should not be used because they do not respect the [Orange Design System]({{< param ods.web >}}) specifications as they are inherited from Bootstrap.
@@ -329,7 +329,7 @@ To display basic tables, Orange Design System recommends using these compact tab
 {{< table class="table table-sm" caption="Boosted small table" >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These colored tables should not be used because they do not respect the [Orange Design System]({{< param ods.web >}}) specifications as they are inherited from Bootstrap.
@@ -449,7 +449,7 @@ Table cells of `<thead>` are always vertical aligned to the bottom. Table cells 
 Border styles, active styles, and table variants are not inherited by nested tables.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications. It is not recommended for usability reasons.

--- a/site/content/docs/5.3/content/tables.md
+++ b/site/content/docs/5.3/content/tables.md
@@ -452,7 +452,7 @@ Border styles, active styles, and table variants are not inherited by nested tab
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications. It is not recommended for usability reasons.
+These variants should not be used because they do not respect the Orange Design System specifications. It is not recommended for usability reasons.
 {{< /design-callout-alert >}}
 
 <div class="bd-example">

--- a/site/content/docs/5.3/content/tables.md
+++ b/site/content/docs/5.3/content/tables.md
@@ -452,7 +452,7 @@ Border styles, active styles, and table variants are not inherited by nested tab
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This component variant should not be used because it does not respect the Orange Design System specifications. It is not recommended for usability reasons.
+This variant should not be used because it does not respect the Orange Design System specifications. It is not recommended for usability reasons.
 {{< /design-callout-alert >}}
 
 <div class="bd-example">

--- a/site/content/docs/5.3/content/tables.md
+++ b/site/content/docs/5.3/content/tables.md
@@ -16,7 +16,7 @@ Using the most basic table markup, here's how `.table`-based tables look in Boos
 
 {{< design-callout-alert info >}}
 In order to get the row height recommended by Orange Design System, please use the `.table-sm` class in addition to `.table`.
-You can refer to [small tables]({{< docsref "/content/tables#small-tables" >}}) paragraph.
+You can refer to [small tables paragraph]({{< docsref "/content/tables#small-tables" >}}).
 {{< /design-callout-alert >}}
 
 {{< table class="table" simplified="false" caption="Boosted tables basic look" >}}

--- a/site/content/docs/5.3/customize/color-palette.md
+++ b/site/content/docs/5.3/customize/color-palette.md
@@ -52,7 +52,7 @@ Bootstrap defines a color palette on its own. We worked on a mapping between Ora
 {{< design-callout-alert >}}
 Some of the colors below do not belong to the Orange Design System specifications.
 
-Please refer to our Boosted [color palette](#palette) section and to the [Color](https://system.design.orange.com/0c1af118d/p/7059a5-colour/b/17b829) guidelines on the Orange Design System website.
+Please refer to our Boosted [color palette section](#palette) and to the [Color guidelines](https://system.design.orange.com/0c1af118d/p/7059a5-colour/b/17b829) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< callout warning >}}

--- a/site/content/docs/5.3/customize/color-palette.md
+++ b/site/content/docs/5.3/customize/color-palette.md
@@ -52,7 +52,7 @@ Bootstrap defines a color palette on its own. We worked on a mapping between Ora
 {{< design-callout-alert >}}
 Some of the colors below do not belong to the Orange Design System specifications.
 
-Please refer to our Boosted [color palette section](#palette) and to the [Color guidelines](https://system.design.orange.com/0c1af118d/p/7059a5-colour/b/17b829) on the Orange Design System website.
+Please refer to our [color palette section](#palette) and to the [Color guidelines](https://system.design.orange.com/0c1af118d/p/7059a5-colour/b/17b829) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< callout warning >}}

--- a/site/content/docs/5.3/examples/download-app/index.html
+++ b/site/content/docs/5.3/examples/download-app/index.html
@@ -97,7 +97,7 @@ aliases:
         <div class="col-12 col-lg-5 py-2 bg-black">
           <h2 class="pt-1 pt-md-3 mb-2 mb-md-3 display-2 text-primary">Implementing mobile designs into code</h2>
           <p class="pt-1 mb-2 display-2">A trusted source for developers</p>
-          <p class="ll-sm pt-1 pt-md-3 mb-3 mb-md-4 fw-bold">From documentation, though repositories, to a showcase mobile application, the Orange Design System provides the elements for developers to implement experiences on mobile iOS and Android operating systems, by integrating brand foundations, design standards, societal and environmental commitments.</p>
+          <p class="ll-sm pt-1 pt-md-3 mb-3 mb-md-4 fw-bold">From documentation, though repositories, to a showcase mobile application, Orange Design System provides the elements for developers to implement experiences on mobile iOS and Android operating systems, by integrating brand foundations, design standards, societal and environmental commitments.</p>
         </div>
       </div>
     </div>
@@ -115,7 +115,7 @@ aliases:
             <use xlink:href="#android"/>
           </svg>
         </div>
-        <p class="h3 mt-1 mt-md-0 mb-0 text-center">The place for mobile designers and developers to experiment the elements of the Orange Design System</p>
+        <p class="h3 mt-1 mt-md-0 mb-0 text-center">The place for mobile designers and developers to experiment the elements of Orange Design System</p>
       </div>
     </div>
     <div class="w-100 mb-2 pt-3 pt-md-5">

--- a/site/content/docs/5.3/extend/icons.md
+++ b/site/content/docs/5.3/extend/icons.md
@@ -50,7 +50,7 @@ All icons can be retrieved easily in any of these formats in the Solaris icons f
 This technique is the preferred choice for flexibility, performance and accessibility.
 
 Using the [Solaris icons finder]({{< param icons >}}), you can generate an SVG sprite—a single SVG file containing all your icons—and insert an icon through the `<use>` element.
-This is similar to an `<img>` element, but with the power of `currentColor` for easy theming: see in this example how some icons inherit their color from the parent's light or dark theme, whereas some others get their color from [text Orange's colors utilities]({{< docsref "/utilities/colors#oranges-colors" >}}) or local style.
+This is similar to an `<img>` element, but with the power of `currentColor` for easy theming: see in this example how some icons inherit their color from the parent's light or dark theme, whereas some others get their color from [text Orange's colors utilities]({{< docsref "/utilities/colors#colors" >}}) or local style.
 
 {{< example >}}
 <p class="p-2" data-bs-theme="light">

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -250,6 +250,15 @@ Create button-like checkboxes and radio buttons by using `.btn` styles rather th
 
 ### Checkbox toggle buttons
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These **checkbox toggle button** variants should not be used because they do not respect the Orange Design System specifications. Indeed, from the Orange Design System point of view a checkbox should always look like a checkbox component.
+
+Instead, consider using our Boosted [Checks component]({{< docsref "/forms/checks-radios#checks" >}}), [Radios component]({{< docsref "/forms/checks-radios#radios" >}}) or [Radio toggle buttons component]({{< docsref "/forms/checks-radios#radio-toggle-buttons" >}}).
+{{< /design-callout-alert >}}
+
 {{< example >}}
 <input type="checkbox" class="btn-check" id="btn-check" autocomplete="off">
 <label class="btn btn-toggle" for="btn-check">Single toggle</label>
@@ -268,6 +277,7 @@ Create button-like checkboxes and radio buttons by using `.btn` styles rather th
 {{< callout info >}}
 Visually, these checkbox toggle buttons are identical to the [button plugin toggle buttons]({{< docsref "/components/buttons#button-plugin" >}}). However, they are conveyed differently by assistive technologies: the checkbox toggles will be announced by screen readers as "checked"/"not checked" (since, despite their appearance, they are fundamentally still checkboxes), whereas the button plugin toggle buttons will be announced as "button"/"button pressed". The choice between these two approaches will depend on the type of toggle you are creating, and whether or not the toggle will make sense to users when announced as a checkbox or as an actual button.
 {{< /callout >}}
+</details>
 
 ### Radio toggle buttons
 

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -256,7 +256,7 @@ Create button-like checkboxes and radio buttons by using `.btn` styles rather th
 {{< design-callout-alert >}}
 These **checkbox toggle button** variants should not be used because they do not respect the Orange Design System specifications. Indeed, from the Orange Design System point of view a checkbox should always look like a checkbox component.
 
-Instead, consider using our Boosted [Checks component]({{< docsref "/forms/checks-radios#checks" >}}), [Radios component]({{< docsref "/forms/checks-radios#radios" >}}) or [Radio toggle buttons component]({{< docsref "/forms/checks-radios#radio-toggle-buttons" >}}).
+Instead, consider using our [Checks component]({{< docsref "/forms/checks-radios#checks" >}}), [Radios component]({{< docsref "/forms/checks-radios#radios" >}}) or [Radio toggle buttons component]({{< docsref "/forms/checks-radios#radio-toggle-buttons" >}}).
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -251,7 +251,7 @@ Create button-like checkboxes and radio buttons by using `.btn` styles rather th
 ### Checkbox toggle buttons
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These **checkbox toggle button** variants should not be used because they do not respect the Orange Design System specifications. Indeed, from the Orange Design System point of view a checkbox should always look like a checkbox component.

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -33,7 +33,7 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 The last variant with a `.form-control-sm` class and a height of 30px can not be used because it does not respect the Orange Design System specifications.
@@ -69,7 +69,7 @@ Form text below inputs can be styled with `.form-text`. If a block-level element
 Inline text can use any typical inline HTML element (be it a `<span>`, `<small>`, or something else) with nothing more than the `.form-text` class.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This form version, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because it does not respect the Orange Design System specifications.
@@ -131,7 +131,7 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This form variant with an **horizontal layout** (i.e. labels not above the input fields) should not be used because it does not respect the Orange Design System specifications.
@@ -193,7 +193,7 @@ Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 The **Small file input example** below with a height of 30px can not be used because it does not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -36,7 +36,7 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-The last variant with a `.form-control-sm` class and a height of 30px can not be used because it does not respect the Orange Design System specifications.
+The last small variant with a `.form-control-sm` class should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -72,7 +72,7 @@ Inline text can use any typical inline HTML element (be it a `<span>`, `<small>`
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This form version, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because it does not respect the Orange Design System specifications.
+This variant with an **horizontal layout** (i.e. labels not above the input fields) should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -134,7 +134,7 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This form variant with an **horizontal layout** (i.e. labels not above the input fields) should not be used because it does not respect the Orange Design System specifications.
+These variants with an **horizontal layout** (i.e. labels not above the input fields) should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -196,7 +196,7 @@ Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-The **Small file input example** below with a height of 30px can not be used because it does not respect the Orange Design System specifications.
+This small variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -30,8 +30,23 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 {{< example >}}
 <input class="form-control form-control-lg" type="text" placeholder=".form-control-lg" aria-label=".form-control-lg example">
 <input class="form-control" type="text" placeholder="Default input" aria-label="default input example">
+{{< /example >}}
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+The last variant with a `.form-control-sm` class and a height of 30px can not be used because it does not respect the Orange Design System specifications.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
+{{< example >}}
+<input class="form-control form-control-lg" type="text" placeholder=".form-control-lg" aria-label=".form-control-lg example">
+<input class="form-control" type="text" placeholder="Default input" aria-label="default input example">
 <input class="form-control form-control-sm" type="text" placeholder=".form-control-sm" aria-label=".form-control-sm example">
 {{< /example >}}
+</details>
 
 ## Form text
 
@@ -53,6 +68,15 @@ Form text below inputs can be styled with `.form-text`. If a block-level element
 
 Inline text can use any typical inline HTML element (be it a `<span>`, `<small>`, or something else) with nothing more than the `.form-text` class.
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This form version, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because it does not respect the Orange Design System specifications.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
 {{< example >}}
 <div class="row g-3 align-items-center">
   <div class="col-auto">
@@ -68,6 +92,7 @@ Inline text can use any typical inline HTML element (be it a `<span>`, `<small>`
   </div>
 </div>
 {{< /example >}}
+</details>
 
 ## Disabled
 
@@ -92,15 +117,39 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 
 {{< example >}}
   <div class="mb-3 row">
-    <label for="staticEmail" class="col-sm-2 col-form-label">Email</label>
-    <div class="col-sm-10">
+    <label for="staticEmail" class="col-form-label">Email</label>
+    <div class="col-12">
       <input type="text" readonly class="form-control-plaintext" id="staticEmail" value="email@example.com">
     </div>
   </div>
   <div class="mb-3 row">
-    <label for="inputPassword" class="col-sm-2 col-form-label">Password</label>
-    <div class="col-sm-10">
+    <label for="inputPassword" class="col-form-label">Password</label>
+    <div class="col-12">
       <input type="password" class="form-control" id="inputPassword">
+    </div>
+  </div>
+{{< /example >}}
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This form variant with an **horizontal layout** (i.e. labels not above the input fields) should not be used because it does not respect the Orange Design System specifications.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
+{{< example >}}
+  <div class="mb-3 row">
+    <label for="staticEmail2" class="col-sm-2 col-form-label">Email</label>
+    <div class="col-sm-10">
+      <input type="text" readonly class="form-control-plaintext" id="staticEmail2" value="email@example.com">
+    </div>
+  </div>
+  <div class="mb-3 row">
+    <label for="inputPassword2" class="col-sm-2 col-form-label">Password</label>
+    <div class="col-sm-10">
+      <input type="password" class="form-control" id="inputPassword2">
     </div>
   </div>
 {{< /example >}}
@@ -108,18 +157,19 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 {{< example >}}
 <form class="row g-3">
   <div class="col-auto">
-    <label for="staticEmail2" class="visually-hidden">Email</label>
-    <input type="text" readonly class="form-control-plaintext" id="staticEmail2" value="email@example.com">
+    <label for="staticEmail3" class="visually-hidden">Email</label>
+    <input type="text" readonly class="form-control-plaintext" id="staticEmail3" value="email@example.com">
   </div>
   <div class="col-auto">
-    <label for="inputPassword2" class="visually-hidden">Password</label>
-    <input type="password" class="form-control" id="inputPassword2" placeholder="Password">
+    <label for="inputPassword3" class="visually-hidden">Password</label>
+    <input type="password" class="form-control" id="inputPassword3" placeholder="Password">
   </div>
   <div class="col-auto">
     <button type="submit" class="btn btn-primary mb-3">Confirm identity</button>
   </div>
 </form>
 {{< /example >}}
+</details>
 
 ## File input
 
@@ -136,15 +186,28 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
   <label for="formFileDisabled" class="form-label is-disabled">Disabled file input example</label>
   <input class="form-control" type="file" id="formFileDisabled" disabled>
 </div>
-<div class="mb-3">
-  <label for="formFileSm" class="form-label">Small file input example</label>
-  <input class="form-control form-control-sm" id="formFileSm" type="file">
-</div>
 <div>
   <label for="formFileLg" class="form-label">Large file input example</label>
   <input class="form-control form-control-lg" id="formFileLg" type="file">
 </div>
 {{< /example >}}
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+The **Small file input example** below with a height of 30px can not be used because it does not respect the Orange Design System specifications.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
+{{< example >}}
+<div>
+  <label for="formFileSm" class="form-label">Small file input example</label>
+  <input class="form-control form-control-sm" id="formFileSm" type="file">
+</div>
+{{< /example >}}
+</details>
 
 ## Color
 

--- a/site/content/docs/5.3/forms/input-group.md
+++ b/site/content/docs/5.3/forms/input-group.md
@@ -350,7 +350,11 @@ Input groups include support for custom selects and custom file inputs. Browser 
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These **first 3** variants should not be used because they do not respect the Orange Design System specifications. The **first 2** variants should have a vertical layout (i.e., having their label above the input field). The **third** variant should be split in 2 elements (a button and a dropdown) which should be presented in a more logical way : the dropdown first and then the button.
+These **first three** variants should not be used because they do not respect the Orange Design System specifications.
+
+The **first two** variants should have a vertical layout (i.e., having their label above the input field).
+
+The **third** variant should be split in two elements (a button and a dropdown) which should be presented in a more logical way: the dropdown first and then the button.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/forms/input-group.md
+++ b/site/content/docs/5.3/forms/input-group.md
@@ -18,7 +18,7 @@ Place one add-on or button on either side of an input. You may also place one on
 {{< design-callout-alert >}}
 These form variants should not be used because they do not respect the Orange Design System specifications.
 
-Please refer to the [Forms](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) guidelines and to the [Pages](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) form examples on the Orange Design System website.
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -77,6 +77,15 @@ Add the relative form sizing classes to the `.input-group` itself and contents w
 
 **Sizing on the individual input group elements isn't supported.**
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These 3 form variants, with an **horizontal layout** (i.e. labels not above the input fields), and the **small** one because of its height, should not be used because they do not respect the Orange Design System specifications.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
 {{< example >}}
 <div class="input-group input-group-sm mb-3">
   <span class="input-group-text" id="inputGroup-sizing-sm">Small</span>
@@ -93,6 +102,7 @@ Add the relative form sizing classes to the `.input-group` itself and contents w
   <input type="text" class="form-control" aria-label="Sizing example input" aria-describedby="inputGroup-sizing-lg">
 </div>
 {{< /example >}}
+</details>
 
 ## Checkboxes and radios
 
@@ -124,7 +134,7 @@ While multiple `<input>`s are supported visually, validation styles are only ava
 {{< design-callout-alert >}}
 This form variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Forms](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) guidelines and to the [Pages](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) form examples on the Orange Design System website.
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -146,7 +156,7 @@ Multiple add-ons are supported and can be mixed with checkbox and radio input ve
 {{< design-callout-alert >}}
 This form variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Forms](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) guidelines and to the [Pages](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) form examples on the Orange Design System website.
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -172,7 +182,7 @@ Please refer to the [Forms](https://system.design.orange.com/0c1af118d/p/88ab5b-
 {{< design-callout-alert >}}
 These variants should not be used because they do not respect the Orange Design System specifications. They are not recommended for usability reasons.
 
-Please refer to the [Forms](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) guidelines and to the [Pages](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) form examples on the Orange Design System website.
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -234,7 +244,7 @@ Please refer to the [Forms](https://system.design.orange.com/0c1af118d/p/88ab5b-
 {{< design-callout-alert >}}
 This **third** form variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Forms](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) guidelines and to the [Pages](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) form examples on the Orange Design System website.
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -325,6 +335,27 @@ Input groups include support for custom selects and custom file inputs. Browser 
 ### Custom select
 
 {{< example >}}
+<div class="input-group">
+  <select class="form-select" id="inputGroupSelect05" aria-label="Example select with button addon">
+    <option selected>Choose...</option>
+    <option value="1">One</option>
+    <option value="2">Two</option>
+    <option value="3">Three</option>
+  </select>
+  <button class="btn btn-outline-secondary" type="button">Button</button>
+</div>
+{{< /example >}}
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These **first 3** form variants should not be used because they do not respect the Orange Design System specifications. The **first 2** form variants should have a vertical layout (i.e., having their label above the input field). The **third** form variant should be split in 2 elements (a button and a dropdown) which should be presented in a more logical way : the dropdown first and then the button.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
+{{< example >}}
 <div class="input-group mb-3">
   <label class="input-group-text" for="inputGroupSelect01">Options</label>
   <select class="form-select" id="inputGroupSelect01">
@@ -365,8 +396,25 @@ Input groups include support for custom selects and custom file inputs. Browser 
   <button class="btn btn-outline-secondary" type="button">Button</button>
 </div>
 {{< /example >}}
+</details>
 
 ### Custom file input
+
+{{< example >}}
+<div class="input-group">
+  <input type="file" class="form-control" id="inputGroupFile04" aria-describedby="inputGroupFileAddon04" aria-label="Upload">
+  <button class="btn btn-outline-secondary" type="button" id="inputGroupFileAddon04">Button</button>
+</div>
+{{< /example >}}
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These form variants should not be used because they do not respect the Orange Design System specifications.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
 
 {{< example >}}
 <div class="input-group mb-3">
@@ -379,16 +427,12 @@ Input groups include support for custom selects and custom file inputs. Browser 
   <label class="input-group-text" for="inputGroupFile02">Upload</label>
 </div>
 
-<div class="input-group mb-3">
+<div class="input-group">
   <button class="btn btn-outline-secondary" type="button" id="inputGroupFileAddon03">Button</button>
   <input type="file" class="form-control" id="inputGroupFile03" aria-describedby="inputGroupFileAddon03" aria-label="Upload">
 </div>
-
-<div class="input-group">
-  <input type="file" class="form-control" id="inputGroupFile04" aria-describedby="inputGroupFileAddon04" aria-label="Upload">
-  <button class="btn btn-outline-secondary" type="button" id="inputGroupFileAddon04">Button</button>
-</div>
 {{< /example >}}
+</details>
 
 ## CSS
 

--- a/site/content/docs/5.3/forms/input-group.md
+++ b/site/content/docs/5.3/forms/input-group.md
@@ -16,7 +16,7 @@ Place one add-on or button on either side of an input. You may also place one on
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These form variants should not be used because they do not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -81,7 +81,7 @@ Add the relative form sizing classes to the `.input-group` itself and contents w
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These 3 form variants, with an **horizontal layout** (i.e. labels not above the input fields), and the **small** one because of its height, should not be used because they do not respect the Orange Design System specifications.
+These 3 variants with an **horizontal layout** (i.e. labels not above the input fields), and the **small** one because of its height, should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -132,7 +132,7 @@ While multiple `<input>`s are supported visually, validation styles are only ava
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This form variant should not be used because it does not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -154,7 +154,7 @@ Multiple add-ons are supported and can be mixed with checkbox and radio input ve
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This form variant should not be used because it does not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -242,7 +242,7 @@ Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This **third** form variant should not be used because it does not respect the Orange Design System specifications.
+This **third** variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -350,7 +350,7 @@ Input groups include support for custom selects and custom file inputs. Browser 
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These **first 3** form variants should not be used because they do not respect the Orange Design System specifications. The **first 2** form variants should have a vertical layout (i.e., having their label above the input field). The **third** form variant should be split in 2 elements (a button and a dropdown) which should be presented in a more logical way : the dropdown first and then the button.
+These **first 3** variants should not be used because they do not respect the Orange Design System specifications. The **first 2** variants should have a vertical layout (i.e., having their label above the input field). The **third** variant should be split in 2 elements (a button and a dropdown) which should be presented in a more logical way : the dropdown first and then the button.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -411,7 +411,7 @@ Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These form variants should not be used because they do not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/forms/input-group.md
+++ b/site/content/docs/5.3/forms/input-group.md
@@ -13,7 +13,7 @@ toc: true
 Place one add-on or button on either side of an input. You may also place one on both sides of an input. Remember to place `<label>`s outside the input group.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These form variants should not be used because they do not respect the Orange Design System specifications.
@@ -78,7 +78,7 @@ Add the relative form sizing classes to the `.input-group` itself and contents w
 **Sizing on the individual input group elements isn't supported.**
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These 3 form variants, with an **horizontal layout** (i.e. labels not above the input fields), and the **small** one because of its height, should not be used because they do not respect the Orange Design System specifications.
@@ -129,7 +129,7 @@ Place any checkbox or radio option within an input group's addon instead of text
 While multiple `<input>`s are supported visually, validation styles are only available for input groups with a single `<input>`.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This form variant should not be used because it does not respect the Orange Design System specifications.
@@ -151,7 +151,7 @@ Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118
 Multiple add-ons are supported and can be mixed with checkbox and radio input versions.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This form variant should not be used because it does not respect the Orange Design System specifications.
@@ -177,7 +177,7 @@ Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118
 ## Button addons
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These variants should not be used because they do not respect the Orange Design System specifications. They are not recommended for usability reasons.
@@ -239,7 +239,7 @@ Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This **third** form variant should not be used because it does not respect the Orange Design System specifications.
@@ -347,7 +347,7 @@ Input groups include support for custom selects and custom file inputs. Browser 
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These **first 3** form variants should not be used because they do not respect the Orange Design System specifications. The **first 2** form variants should have a vertical layout (i.e., having their label above the input field). The **third** form variant should be split in 2 elements (a button and a dropdown) which should be presented in a more logical way : the dropdown first and then the button.
@@ -408,7 +408,7 @@ Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These form variants should not be used because they do not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/forms/layout.md
+++ b/site/content/docs/5.3/forms/layout.md
@@ -119,6 +119,15 @@ Create horizontal forms with the grid by adding the `.row` class to form groups 
 
 At times, you maybe need to use margin or padding utilities to create that perfect alignment you need. For example, we've removed the `padding-top` on our stacked radio inputs label to better align the text baseline.
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This form variant, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because it does not respect the Orange Design System specifications.
+
+Please refer to our Boosted [Forms example]({{< docsref "/examples/form" >}}). You can also refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
 {{< example >}}
 <form>
   <div class="row mb-3">
@@ -169,10 +178,20 @@ At times, you maybe need to use margin or padding utilities to create that perfe
   <button type="submit" class="btn btn-primary mt-2">Sign in</button>
 </form>
 {{< /example >}}
+</details>
 
 ### Horizontal form label sizing
 
 Be sure to use `.col-form-label-sm` or `.col-form-label-lg` to your `<label>`s or `<legend>`s to correctly follow the size of `.form-control-lg` and `.form-control-sm`.
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These 3 form variants, with an **horizontal layout** (i.e. labels not above the input fields), and the **small** one with a `col-form-label-sm` class because of its height, should not be used because it does not respect the Orange Design System specifications.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
 
 {{< example >}}
 <div class="row mb-3">
@@ -194,10 +213,20 @@ Be sure to use `.col-form-label-sm` or `.col-form-label-lg` to your `<label>`s o
   </div>
 </div>
 {{< /example >}}
+</details>
 
 ## Column sizing
 
 As shown in the previous examples, our grid system allows you to place any number of `.col`s within a `.row`. They'll split the available width equally between them. You may also pick a subset of your columns to take up more or less space, while the remaining `.col`s equally split the rest, with specific column classes like `.col-sm-7`.
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These form variants, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because they do not respect the Orange Design System specifications.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
 
 {{< example >}}
 <div class="row g-3">
@@ -212,10 +241,20 @@ As shown in the previous examples, our grid system allows you to place any numbe
   </div>
 </div>
 {{< /example >}}
+</details>
 
 ## Auto-sizing
 
 The example below uses a flexbox utility to vertically center the contents and changes `.col` to `.col-auto` so that your columns only take up as much space as needed. Put another way, the column sizes itself based on the contents.
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+These form variants, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because they do not respect the Orange Design System specifications.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
 
 {{< example >}}
 <form class="row gy-2 gx-3 align-items-center">
@@ -290,6 +329,7 @@ You can then remix that once again with size-specific column classes.
   </div>
 </form>
 {{< /example >}}
+</details>
 
 ## Inline forms
 
@@ -301,7 +341,7 @@ Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding
 {{< design-callout-alert >}}
 This form variant should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to the [Forms](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) guidelines and to the [Pages](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) form examples on the Orange Design System website.
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/forms/layout.md
+++ b/site/content/docs/5.3/forms/layout.md
@@ -120,7 +120,7 @@ Create horizontal forms with the grid by adding the `.row` class to form groups 
 At times, you maybe need to use margin or padding utilities to create that perfect alignment you need. For example, we've removed the `padding-top` on our stacked radio inputs label to better align the text baseline.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This form variant, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because it does not respect the Orange Design System specifications.
@@ -185,7 +185,7 @@ Please refer to our Boosted [Forms example]({{< docsref "/examples/form" >}}). Y
 Be sure to use `.col-form-label-sm` or `.col-form-label-lg` to your `<label>`s or `<legend>`s to correctly follow the size of `.form-control-lg` and `.form-control-sm`.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These 3 form variants, with an **horizontal layout** (i.e. labels not above the input fields), and the **small** one with a `col-form-label-sm` class because of its height, should not be used because it does not respect the Orange Design System specifications.
@@ -220,7 +220,7 @@ Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118
 As shown in the previous examples, our grid system allows you to place any number of `.col`s within a `.row`. They'll split the available width equally between them. You may also pick a subset of your columns to take up more or less space, while the remaining `.col`s equally split the rest, with specific column classes like `.col-sm-7`.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These form variants, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because they do not respect the Orange Design System specifications.
@@ -248,7 +248,7 @@ Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118
 The example below uses a flexbox utility to vertically center the contents and changes `.col` to `.col-auto` so that your columns only take up as much space as needed. Put another way, the column sizes itself based on the contents.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These form variants, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because they do not respect the Orange Design System specifications.
@@ -336,7 +336,7 @@ You can then remix that once again with size-specific column classes.
 Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding [gutter modifier classes]({{< docsref "/layout/gutters" >}}), we'll have gutters in horizontal and vertical directions. On narrow mobile viewports, the `.col-12` helps stack the form controls and more. The `.align-items-center` aligns the form elements to the middle, making the `.form-check` align properly.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This form variant should not be used because it does not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/forms/layout.md
+++ b/site/content/docs/5.3/forms/layout.md
@@ -125,7 +125,7 @@ At times, you maybe need to use margin or padding utilities to create that perfe
 {{< design-callout-alert >}}
 This form variant, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because it does not respect the Orange Design System specifications.
 
-Please refer to our Boosted [Forms example]({{< docsref "/examples/form" >}}). You can also refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+Please refer to our [Forms example]({{< docsref "/examples/form" >}}). You can also refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/forms/layout.md
+++ b/site/content/docs/5.3/forms/layout.md
@@ -123,7 +123,7 @@ At times, you maybe need to use margin or padding utilities to create that perfe
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This form variant, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because it does not respect the Orange Design System specifications.
+This variant with an **horizontal layout** (i.e. labels not above the input fields) should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to our [Forms example]({{< docsref "/examples/form" >}}). You can also refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -188,7 +188,7 @@ Be sure to use `.col-form-label-sm` or `.col-form-label-lg` to your `<label>`s o
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These 3 form variants, with an **horizontal layout** (i.e. labels not above the input fields), and the **small** one with a `col-form-label-sm` class because of its height, should not be used because it does not respect the Orange Design System specifications.
+These 3 variants with an **horizontal layout** (i.e. labels not above the input fields), and the **small** one with a `col-form-label-sm` class because of its height, should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -223,7 +223,7 @@ As shown in the previous examples, our grid system allows you to place any numbe
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These form variants, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because they do not respect the Orange Design System specifications.
+These variants with an **horizontal layout** (i.e. labels not above the input fields) should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -251,7 +251,7 @@ The example below uses a flexbox utility to vertically center the contents and c
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-These form variants, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because they do not respect the Orange Design System specifications.
+These variants with an **horizontal layout** (i.e. labels not above the input fields) should not be used because they do not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
@@ -339,7 +339,7 @@ Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This form variant should not be used because it does not respect the Orange Design System specifications.
+This variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/forms/select.md
+++ b/site/content/docs/5.3/forms/select.md
@@ -38,7 +38,7 @@ You may also choose from small and large custom selects to match our similarly s
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This size variant, with a **height of 30px**, should not be used because it does not respect the Orange Design System specifications.
+This small variant should not be used because it does not respect the Orange Design System specifications.
 
 Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/forms/select.md
+++ b/site/content/docs/5.3/forms/select.md
@@ -32,7 +32,18 @@ You may also choose from small and large custom selects to match our similarly s
   <option value="2">Two</option>
   <option value="3">Three</option>
 </select>
+{{< /example >}}
 
+<details class="mb-3">
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This size variant, with a **height of 30px**, should not be used because it does not respect the Orange Design System specifications.
+
+Please refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
+{{< example >}}
 <select class="form-select form-select-sm" aria-label="Small select example">
   <option selected>Open this select menu</option>
   <option value="1">One</option>
@@ -40,6 +51,7 @@ You may also choose from small and large custom selects to match our similarly s
   <option value="3">Three</option>
 </select>
 {{< /example >}}
+</details>
 
 The `multiple` attribute is also supported:
 

--- a/site/content/docs/5.3/forms/select.md
+++ b/site/content/docs/5.3/forms/select.md
@@ -35,7 +35,7 @@ You may also choose from small and large custom selects to match our similarly s
 {{< /example >}}
 
 <details class="mb-3">
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This size variant, with a **height of 30px**, should not be used because it does not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -118,7 +118,7 @@ While these feedback styles cannot be styled with CSS, you can still customize t
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This form variant, **with browser default validation feedback messages**, should not be used because it does not respect the Orange Design System specifications.
+This variant, **with browser default validation feedback messages**, should not be used because it does not respect the Orange Design System specifications.
 
 Instead, please refer to our [Custom styles section](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1614/files). You can also refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -120,7 +120,7 @@ While these feedback styles cannot be styled with CSS, you can still customize t
 {{< design-callout-alert >}}
 This form variant, **with browser default validation feedback messages**, should not be used because it does not respect the Orange Design System specifications.
 
-Instead, please refer to our Boosted [Custom styles section](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1614/files). You can also refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+Instead, please refer to our [Custom styles section](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1614/files). You can also refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -114,6 +114,15 @@ Not interested in custom validation feedback messages or writing JavaScript to c
 
 While these feedback styles cannot be styled with CSS, you can still customize the feedback text through JavaScript.
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This form variant, **with browser default validation feedback messages**, should not be used because it does not respect the Orange Design System specifications.
+
+Instead, please refer to our Boosted [Custom styles section](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/1614/files). You can also refer to the [Forms guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459) and to the [Pages form examples](https://system.design.orange.com/0c1af118d/p/20500e-form/b/16bb53) on the Orange Design System website.
+{{< /design-callout-alert >}}
+
 {{< example >}}
 <form class="row g-3">
   <div class="col-md-4">
@@ -158,6 +167,7 @@ While these feedback styles cannot be styled with CSS, you can still customize t
   </div>
 </form>
 {{< /example >}}
+</details>
 
 ## Server-side
 

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -115,7 +115,7 @@ Not interested in custom validation feedback messages or writing JavaScript to c
 While these feedback styles cannot be styled with CSS, you can still customize the feedback text through JavaScript.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This form variant, **with browser default validation feedback messages**, should not be used because it does not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/getting-started/introduction.md
+++ b/site/content/docs/5.3/getting-started/introduction.md
@@ -25,7 +25,7 @@ Design incompatibility callouts message example:
 {{< design-callout-alert >}}
 This checkbox variant should not be used because it does not respect the Orange Design System specifications.
 
-From the Orange Design System point of view, checkboxes should be represented like in our Boosted [Checks component]({{< docsref "/forms/checks-radios" >}}). You can also refer to the [Checkbox guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459/i/48901789) on on the Orange Design System website.
+From the Orange Design System point of view, checkboxes should be represented like in our [Checks component]({{< docsref "/forms/checks-radios" >}}). You can also refer to the [Checkbox guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459/i/48901789) on on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 In the same spirit, some blue recommendation design callouts will inform you of specific Orange Design System recommendations.

--- a/site/content/docs/5.3/getting-started/introduction.md
+++ b/site/content/docs/5.3/getting-started/introduction.md
@@ -15,7 +15,7 @@ toc: true
 
 As Boosted is based on Bootstrap, you'll find in Boosted **all** the Bootstrap's components and their variants, but with an Orange branded look.
 
-Among those inherited components and variants, some exist in the Orange Design System and fully respect its design specifications and some don't. Those ones should not be used in your projects to ensure a consistent user experience throughout our Orange web services.
+Among those inherited components and variants, some exist in Orange Design System and fully respect its design specifications and some don't. Those ones should not be used in your projects to ensure a consistent user experience throughout our Orange web services.
 
 As for maintainability reasons we have to keep them in this documentation, we tagged them under a `<details><summary>` with red incompatibility design callouts. They inform you of what should not be used from an Orange design point of view. They suggest, when available, a replacement solution and/or a link to the Orange Design System website to see other possibilities. We tried to hide them as much as possible while keeping the variants in our documentation.
 Thanks for taking this information into account.

--- a/site/content/docs/5.3/getting-started/introduction.md
+++ b/site/content/docs/5.3/getting-started/introduction.md
@@ -17,7 +17,7 @@ As Boosted is based on Bootstrap, you'll find in Boosted **all** the Bootstrap's
 
 Among those inherited components and variants, some exist in the Orange Design System and fully respect its design specifications and some don't. Those ones should not be used in your projects to ensure a consistent user experience throughout our Orange web services.
 
-As for maintainability reasons we have to keep them in this documentation, we tagged them under a `<details><summary>` with red incompatibility design callouts. They inform you of what should not be used from an Orange design point of view. They suggest, when available, a replacement solution and/or a link to the Orange Design System website to see other possibilities.
+As for maintainability reasons we have to keep them in this documentation, we tagged them under a `<details><summary>` with red incompatibility design callouts. They inform you of what should not be used from an Orange design point of view. They suggest, when available, a replacement solution and/or a link to the Orange Design System website to see other possibilities. We tried to hide them as much as possible while keeping the variants in our documentation.
 Thanks for taking this information into account.
 
 Design incompatibility callouts message example:
@@ -25,7 +25,7 @@ Design incompatibility callouts message example:
 {{< design-callout-alert >}}
 This checkbox variant should not be used because it does not respect the Orange Design System specifications.
 
-From the Orange Design System point of view, checkboxes should be represented like in our Boosted [Checks]({{< docsref "/forms/checks-radios" >}}) component. You can also refer to the [Checkbox](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459/i/48901789) guidelines on on the Orange Design System website.
+From the Orange Design System point of view, checkboxes should be represented like in our Boosted [Checks component]({{< docsref "/forms/checks-radios" >}}). You can also refer to the [Checkbox guidelines](https://system.design.orange.com/0c1af118d/p/88ab5b-forms/b/599459/i/48901789) on on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 In the same spirit, some blue recommendation design callouts will inform you of specific Orange Design System recommendations.

--- a/site/content/docs/5.3/guidelines/_index.md
+++ b/site/content/docs/5.3/guidelines/_index.md
@@ -9,7 +9,7 @@ aliases:
 
 <div class="ods-guidelines py-4 mt-md-2">
   <div class="container-xxl">
-    <h2 class="h1">Other platforms in the Orange Design System</h2>
+    <h2 class="h1">Other platforms in Orange Design System</h2>
     <div class="row pt-3">
       {{< design-guidelines-cards.inline >}}
       {{ range (index $.Site.Data "design-guidelines") -}}

--- a/site/content/docs/5.3/helpers/color-background.md
+++ b/site/content/docs/5.3/helpers/color-background.md
@@ -36,7 +36,7 @@ Color and background helpers combine the power of our [`.text-*` utilities]({{< 
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant should not be used because it does not respect the Orange Design System specifications.
+These variants should not be used because they do not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 Use them in place of combined `.text-*` and `.bg-*` classes, like on [badges]({{< docsref "/components/badge#background-colors" >}}):

--- a/site/content/docs/5.3/helpers/color-background.md
+++ b/site/content/docs/5.3/helpers/color-background.md
@@ -32,6 +32,13 @@ Color and background helpers combine the power of our [`.text-*` utilities]({{< 
 
 ## With components
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This variant should not be used because it does not respect the Orange Design System specifications.
+{{< /design-callout-alert >}}
+
 Use them in place of combined `.text-*` and `.bg-*` classes, like on [badges]({{< docsref "/components/badge#background-colors" >}}):
 
 {{< example >}}
@@ -55,3 +62,4 @@ Or on [cards]({{< docsref "/components/card#background-and-color" >}}):
   </div>
 </div>
 {{< /example >}}
+</details>

--- a/site/content/docs/5.3/helpers/color-background.md
+++ b/site/content/docs/5.3/helpers/color-background.md
@@ -33,7 +33,7 @@ Color and background helpers combine the power of our [`.text-*` utilities]({{< 
 ## With components
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This variant should not be used because it does not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/helpers/colored-links.md
+++ b/site/content/docs/5.3/helpers/colored-links.md
@@ -13,7 +13,7 @@ toc: true
 You can use the `.link-*` classes to colorize links. Unlike the [`.text-*` classes]({{< docsref "/utilities/colors" >}}), these classes have a `:hover` and `:focus` state. Some of the link styles use a relatively light foreground color, and should only be used on a dark background in order to have sufficient contrast.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 The colors combinations below do not belong to the Orange Design System specifications.
@@ -48,7 +48,7 @@ Please refer to our Boosted [links section]({{< docsref "/content/typography#lin
 Colored links can also be modified by [our link utilities]({{< docsref "/utilities/link/" >}}).
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 The colors combinations below do not belong to the Orange Design System specifications.

--- a/site/content/docs/5.3/helpers/colored-links.md
+++ b/site/content/docs/5.3/helpers/colored-links.md
@@ -18,7 +18,7 @@ You can use the `.link-*` classes to colorize links. Unlike the [`.text-*` class
 {{< design-callout-alert >}}
 The colors combinations below do not belong to the Orange Design System specifications.
 
-Please refer to our Boosted [links section]({{< docsref "/content/typography#links" >}}) and to the [Text links in body copy guidelines](https://system.design.orange.com/0c1af118d/p/38f221-typography/t/56933e) on the Orange Design System website.
+Please refer to our [links section]({{< docsref "/content/typography#links" >}}) and to the [Text links in body copy guidelines](https://system.design.orange.com/0c1af118d/p/38f221-typography/t/56933e) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< callout info >}}
@@ -53,7 +53,7 @@ Colored links can also be modified by [our link utilities]({{< docsref "/utiliti
 {{< design-callout-alert >}}
 The colors combinations below do not belong to the Orange Design System specifications.
 
-Please refer to our Boosted [links section]({{< docsref "/content/typography#links" >}}) and to the [Text links in body copy guidelines](https://system.design.orange.com/0c1af118d/p/38f221-typography/t/56933e) on the Orange Design System website.
+Please refer to our [links section]({{< docsref "/content/typography#links" >}}) and to the [Text links in body copy guidelines](https://system.design.orange.com/0c1af118d/p/38f221-typography/t/56933e) on the Orange Design System website.
 {{< /design-callout-alert >}}
 <!--Boosted mod: feature limited to primary and light, we don't loop over "theme-colors; body-emphasis is treated on its own"-->
 {{< example >}}

--- a/site/content/docs/5.3/helpers/colored-links.md
+++ b/site/content/docs/5.3/helpers/colored-links.md
@@ -18,7 +18,7 @@ You can use the `.link-*` classes to colorize links. Unlike the [`.text-*` class
 {{< design-callout-alert >}}
 The colors combinations below do not belong to the Orange Design System specifications.
 
-Please refer to our Boosted [links]({{< docsref "/content/typography#links" >}}) section and to the [Text links in body copy](https://system.design.orange.com/0c1af118d/p/38f221-typography/t/56933e) guidelines on the Orange Design System website.
+Please refer to our Boosted [links section]({{< docsref "/content/typography#links" >}}) and to the [Text links in body copy guidelines](https://system.design.orange.com/0c1af118d/p/38f221-typography/t/56933e) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< callout info >}}
@@ -53,7 +53,7 @@ Colored links can also be modified by [our link utilities]({{< docsref "/utiliti
 {{< design-callout-alert >}}
 The colors combinations below do not belong to the Orange Design System specifications.
 
-Please refer to our Boosted [links]({{< docsref "/content/typography#links" >}}) section and to the [Text links in body copy](https://system.design.orange.com/0c1af118d/p/38f221-typography/t/56933e) guidelines on the Orange Design System website.
+Please refer to our Boosted [links section]({{< docsref "/content/typography#links" >}}) and to the [Text links in body copy guidelines](https://system.design.orange.com/0c1af118d/p/38f221-typography/t/56933e) on the Orange Design System website.
 {{< /design-callout-alert >}}
 <!--Boosted mod: feature limited to primary and light, we don't loop over "theme-colors; body-emphasis is treated on its own"-->
 {{< example >}}

--- a/site/content/docs/5.3/helpers/focus-ring.md
+++ b/site/content/docs/5.3/helpers/focus-ring.md
@@ -20,7 +20,7 @@ Click directly on the link below to see the focus ring in action, or into the ex
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should not be used because the rendering provided in the following examples does not exist in the Orange Design System specifications.
+This helper should not be used because the rendering provided in the following examples does not respect in the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -42,7 +42,7 @@ Modify the `--bs-focus-ring-*` CSS variables as needed to change the default app
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should not be used because the rendering provided in the following examples does not exist in the Orange Design System specifications.
+This helper should not be used because the rendering provided in the following examples does not respect in the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -78,7 +78,7 @@ In addition to `.focus-ring`, we have several `.focus-ring-*` utilities to modif
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should not be used because the rendering provided in the following examples does not exist in the Orange Design System specifications.
+This helper should not be used because the rendering provided in the following examples does not respect in the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/helpers/focus-ring.md
+++ b/site/content/docs/5.3/helpers/focus-ring.md
@@ -20,7 +20,7 @@ Click directly on the link below to see the focus ring in action, or into the ex
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should not be used because the rendering provided in the following examples does not respect in the Orange Design System specifications.
+This helper should not be used because the rendering provided in the following examples does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -42,7 +42,7 @@ Modify the `--bs-focus-ring-*` CSS variables as needed to change the default app
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should not be used because the rendering provided in the following examples does not respect in the Orange Design System specifications.
+This helper should not be used because the rendering provided in the following examples does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -78,7 +78,7 @@ In addition to `.focus-ring`, we have several `.focus-ring-*` utilities to modif
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should not be used because the rendering provided in the following examples does not respect in the Orange Design System specifications.
+This helper should not be used because the rendering provided in the following examples does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/helpers/focus-ring.md
+++ b/site/content/docs/5.3/helpers/focus-ring.md
@@ -17,7 +17,7 @@ The `.focus-ring` helper removes the default `outline` on `:focus`, replacing it
 Click directly on the link below to see the focus ring in action, or into the example below and then press <kbd>Tab</kbd>.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This helper should not be used because the rendering provided in the following examples does not respect in the Orange Design System specifications.
@@ -39,7 +39,7 @@ Modify the styling of a focus ring with our CSS variables, Sass variables, utili
 Modify the `--bs-focus-ring-*` CSS variables as needed to change the default appearance.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This helper should not be used because the rendering provided in the following examples does not respect in the Orange Design System specifications.
@@ -75,7 +75,7 @@ Customize the focus ring Sass variables to modify all usage of the focus ring st
 In addition to `.focus-ring`, we have several `.focus-ring-*` utilities to modify the helper class defaults. Modify the color with any of our [theme colors]({{< docsref "/customize/color-theme#theming" >}}). Note that the light and dark variants may not be visible on all background colors given current color mode support.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This helper should not be used because the rendering provided in the following examples does not respect in the Orange Design System specifications.

--- a/site/content/docs/5.3/helpers/icon-link.md
+++ b/site/content/docs/5.3/helpers/icon-link.md
@@ -33,7 +33,7 @@ When icons are purely decorative, they should be hidden from assistive technolog
 Take a regular `<a>` element, add `.icon-link`, and insert an icon on either the left or right of your link text. The icon is automatically sized, placed, and colored.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
@@ -59,7 +59,7 @@ This helper should be used carefully because the rendering provided in the follo
 Add `.icon-link-hover` to move the icon to the right on hover.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
@@ -82,7 +82,7 @@ Modify the styling of an icon link with our link CSS variables, Sass variables, 
 Modify the `--bs-link-*` and `--bs-icon-link-*` CSS variables as needed to change the default appearance.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
@@ -118,7 +118,7 @@ Customize the icon link Sass variables to modify all icon link styles across you
 Modify icon links with any of [our link utilities]({{< docsref "/utilities/link/" >}}) for modifying underline color and offset.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.

--- a/site/content/docs/5.3/helpers/icon-link.md
+++ b/site/content/docs/5.3/helpers/icon-link.md
@@ -36,7 +36,7 @@ Take a regular `<a>` element, add `.icon-link`, and insert an icon on either the
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
+This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -62,7 +62,7 @@ Add `.icon-link-hover` to move the icon to the right on hover.
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
+This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -85,7 +85,7 @@ Modify the `--bs-link-*` and `--bs-icon-link-*` CSS variables as needed to chang
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
+This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
 {{< /design-callout-alert >}}
 
 Customize the hover `transform` by overriding the `--bs-icon-link-transform` CSS variable:
@@ -121,7 +121,7 @@ Modify icon links with any of [our link utilities]({{< docsref "/utilities/link/
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
+This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/helpers/icon-link.md
+++ b/site/content/docs/5.3/helpers/icon-link.md
@@ -36,7 +36,7 @@ Take a regular `<a>` element, add `.icon-link`, and insert an icon on either the
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
+This helper should be used carefully because the rendering provided in the following examples does not respect the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -62,7 +62,7 @@ Add `.icon-link-hover` to move the icon to the right on hover.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
+This helper should be used carefully because the rendering provided in the following examples does not respect the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -85,7 +85,7 @@ Modify the `--bs-link-*` and `--bs-icon-link-*` CSS variables as needed to chang
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
+This helper should be used carefully because the rendering provided in the following examples does not respect the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
 {{< /design-callout-alert >}}
 
 Customize the hover `transform` by overriding the `--bs-icon-link-transform` CSS variable:
@@ -121,7 +121,7 @@ Modify icon links with any of [our link utilities]({{< docsref "/utilities/link/
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This helper should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
+This helper should be used carefully because the rendering provided in the following examples does not respect the Orange Design System specifications. But still, this helper could help in some cases to build specific ues cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/helpers/stacks.md
+++ b/site/content/docs/5.3/helpers/stacks.md
@@ -79,7 +79,7 @@ Create an inline form with `.hstack`:
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This form variant, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because it does not respect the Orange Design System specifications.
+This variant with an **horizontal layout** (i.e. labels not above the input fields) should not be used because it does not respect the Orange Design System specifications.
 {{< /design-callout-alert >}}
 
 <!-- Boosted mod: primary and outline secondary button -->

--- a/site/content/docs/5.3/helpers/stacks.md
+++ b/site/content/docs/5.3/helpers/stacks.md
@@ -76,7 +76,7 @@ Use `.vstack` to stack buttons and other elements:
 Create an inline form with `.hstack`:
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 This form variant, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because it does not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/helpers/stacks.md
+++ b/site/content/docs/5.3/helpers/stacks.md
@@ -75,6 +75,13 @@ Use `.vstack` to stack buttons and other elements:
 
 Create an inline form with `.hstack`:
 
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This form variant, with an **horizontal layout** (i.e. labels not above the input fields), should not be used because it does not respect the Orange Design System specifications.
+{{< /design-callout-alert >}}
+
 <!-- Boosted mod: primary and outline secondary button -->
 {{< example >}}
 <div class="hstack gap-3">
@@ -84,6 +91,7 @@ Create an inline form with `.hstack`:
   <button type="button" class="btn btn-outline-secondary">Reset</button>
 </div>
 {{< /example >}}
+</details>
 
 ## CSS
 

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -16,6 +16,10 @@ toc: true
 - **Colors**
   - <span class="badge text-bg-warning">Warning</span> The dark mode red color hexadecimal value has been updated from `#f66` to `#ff4d4d` after a change in the design specifications to enhance the contrast for a better accessibility. This modification should be transparent for you except if you were using an hardcoded hexadecimal value directly in your websites.
 
+### Docs
+
+- Some component variants have been hidden from the documentation in order for you to better see the variants you should use and ease the link between [Orange Design System]({{< param ods.web >}}) and the Boosted documentation. These variants are still available under the details of `See Bootstrap example(s) that are incompatible with Orange Design System.`, but know that using them might be a transgression of the Orange Design System rules and try to avoid them as much as possible.
+
 ### CSS and Sass variables
 
 - <details class="mb-2">
@@ -934,7 +938,7 @@ Color mode mechanism coming from Bootstrap is available from Boosted v5.3.0. How
 
 - <span class="badge text-bg-warning">Warning</span> We slightly changed the values for `.lh-sm`, `.lh-base` and `.lh-lg` to provide some more usable values. Please check that it doesn't break your design. Otherwise, it could still be reverted by setting the value directly in `_utilities.scss`.
 
-- <span class="badge text-bg-danger">Breaking</span> We restored all Bootstrap [text color utilities]({{< docsref "/utilities/colors" >}}) and removed automatic corresponding backgrounds. Please note that you must now check for sufficient contrast yourself when using text color utilities. Guidance on this has been added in [Orange's color utilities]({{< docsref "/utilities/colors#oranges-colors" >}}).
+- <span class="badge text-bg-danger">Breaking</span> We restored all Bootstrap [text color utilities]({{< docsref "/utilities/colors" >}}) and removed automatic corresponding backgrounds. Please note that you must now check for sufficient contrast yourself when using text color utilities. Guidance on this has been added in [Orange's color utilities]({{< docsref "/utilities/colors#colors" >}}).
 
 ### Examples
 

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -18,7 +18,7 @@ toc: true
 
 ### Docs
 
-- Some component variants have been hidden from the documentation in order for you to better see the variants you should use and ease the link between [Orange Design System]({{< param ods.web >}}) and the Boosted documentation. These variants are still available under the details of `See Bootstrap example(s) that are incompatible with Orange Design System.`, but know that using them might be a transgression of the Orange Design System rules and try to avoid them as much as possible.
+- Some variants of the components have been hidden from the documentation in order for you to better see the variants you should use and ease the link between [Orange Design System]({{< param ods.web >}}) and the Boosted documentation. These variants are still available under the details of `See Bootstrap example(s) that are incompatible with Orange Design System.`, but know that using them might be a transgression of the Orange Design System rules and try to avoid them as much as possible.
 
 ### CSS and Sass variables
 

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -18,7 +18,7 @@ toc: true
 
 ### Docs
 
-- Some variants of the components have been hidden from the documentation in order for you to better see the variants you should use and ease the link between [Orange Design System]({{< param ods.web >}}) and the Boosted documentation. These variants are still available under the details of `See Bootstrap example(s) that are incompatible with Orange Design System.`, but know that using them might be a transgression of the Orange Design System rules and try to avoid them as much as possible.
+- Some variants of the components have been hidden from the documentation in order for you to better see the variants you should use and ease the link between [Orange Design System]({{< param ods.web >}}) and the Boosted documentation. These variants are still available under the details of `See Bootstrap examples that are incompatible with Orange Design System.`, but know that using them might be a transgression of the Orange Design System rules and try to avoid them as much as possible.
 
 ### CSS and Sass variables
 

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -18,7 +18,9 @@ toc: true
 
 ### Docs
 
-- Some variants of the components have been hidden from the documentation in order for you to better see the variants you should use and ease the link between [Orange Design System]({{< param ods.web >}}) and the Boosted documentation. These variants are still available under the details of `See Bootstrap examples that are incompatible with Orange Design System.`, but know that using them might be a transgression of the Orange Design System rules and try to avoid them as much as possible.
+- Certain variants of the components and renderings have been omitted from the documentation to help you clearly understand what is available for use, thereby simplifying the connection between [Orange Design System]({{< param ods.web >}}) and the Boosted documentation.
+  
+  Although these variants can still be found under the "See Bootstrap examples that are incompatible with Orange Design System" section, be aware that using them may violate the Orange Design System guidelines. It is advisable to avoid these variants whenever possible.
 
 ### CSS and Sass variables
 

--- a/site/content/docs/5.3/utilities/background.md
+++ b/site/content/docs/5.3/utilities/background.md
@@ -94,10 +94,6 @@ We use an RGB version of our `--bs-success` (with the value of `25, 135, 84`) CS
 
 To change that opacity, override `--bs-bg-opacity` via custom styles or inline styles.
 
-{{< example >}}
-<div class="bg-success p-2 text-bg-success">This is default success background</div>
-{{< /example >}}
-
 <details>
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>

--- a/site/content/docs/5.3/utilities/background.md
+++ b/site/content/docs/5.3/utilities/background.md
@@ -95,6 +95,17 @@ We use an RGB version of our `--bs-success` (with the value of `25, 135, 84`) CS
 To change that opacity, override `--bs-bg-opacity` via custom styles or inline styles.
 
 {{< example >}}
+<div class="bg-success p-2 text-bg-success">This is default success background</div>
+{{< /example >}}
+
+<details>
+<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+Some of the colors combinations below do not belong to the Orange Design System specifications, and do not meet accessibility standards.
+{{< /design-callout-alert >}}
+
+{{< example >}}
 <div class="bg-success p-2 text-dark">This is default success background</div>
 <div class="bg-success p-2" style="--bs-bg-opacity: .5;">This is 50% opacity success background</div>
 {{< /example >}}
@@ -108,6 +119,7 @@ Or, choose from any of the `.bg-opacity` utilities:
 <div class="bg-success p-2 text-dark bg-opacity-25">This is 25% opacity success background</div>
 <div class="bg-success p-2 text-dark bg-opacity-10">This is 10% opacity success background</div>
 {{< /example >}}
+</details>
 
 ## CSS
 

--- a/site/content/docs/5.3/utilities/background.md
+++ b/site/content/docs/5.3/utilities/background.md
@@ -46,7 +46,7 @@ Supporting background utilities are generated from our [supporting colors]({{< d
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Bootstrap-specific background color utilities should not be used because they are not part of the [Orange Design System]({{< param ods.web >}}) as they are inherited from Bootstrap.
@@ -99,7 +99,7 @@ To change that opacity, override `--bs-bg-opacity` via custom styles or inline s
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Some of the colors combinations below do not belong to the Orange Design System specifications, and do not meet accessibility standards.

--- a/site/content/docs/5.3/utilities/borders.md
+++ b/site/content/docs/5.3/utilities/borders.md
@@ -68,7 +68,7 @@ Here is a list of these extra classes:
 Or modify the default `border-color` of a component:
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These border color variants are just **examples illustrating the use of this color utility**. They should not be used because they do not respect the Orange Design System specifications.
@@ -118,7 +118,7 @@ To change that opacity, override `--bs-border-opacity` via custom styles or inli
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These border color variants **with opacity** should not be used because they do not respect the Orange Design System specifications.
@@ -149,7 +149,7 @@ Or, choose from any of the `.border-opacity` utilities:
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 The three last border utilities with **a width larger than 2px** should not be used because they do not respect the Orange Design System specifications.
@@ -175,7 +175,7 @@ Add classes to an element to easily round its corners.
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These border variants with **a radius CSS class different than `.rounded-circle` and `.rounded-pill`** should not be used because they do not respect the Orange Design System specifications.
@@ -203,7 +203,7 @@ Use the scaling classes for larger or smaller rounded corners. Sizes range from 
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 These border variants with **a size CSS class different than `.rounded-0`** should not be used because they do not respect the Orange Design System specifications.

--- a/site/content/docs/5.3/utilities/colors.md
+++ b/site/content/docs/5.3/utilities/colors.md
@@ -69,7 +69,7 @@ The following colors are meant to be used with icons.
 {{< /example >}}
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Some of the colors combinations below do not belong to the Orange Design System specifications, and do not meet accessibility standards.
@@ -131,7 +131,7 @@ When used in dark mode, `--bs-primary-rgb` will use the value of (with the value
 To change that opacity, override `--bs-text-opacity` via custom styles or inline styles.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Some of the colors combinations below do not belong to the Orange Design System specifications, and do not meet accessibility standards.

--- a/site/content/docs/5.3/utilities/colors.md
+++ b/site/content/docs/5.3/utilities/colors.md
@@ -74,7 +74,7 @@ The following colors are meant to be used with icons.
 {{< design-callout-alert >}}
 Some of the colors combinations below do not belong to the Orange Design System specifications, and do not meet accessibility standards.
 
-Please refer to our [Orange's colors]({{< docsref "/utilities/colors#oranges-colors" >}}) section underneath and to the [Color](https://system.design.orange.com/0c1af118d/p/7059a5-colour/b/17b829) guidelines on the Orange Design System website.
+Please refer to our [Orange's colors section]({{< docsref "/utilities/colors#colors" >}}) above and to the [Color guidelines](https://system.design.orange.com/0c1af118d/p/7059a5-colour/b/17b829) on the Orange Design System website.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -136,7 +136,7 @@ To change that opacity, override `--bs-text-opacity` via custom styles or inline
 {{< design-callout-alert >}}
 Some of the colors combinations below do not belong to the Orange Design System specifications, and do not meet accessibility standards.
 
-Please refer to our [Orange's colors]({{< docsref "/utilities/colors#oranges-colors" >}}) section underneath and to the [Color](https://system.design.orange.com/0c1af118d/p/7059a5-colour/b/17b829) guidelines on the Orange Design System website.
+Please refer to our [Orange's colors section]({{< docsref "/utilities/colors#colors" >}}) above.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/5.3/utilities/link.md
+++ b/site/content/docs/5.3/utilities/link.md
@@ -15,7 +15,7 @@ added:
 Change the alpha opacity of the link `rgba()` color value with utilities. Please be aware that changes to a color's opacity can lead to links with [*insufficient* contrast]({{< docsref "getting-started/accessibility#color-contrast" >}}).
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
@@ -47,7 +47,7 @@ You can even change the opacity level on hover.
 Change the underline's color independent of the link text color.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
@@ -67,7 +67,7 @@ Link utilities should be used carefully because the rendering provided in the fo
 Change the underline's distance from your text. Offset is set in `em` units to automatically scale with the element's current `font-size`.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
@@ -86,7 +86,7 @@ Link utilities should be used carefully because the rendering provided in the fo
 Change the underline's opacity. Requires adding `.link-underline` to first set an `rgba()` color we use to then modify the alpha opacity.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
@@ -107,7 +107,7 @@ Link utilities should be used carefully because the rendering provided in the fo
 Just like the `.link-opacity-*-hover` utilities, `.link-offset` and `.link-underline-opacity` utilities include `:hover` variants by default. Mix and match to create unique link styles.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
@@ -125,7 +125,7 @@ Link utilities should be used carefully because the rendering provided in the fo
 [Colored link helpers]({{< docsref "/helpers/colored-links/" >}}) have been updated to pair with our link utilities. Use the new utilities to modify the link opacity, underline opacity, and underline offset.
 
 <details>
-<summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
 Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.

--- a/site/content/docs/5.3/utilities/link.md
+++ b/site/content/docs/5.3/utilities/link.md
@@ -18,7 +18,7 @@ Change the alpha opacity of the link `rgba()` color value with utilities. Please
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific ues cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -50,7 +50,7 @@ Change the underline's color independent of the link text color.
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific ues cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -70,7 +70,7 @@ Change the underline's distance from your text. Offset is set in `em` units to a
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific ues cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -89,7 +89,7 @@ Change the underline's opacity. Requires adding `.link-underline` to first set a
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific ues cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -110,7 +110,7 @@ Just like the `.link-opacity-*-hover` utilities, `.link-offset` and `.link-under
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific ues cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -128,7 +128,7 @@ Link utilities should be used carefully because the rendering provided in the fo
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific ues cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 <!--Boosted mod: use `contrast_color` as background to ensure a good contrast-->

--- a/site/content/docs/5.3/utilities/link.md
+++ b/site/content/docs/5.3/utilities/link.md
@@ -18,7 +18,7 @@ Change the alpha opacity of the link `rgba()` color value with utilities. Please
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -50,7 +50,7 @@ Change the underline's color independent of the link text color.
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -70,7 +70,7 @@ Change the underline's distance from your text. Offset is set in `em` units to a
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -89,7 +89,7 @@ Change the underline's opacity. Requires adding `.link-underline` to first set a
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -110,7 +110,7 @@ Just like the `.link-opacity-*-hover` utilities, `.link-offset` and `.link-under
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -128,7 +128,7 @@ Link utilities should be used carefully because the rendering provided in the fo
 <summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 <!--Boosted mod: use `contrast_color` as background to ensure a good contrast-->

--- a/site/content/docs/5.3/utilities/link.md
+++ b/site/content/docs/5.3/utilities/link.md
@@ -18,7 +18,7 @@ Change the alpha opacity of the link `rgba()` color value with utilities. Please
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -50,7 +50,7 @@ Change the underline's color independent of the link text color.
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -70,7 +70,7 @@ Change the underline's distance from your text. Offset is set in `em` units to a
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -89,7 +89,7 @@ Change the underline's opacity. Requires adding `.link-underline` to first set a
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -110,7 +110,7 @@ Just like the `.link-opacity-*-hover` utilities, `.link-offset` and `.link-under
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 {{< example >}}
@@ -128,7 +128,7 @@ Link utilities should be used carefully because the rendering provided in the fo
 <summary>See Bootstrap example(s) that are incompatible with Orange Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-Link utilities should be used carefully because the rendering provided in the following examples does not exist in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
+Link utilities should be used carefully because the rendering provided in the following examples does not respect in the Orange Design System specifications and do not always meet accessibility standards. But still, these utilities could help in some cases to build specific use cases or other reusable components.
 {{< /design-callout-alert >}}
 
 <!--Boosted mod: use `contrast_color` as background to ensure a good contrast-->


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Supersedes #1614 and #2001.
Closes #2128.

### Description

Links have a component or guidelines word inside to let people know that the link goes on Boosted or the DSM.
If one example is fine, it should appear before the details/summary.
Use `See Bootstrap example(s) that are incompatible with Orange Design System.` sentence in the summary.
Use small sentences to explain why the example isn't good.

### Motivation & Context

Before long term maintenance.

### Types of change

- Docs enhancement (non-breaking change which adds functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2625--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- (NA) I have added JavaScript unit tests to cover my changes
- (NA) I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] My change introduces changes to the migration guide
- (NA) My new component is well displayed in [Storybook](https://deploy-preview-2625--boosted.netlify.app/storybook)
- (NA) My new component is compatible with RTL
- (NA) Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- (NA) Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)