### PR TITLE
[OUDS] docs: add 'Extend > Approach' page

### DIFF
--- a/site/content/docs/0.0/extend/approach.md
+++ b/site/content/docs/0.0/extend/approach.md
@@ -20,7 +20,7 @@ We'll dive into each of these more throughout, but at a high level, here's what 
 
 - Components should be responsive and mobile-first
 - Components should be built with a base class and extended via modifier classes
-- Component states should obey a common z-index scale
+<!--- Component states should obey a common z-index scale-->
 - Whenever possible, prefer an HTML and CSS implementation over JavaScript
 - Whenever possible, use utilities over custom styles
 - Whenever possible, avoid enforcing strict HTML requirements (children selectors)
@@ -29,18 +29,21 @@ We'll dive into each of these more throughout, but at a high level, here's what 
 
 OUDS Web's responsive styles are built to be responsive, an approach that's often referred to as _mobile-first_. We use this term in our docs and largely agree with it, but at times it can be too broad. While not every component _must_ be entirely responsive in OUDS Web, this responsive approach is about reducing CSS overrides by pushing you to add styles as the viewport becomes larger.
 
+<!--
 Across OUDS Web, you'll see this most clearly in our media queries. In most cases, we use `min-width` queries that begin to apply at a specific breakpoint and carry up through the higher breakpoints. For example, a `.d-none` applies from `min-width: 0` to infinity. On the other hand, a `.d-md-none` applies from the medium breakpoint and up.
 
 At times we'll use `max-width` when a component's inherent complexity requires it. At times, these overrides are functionally and mentally clearer to implement and support than rewriting core functionality from our components. We strive to limit this approach, but will use it from time to time.
+-->
 
 ## Classes
 
 Aside from our Reboot, a cross-browser normalization stylesheet, all our styles aim to use classes as selectors. This means steering clear of type selectors (e.g., `input[type="text"]`) and extraneous parent classes (e.g., `.parent .child`) that make styles too specific to easily override.
 
-As such, components should be built with a base class that houses common, not-to-be overridden property-value pairs. For example, `.btn` and `.btn-primary`. We use `.btn` for all the common styles like `display`, `padding`, and `border-width`. We then use modifiers like `.btn-primary` to add the color, background-color, border-color, etc.
+As such, components should be built with a base class that houses common, not-to-be overridden property-value pairs. <!--For example, `.btn` and `.btn-primary`. We use `.btn` for all the common styles like `display`, `padding`, and `border-width`. We then use modifiers like `.btn-primary` to add the color, background-color, border-color, etc.-->
 
 Modifier classes should only be used when there are multiple properties or values to be changed across multiple variants. Modifiers are not always necessary, so be sure you're actually saving lines of code and preventing unnecessary overrides when creating them. Good examples of modifiers are our theme color classes and size variants.
 
+<!--
 ## z-index scales
 
 There are two `z-index` scales in OUDS Web—elements within a component and overlay components.
@@ -59,14 +62,15 @@ OUDS Web includes several components that function as an overlay of some kind. T
 Each overlay component increases its `z-index` value slightly in such a way that common UI principles allow user focused or hovered elements to remain in view at all times. For example, a modal is document blocking (e.g., you cannot take any other action save for the modal's action), so we put that above our navbars.
 
 Learn more about this in our [`z-index` layout page]({{< docsref "/layout/z-index" >}}).
+-->
 
 ## HTML and CSS over JS
 
 Whenever possible, we prefer to write HTML and CSS over JavaScript. In general, HTML and CSS are more prolific and accessible to more people of all different experience levels. HTML and CSS are also faster in your browser than JavaScript, and your browser generally provides a great deal of functionality for you.
 
-This principle is our first-class JavaScript API using `data` attributes. You don't need to write nearly any JavaScript to use our JavaScript plugins; instead, write HTML. Read more about this in [our JavaScript overview page]({{< docsref "/getting-started/javascript#data-attributes" >}}).
+This principle is our first-class JavaScript API using `data` attributes. You don't need to write nearly any JavaScript to use our JavaScript plugins; instead, write HTML. <!--Read more about this in [our JavaScript overview page]({{< docsref "/getting-started/javascript#data-attributes" >}}).-->
 
-Lastly, our styles build on the fundamental behaviors of common web elements. Whenever possible, we prefer to use what the browser provides. For example, you can put a `.btn` class on nearly any element, but most elements don't provide any semantic value or browser functionality. So instead, we use `<button>`s and `<a>`s.
+Lastly, our styles build on the fundamental behaviors of common web elements. Whenever possible, we prefer to use what the browser provides. <!--For example, you can put a `.btn` class on nearly any element, but most elements don't provide any semantic value or browser functionality. So instead, we use `<button>`s and `<a>`s.-->
 
 The same goes for more complex components. While we _could_ write our own form validation plugin to add classes to a parent element based on an input's state, thereby allowing us to style the text say red, we prefer using the `:valid`/`:invalid` pseudo-elements every browser provides us.
 

--- a/site/content/docs/0.0/extend/approach.md
+++ b/site/content/docs/0.0/extend/approach.md
@@ -22,7 +22,7 @@ We'll dive into each of these more throughout, but at a high level, here's what 
 - Components should be built with a base class and extended via modifier classes
 <!--- Component states should obey a common z-index scale-->
 - Whenever possible, prefer an HTML and CSS implementation over JavaScript
-- Whenever possible, use utilities over custom styles
+<!--- Whenever possible, use utilities over custom styles-->
 - Whenever possible, avoid enforcing strict HTML requirements (children selectors)
 
 ## Responsive
@@ -76,11 +76,13 @@ The same goes for more complex components. While we _could_ write our own form v
 
 Whenever possible, we prefer to write HTML and CSS over JavaScript. In general, HTML and CSS are more prolific and accessible to more people of all different experience levels. HTML and CSS are also faster in your browser than JavaScript, and your browser generally provides a great deal of functionality for you.
 
+<!--
 ## Utilities
 
 Utility classes are a powerful ally in combating CSS bloat and poor page performance. A utility class is typically a single, immutable property-value pairing expressed as a class (e.g., `.d-block` represents `display: block;`). Their primary appeal is speed of use while writing HTML and limiting the amount of custom CSS you have to write.
 
 Specifically regarding custom CSS, utilities can help combat increasing file size by reducing your most commonly repeated property-value pairs into single classes. This can have a dramatic effect at scale in your projects.
+-->
 
 ## Flexible HTML
 

--- a/site/content/docs/0.0/extend/approach.md
+++ b/site/content/docs/0.0/extend/approach.md
@@ -10,4 +10,82 @@ aliases:
   - "/docs/extend/approach/"
 ---
 
-{{< callout-soon "page" >}}
+While the getting started pages provide an introductory tour of the project and what it offers, this document focuses on _why_ we do the things we do in OUDS Web. It explains our philosophy to building on the web so that others can learn from us, contribute with us, and help us improve.
+
+See something that doesn't sound right, or perhaps could be done better? [Open an issue]({{< param repo >}}/issues/new/choose)—we'd love to discuss it with you.
+
+## Summary
+
+We'll dive into each of these more throughout, but at a high level, here's what guides our approach.
+
+- Components should be responsive and mobile-first
+- Components should be built with a base class and extended via modifier classes
+- Component states should obey a common z-index scale
+- Whenever possible, prefer an HTML and CSS implementation over JavaScript
+- Whenever possible, use utilities over custom styles
+- Whenever possible, avoid enforcing strict HTML requirements (children selectors)
+
+## Responsive
+
+OUDS Web's responsive styles are built to be responsive, an approach that's often referred to as _mobile-first_. We use this term in our docs and largely agree with it, but at times it can be too broad. While not every component _must_ be entirely responsive in OUDS Web, this responsive approach is about reducing CSS overrides by pushing you to add styles as the viewport becomes larger.
+
+Across OUDS Web, you'll see this most clearly in our media queries. In most cases, we use `min-width` queries that begin to apply at a specific breakpoint and carry up through the higher breakpoints. For example, a `.d-none` applies from `min-width: 0` to infinity. On the other hand, a `.d-md-none` applies from the medium breakpoint and up.
+
+At times we'll use `max-width` when a component's inherent complexity requires it. At times, these overrides are functionally and mentally clearer to implement and support than rewriting core functionality from our components. We strive to limit this approach, but will use it from time to time.
+
+## Classes
+
+Aside from our Reboot, a cross-browser normalization stylesheet, all our styles aim to use classes as selectors. This means steering clear of type selectors (e.g., `input[type="text"]`) and extraneous parent classes (e.g., `.parent .child`) that make styles too specific to easily override.
+
+As such, components should be built with a base class that houses common, not-to-be overridden property-value pairs. For example, `.btn` and `.btn-primary`. We use `.btn` for all the common styles like `display`, `padding`, and `border-width`. We then use modifiers like `.btn-primary` to add the color, background-color, border-color, etc.
+
+Modifier classes should only be used when there are multiple properties or values to be changed across multiple variants. Modifiers are not always necessary, so be sure you're actually saving lines of code and preventing unnecessary overrides when creating them. Good examples of modifiers are our theme color classes and size variants.
+
+## z-index scales
+
+There are two `z-index` scales in OUDS Web—elements within a component and overlay components.
+
+### Component elements
+
+- Some components in OUDS Web are built with overlapping elements to prevent double borders without modifying the `border` property. For example, button groups, input groups, and pagination.
+- These components share a standard `z-index` scale of `0` through `3`.
+- `0` is default (initial), `1` is `:hover`, `2` is `:active`/`.active`, and `3` is `:focus`.
+- This approach matches our expectations of highest user priority. If an element is focused, it's in view and at the user's attention. Active elements are second highest because they indicate state. Hover is third highest because it indicates user intent, but nearly _anything_ can be hovered.
+
+### Overlay components
+
+OUDS Web includes several components that function as an overlay of some kind. This includes, in order of highest `z-index`, dropdowns, fixed and sticky navbars, modals, tooltips, and popovers. These components have their own `z-index` scale that begins at `1000`. This starting number was chosen arbitrarily and serves as a small buffer between our styles and your project's custom styles.
+
+Each overlay component increases its `z-index` value slightly in such a way that common UI principles allow user focused or hovered elements to remain in view at all times. For example, a modal is document blocking (e.g., you cannot take any other action save for the modal's action), so we put that above our navbars.
+
+Learn more about this in our [`z-index` layout page]({{< docsref "/layout/z-index" >}}).
+
+## HTML and CSS over JS
+
+Whenever possible, we prefer to write HTML and CSS over JavaScript. In general, HTML and CSS are more prolific and accessible to more people of all different experience levels. HTML and CSS are also faster in your browser than JavaScript, and your browser generally provides a great deal of functionality for you.
+
+This principle is our first-class JavaScript API using `data` attributes. You don't need to write nearly any JavaScript to use our JavaScript plugins; instead, write HTML. Read more about this in [our JavaScript overview page]({{< docsref "/getting-started/javascript#data-attributes" >}}).
+
+Lastly, our styles build on the fundamental behaviors of common web elements. Whenever possible, we prefer to use what the browser provides. For example, you can put a `.btn` class on nearly any element, but most elements don't provide any semantic value or browser functionality. So instead, we use `<button>`s and `<a>`s.
+
+The same goes for more complex components. While we _could_ write our own form validation plugin to add classes to a parent element based on an input's state, thereby allowing us to style the text say red, we prefer using the `:valid`/`:invalid` pseudo-elements every browser provides us.
+
+Whenever possible, we prefer to write HTML and CSS over JavaScript. In general, HTML and CSS are more prolific and accessible to more people of all different experience levels. HTML and CSS are also faster in your browser than JavaScript, and your browser generally provides a great deal of functionality for you.
+
+## Utilities
+
+Utility classes are a powerful ally in combating CSS bloat and poor page performance. A utility class is typically a single, immutable property-value pairing expressed as a class (e.g., `.d-block` represents `display: block;`). Their primary appeal is speed of use while writing HTML and limiting the amount of custom CSS you have to write.
+
+Specifically regarding custom CSS, utilities can help combat increasing file size by reducing your most commonly repeated property-value pairs into single classes. This can have a dramatic effect at scale in your projects.
+
+## Flexible HTML
+
+While not always possible, we strive to avoid being overly dogmatic in our HTML requirements for components. Thus, we focus on single classes in our CSS selectors and try to avoid immediate children selectors (`>`). This gives you more flexibility in your implementation and helps keep our CSS simpler and less specific.
+
+## Code conventions
+
+[Code Guide](https://codeguide.co/) (from Bootstrap co-creator, @mdo) documents how we write our HTML and CSS across OUDS Web. It specifies guidelines for general formatting, common sense defaults, property and attribute orders, and more.
+
+We use [Stylelint](https://stylelint.io/) to enforce these standards and more in our Sass/CSS. [Bootstrap custom Stylelint config](https://github.com/twbs/stylelint-config-twbs-bootstrap) is open source and available for others to use and extend.
+
+We use [vnu-jar](https://www.npmjs.com/package/vnu-jar) to enforce standard and semantic HTML, as well as detecting common errors.

--- a/site/content/docs/0.0/extend/approach.md
+++ b/site/content/docs/0.0/extend/approach.md
@@ -20,9 +20,9 @@ We'll dive into each of these more throughout, but at a high level, here's what 
 
 - Components should be responsive and mobile-first
 - Components should be built with a base class and extended via modifier classes
-<!--- Component states should obey a common z-index scale-->
+- Component states should obey a common z-index scale
 - Whenever possible, prefer an HTML and CSS implementation over JavaScript
-<!--- Whenever possible, use utilities over custom styles-->
+- Whenever possible, use utilities over custom styles
 - Whenever possible, avoid enforcing strict HTML requirements (children selectors)
 
 ## Responsive
@@ -73,8 +73,6 @@ This principle is our first-class JavaScript API using `data` attributes. You do
 Lastly, our styles build on the fundamental behaviors of common web elements. Whenever possible, we prefer to use what the browser provides. <!--For example, you can put a `.btn` class on nearly any element, but most elements don't provide any semantic value or browser functionality. So instead, we use `<button>`s and `<a>`s.-->
 
 The same goes for more complex components. While we _could_ write our own form validation plugin to add classes to a parent element based on an input's state, thereby allowing us to style the text say red, we prefer using the `:valid`/`:invalid` pseudo-elements every browser provides us.
-
-Whenever possible, we prefer to write HTML and CSS over JavaScript. In general, HTML and CSS are more prolific and accessible to more people of all different experience levels. HTML and CSS are also faster in your browser than JavaScript, and your browser generally provides a great deal of functionality for you.
 
 <!--
 ## Utilities

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -259,7 +259,6 @@
   icon_color: body-color
   pages:
     - title: Approach
-      draft: true
     - title: Icons
       draft: true
 


### PR DESCRIPTION
### Related issues

Listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2589

### Description

This PR adds the "Getting Started > Contribute" page based on:
- the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/extend/approach/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/extend/approach.md))
- the [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/extend/approach/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/extend/approach.md))

Please that not all content can be reintroduced in this first PR, as some components or concepts are not yet described in the rest of the documentation.

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2650--boosted.netlify.app/docs/0.0/extend/approach/
