### PR TITLE
fix(docs): broken links to /blob/vx.y.z-ouds-web files

### DIFF
--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -22,7 +22,7 @@
             {{- if (or (and (.Page.Params.added) (not (isset .Page.Params.added "show_badge"))) (and (.Page.Params.added) (isset .Page.Params.added "show_badge") (not (eq .Page.Params.added.show_badge false)))) -}}
               <p class="mb-0 me-2"><span class="tag tag-sm">Added in v{{ .Page.Params.added.version }}</span></p>
             {{- end -}}
-            <a class="btn btn-sm btn-outline-secondary" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}/site/content/{{ .Page.File.Path | replaceRE `\\` "/" }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">
+            <a class="btn btn-sm btn-outline-secondary" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}-ouds-web/site/content/{{ .Page.File.Path | replaceRE `\\` "/" }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">
               View on GitHub
             </a>
           </div>

--- a/site/layouts/shortcodes/js-docs.html
+++ b/site/layouts/shortcodes/js-docs.html
@@ -35,7 +35,7 @@
   <div class="bd-example-snippet bd-code-snippet bd-file-ref">
     <!-- OUDS mod: added `.border-1` and `.border-subtle` -->
     <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom border-1 border-subtle">
-      <a class="font-monospace link-body-emphasis link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}/{{ $file | replaceRE `\\` "/" }}">
+      <a class="font-monospace link-body-emphasis link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}-ouds-web/{{ $file | replaceRE `\\` "/" }}">
         {{- $file -}}
       </a>
       <div class="d-flex ms-auto">

--- a/site/layouts/shortcodes/scss-docs.html
+++ b/site/layouts/shortcodes/scss-docs.html
@@ -48,7 +48,7 @@
   <div class="bd-example-snippet bd-code-snippet bd-file-ref">
     <!-- OUDS mod: added `.border-1` and `.border-subtle` -->
     <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom border-1 border-subtle">
-      <a class="font-monospace link-body-emphasis link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}/{{ $file | replaceRE `\\` "/" }}">
+      <a class="font-monospace link-body-emphasis link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}-ouds-web/{{ $file | replaceRE `\\` "/" }}">
         {{- $file -}}
       </a>
       <div class="d-flex ms-auto">


### PR DESCRIPTION
### Description

This PR fixes some broken links due to the fact that our tags have a "-ouds-web" suffix.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>
