### PR TITLE
[OUDS] CI/CD: Browserstack tests

### DIFF
--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -103,7 +103,7 @@ if (BROWSERSTACK) {
   config.browserStack = {
     username: ENV.BROWSER_STACK_USERNAME,
     accessKey: ENV.BROWSER_STACK_ACCESS_KEY,
-    build: `boosted-v5-${ENV.GITHUB_SHA ? `${ENV.GITHUB_SHA.slice(0, 7)}-` : ''}${new Date().toISOString()}`,
+    build: `ouds-web-${ENV.GITHUB_SHA ? `${ENV.GITHUB_SHA.slice(0, 7)}-` : ''}${new Date().toISOString()}`,
     project: 'OUDS Web',
     retryLimit: 2
   }

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -107,7 +107,6 @@ if (BROWSERSTACK) {
     project: 'OUDS Web',
     retryLimit: 2
   }
-  console.log(JSON.stringify(config))
   plugins.push('karma-browserstack-launcher', 'karma-jasmine-html-reporter')
   config.customLaunchers = browsers
   config.browsers = Object.keys(browsers)

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -107,6 +107,7 @@ if (BROWSERSTACK) {
     project: 'OUDS Web',
     retryLimit: 2
   }
+  console.log(JSON.stringify(config))
   plugins.push('karma-browserstack-launcher', 'karma-jasmine-html-reporter')
   config.customLaunchers = browsers
   config.browsers = Object.keys(browsers)


### PR DESCRIPTION
### Related issues

Listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2589

### Description

This PR tries to trigger BrowserStack tests. They should fail but with a new build name. 

**Results:** 
- The build name is well changed, search for `ouds-web-` in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/runs/10041403964/job/27749411325
- The CI is still triggered manually
- The tests still fail

### Types of change

- Refactoring (non-breaking change)