### PR TITLE
[OUDS] Fix(README): composer command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Several quick start options are available:
 - Clone the repo: `git clone https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap.git`
 - Install with [npm](https://www.npmjs.com/): `npm install @ouds/web@v0.0.1`
 - Install with [yarn](https://yarnpkg.com/): `yarn add @ouds/web@v0.0.1`
-- Install with [Composer](https://getcomposer.org/): `composer require Orange-OpenSource/ouds-web:0.0.1`
+- Install with [Composer](https://getcomposer.org/): `composer require orange-opensource/orange-boosted-bootstrap:dev-ouds/main`
 - Install with [NuGet](https://www.nuget.org/): CSS: `Install-Package ouds-web` Sass: `Install-Package ouds-web.sass`
 
 Read the [Getting started page](https://web.unified-design-system.orange.com/docs/getting-started/introduction/) for information on the framework contents, templates, examples, and more.


### PR DESCRIPTION
### Context

There were errors mentioned at https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap and received by emails as error notifications too.
These have been supposedly fixed.

### Description

This PR updates the command mentioned in our README file.

The name provided in our current `ouds/main` for Composer is `"name": "orange-opensource/ouds-web",`, targetting the future repository URL.
It means that, in the meantime, there won't be any `vx.y.z-ouds-web` Composer versions at https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap.
We don't have many users, so the solution, for now is to provide the reference of our main OUDS Web branch.

Locally, you can test to run: `composer require orange-opensource/orange-boosted-bootstrap:dev-ouds/main`:

```
./composer.json has been created
Running composer update orange-opensource/orange-boosted-bootstrap
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking orange-opensource/orange-boosted-bootstrap (dev-ouds/main 847cf7d)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing orange-opensource/orange-boosted-bootstrap (dev-ouds/main 847cf7d): Extracting archive
Generating autoload files
No security vulnerability advisories found
```

As you can see, it uses our current latest commit (847cf7d).
