### PR TITLE
fix(composer): drop 'replace' property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,5 @@
   "support": {
     "issues": "https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues"
   },
-  "license": "MIT",
-  "replace": {
-    "orange-opensource/orange-boosted-bootstrap": "self.version"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
### Description

This PR doesn't change anything to our v4 version. It's only there to silent the Packagist errors sent for each Packagist updates:

```
Reading composer.json of orange-opensource/orange-boosted-bootstrap (v4-dev)
Importing branch v4-dev (dev-v4-dev)
Skipped branch v4-dev, Invalid package information: 
replace.orange-opensource/orange-boosted-bootstrap : a package cannot set a replace on itself
```