### PR TITLE
fix(README): npm version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Read the [Getting started page](https://web.unified-design-system.orange.com/doc
 ## Status
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/Orange-OpenSource/Orange-Boosted-Bootstrap/js.yml?branch=ouds/main&label=JS%20Tests&logo=github)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/js.yml?query=workflow%3AJS+branch%3Aouds%2Fmain)
-[![npm version](https://img.shields.io/npm/v/ouds-web?logo=npm&logoColor=fff)](https://www.npmjs.com/package/ouds-web)
+[![npm version](https://img.shields.io/npm/v/@ouds/web?logo=npm&logoColor=fff)](https://www.npmjs.com/package/@ouds/web)
 [![Packagist Prerelease](https://img.shields.io/packagist/v/Orange-Opensource/Orange-Boosted-Bootstrap.svg?include_prereleases&logo=packagist&logoColor=fff)](https://packagist.org/packages/Orange-OpenSource/Orange-Boosted-Bootstrap)
 [![NuGet](https://img.shields.io/nuget/vpre/ouds-web?logo=nuget&logoColor=fff)](https://www.nuget.org/packages/ouds-web/absoluteLatest)
 [![Coverage Status](https://img.shields.io/coveralls/github/Orange-OpenSource/Orange-Boosted-Bootstrap/ouds/main?logo=coveralls&logoColor=fff)](https://coveralls.io/github/Orange-OpenSource/Orange-Boosted-Bootstrap?branch=ouds/main)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Read the [Getting started page](https://web.unified-design-system.orange.com/doc
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/Orange-OpenSource/Orange-Boosted-Bootstrap/js.yml?branch=ouds/main&label=JS%20Tests&logo=github)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/js.yml?query=workflow%3AJS+branch%3Aouds%2Fmain)
 [![npm version](https://img.shields.io/npm/v/@ouds/web?logo=npm&logoColor=fff)](https://www.npmjs.com/package/@ouds/web)
-[![Packagist Prerelease](https://img.shields.io/packagist/v/Orange-Opensource/Orange-Boosted-Bootstrap.svg?include_prereleases&logo=packagist&logoColor=fff)](https://packagist.org/packages/Orange-OpenSource/Orange-Boosted-Bootstrap)
 [![NuGet](https://img.shields.io/nuget/vpre/ouds-web?logo=nuget&logoColor=fff)](https://www.nuget.org/packages/ouds-web/absoluteLatest)
 [![Coverage Status](https://img.shields.io/coveralls/github/Orange-OpenSource/Orange-Boosted-Bootstrap/ouds/main?logo=coveralls&logoColor=fff)](https://coveralls.io/github/Orange-OpenSource/Orange-Boosted-Bootstrap?branch=ouds/main)
 [![CSS gzip size](https://img.badgesize.io/Orange-OpenSource/Orange-Boosted-Bootstrap/ouds/main/dist/css/ouds-web.min.css?compression=gzip&label=CSS%20gzip%20size)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/dist/css/ouds-web.min.css)


### PR DESCRIPTION
### Description

This PR fixes the "npm version" badge present in our README. Indeed, it was configured to use the non-scoped version of the package we defined earlier.

The rich diff can show the before/after rendering: https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2634/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5

The PR also removes the Packagist badge as we're not deploying yet our package there.