### PR TITLE
[OUDS] Docs: add 'Utilities > Display' page

### DIFF
--- a/site/content/docs/0.0/utilities/display.md
+++ b/site/content/docs/0.0/utilities/display.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Display property
-description: Quickly and responsively toggle the display value of components and more with our display utilities. Includes support for some of the more common values, as well as some extras for controlling display when printing.
+description: Quickly <!--and responsively -->toggle the display value of components and more with our display utilities. Includes support for some of the more common values, as well as some extras for controlling display when printing.
 group: utilities
 aliases:
   - "/docs/utilities/display/"
@@ -10,7 +10,7 @@ toc: true
 
 ## How it works
 
-Change the value of the [`display` property](https://developer.mozilla.org/en-US/docs/Web/CSS/display) with our responsive display utility classes. We purposely support only a subset of all possible values for `display`. Classes can be combined for various effects as you need.
+Change the value of the [`display` property](https://developer.mozilla.org/en-US/docs/Web/CSS/display) with our <!--responsive -->display utility classes. We purposely support only a subset of all possible values for `display`. Classes can be combined for various effects as you need.
 
 ## Notation
 
@@ -19,7 +19,7 @@ Display utility classes that apply to all breakpoints<!-- [breakpoints]({{< docs
 As such, the classes are named using the format:
 
 - `.d-{value}`<!-- for `xs`-->
-- `.d-{breakpoint}-{value}`<!-- for `sm`, `md`, `lg`, `xl`, and `xxl`.-->
+<!--- `.d-{breakpoint}-{value}` for `sm`, `md`, `lg`, `xl`, and `xxl`.-->
 
 Where *value* is one of:
 
@@ -53,7 +53,7 @@ The media queries affect screen widths with the given breakpoint *or larger*. <!
 
 ## Hiding elements
 
-For faster mobile-friendly development, use responsive display classes for showing and hiding elements by device. Avoid creating entirely different versions of the same site, instead hide elements responsively for each screen size.
+<!--For faster mobile-friendly development, use responsive-->Use display classes for showing and hiding elements<!-- by device-->.<!-- Avoid creating entirely different versions of the same site, instead hide elements responsively for each screen size.-->
 
 To hide elements simply use the `.d-none` class<!-- or one of the `.d-{sm,md,lg,xl,xxl}-none` classes for any responsive screen variation-->.
 
@@ -85,7 +85,7 @@ To hide elements simply use the `.d-none` class<!-- or one of the `.d-{sm,md,lg,
 
 ## Display in print
 
-Change the `display` value of elements when printing with our print display utility classes. Includes support for the same `display` values as our responsive `.d-*` utilities.
+Change the `display` value of elements when printing with our print display utility classes. Includes support for the same `display` values as our <!--responsive -->`.d-*` utilities.
 
 - `.d-print-none`
 - `.d-print-inline`

--- a/site/content/docs/0.0/utilities/display.md
+++ b/site/content/docs/0.0/utilities/display.md
@@ -8,4 +8,109 @@ aliases:
 toc: true
 ---
 
-{{< callout-soon "page" >}}
+## How it works
+
+Change the value of the [`display` property](https://developer.mozilla.org/en-US/docs/Web/CSS/display) with our responsive display utility classes. We purposely support only a subset of all possible values for `display`. Classes can be combined for various effects as you need.
+
+## Notation
+
+Display utility classes that apply to all breakpoints<!-- [breakpoints]({{< docsref "/layout/breakpoints" >}}), from `xs` to `xxl`-->, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0;` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.
+
+As such, the classes are named using the format:
+
+- `.d-{value}`<!-- for `xs`-->
+- `.d-{breakpoint}-{value}`<!-- for `sm`, `md`, `lg`, `xl`, and `xxl`.-->
+
+Where *value* is one of:
+
+- `none`
+- `inline`
+- `inline-block`
+- `block`
+- `grid`
+- `inline-grid`
+- `table`
+- `table-cell`
+- `table-row`
+- `flex`
+- `inline-flex`
+
+The display values can be altered by changing the `display` values defined in `$utilities` and recompiling the SCSS.
+
+The media queries affect screen widths with the given breakpoint *or larger*. <!--For example, `.d-lg-none` sets `display: none;` on `lg`, `xl`, and `xxl` screens.-->
+
+## Examples
+
+{{< example >}}
+<div class="d-inline p-2 text-bg-primary">d-inline</div>
+<div class="d-inline p-2 text-bg-dark">d-inline</div>
+{{< /example >}}
+
+{{< example >}}
+<span class="d-block p-2 text-bg-primary">d-block</span>
+<span class="d-block p-2 text-bg-dark">d-block</span>
+{{< /example >}}
+
+## Hiding elements
+
+For faster mobile-friendly development, use responsive display classes for showing and hiding elements by device. Avoid creating entirely different versions of the same site, instead hide elements responsively for each screen size.
+
+To hide elements simply use the `.d-none` class<!-- or one of the `.d-{sm,md,lg,xl,xxl}-none` classes for any responsive screen variation-->.
+
+<!--To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none .d-md-block .d-xl-none .d-xxl-none` will hide the element for all screen sizes except on medium and large devices.-->
+
+{{< bs-table >}}
+| Screen size | Class |
+| --- | --- |
+| Hidden on all | `.d-none` |
+| Visible on all | `.d-block` |
+<!--| Hidden only on xs | `.d-none .d-sm-block` |
+| Hidden only on sm | `.d-sm-none .d-md-block` |
+| Hidden only on md | `.d-md-none .d-lg-block` |
+| Hidden only on lg | `.d-lg-none .d-xl-block` |
+| Hidden only on xl | `.d-xl-none .d-xxl-block` |
+| Hidden only on xxl | `.d-xxl-none` |-->
+<!--| Visible only on xs | `.d-block .d-sm-none` |
+| Visible only on sm | `.d-none .d-sm-block .d-md-none` |
+| Visible only on md | `.d-none .d-md-block .d-lg-none` |
+| Visible only on lg | `.d-none .d-lg-block .d-xl-none` |
+| Visible only on xl | `.d-none .d-xl-block .d-xxl-none` |
+| Visible only on xxl | `.d-none .d-xxl-block` |-->
+{{< /bs-table >}}
+
+<!--{{< example >}}
+<div class="d-lg-none">hide on lg and wider screens</div>
+<div class="d-none d-lg-block">hide on screens smaller than lg</div>
+{{< /example >}}-->
+
+## Display in print
+
+Change the `display` value of elements when printing with our print display utility classes. Includes support for the same `display` values as our responsive `.d-*` utilities.
+
+- `.d-print-none`
+- `.d-print-inline`
+- `.d-print-inline-block`
+- `.d-print-block`
+- `.d-print-grid`
+- `.d-print-inline-grid`
+- `.d-print-table`
+- `.d-print-table-row`
+- `.d-print-table-cell`
+- `.d-print-flex`
+- `.d-print-inline-flex`
+
+The print and display classes can be combined.
+
+{{< example >}}
+<div class="d-print-none">Screen Only (Hide on print only)</div>
+<div class="d-none d-print-block">Print Only (Hide on screen only)</div>
+<!--<div class="d-none d-lg-block d-print-block">Hide up to large on screen, but always show on print</div>-->
+{{< /example >}}
+
+## CSS
+
+### Sass utilities API
+
+Display utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
+
+{{< scss-docs name="utils-display" file="scss/_utilities.scss" >}}

--- a/site/content/docs/0.0/utilities/display.md
+++ b/site/content/docs/0.0/utilities/display.md
@@ -14,9 +14,9 @@ Change the value of the [`display` property](https://developer.mozilla.org/en-US
 
 ## Notation
 
-Display utility classes that apply to all breakpoints<!-- [breakpoints]({{< docsref "/layout/breakpoints" >}}), from `xs` to `xxl`-->, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0;` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.
+<!--Display utility classes that apply to all [breakpoints]({{< docsref "/layout/breakpoints" >}}), from `xs` to `xxl`, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0;` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.-->
 
-As such, the classes are named using the format:
+<!--As such, t-->The classes are named using the format:
 
 - `.d-{value}`<!-- for `xs`-->
 <!--- `.d-{breakpoint}-{value}` for `sm`, `md`, `lg`, `xl`, and `xxl`.-->
@@ -37,9 +37,9 @@ Where *value* is one of:
 
 The display values can be altered by changing the `display` values defined in `$utilities` and recompiling the SCSS.
 
-The media queries affect screen widths with the given breakpoint *or larger*. <!--For example, `.d-lg-none` sets `display: none;` on `lg`, `xl`, and `xxl` screens.-->
+<!--The media queries affect screen widths with the given breakpoint *or larger*. For example, `.d-lg-none` sets `display: none;` on `lg`, `xl`, and `xxl` screens.-->
 
-## Examples
+<!--## Examples
 
 {{< example >}}
 <div class="d-inline p-2 text-bg-primary">d-inline</div>
@@ -49,7 +49,7 @@ The media queries affect screen widths with the given breakpoint *or larger*. <!
 {{< example >}}
 <span class="d-block p-2 text-bg-primary">d-block</span>
 <span class="d-block p-2 text-bg-dark">d-block</span>
-{{< /example >}}
+{{< /example >}}-->
 
 ## Hiding elements
 

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -221,7 +221,6 @@
     - title: Colors
       draft: true
     - title: Display
-      draft: true
     - title: Flex
       draft: true
     - title: Float


### PR DESCRIPTION
### Related issues

Listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2589.

### Description

This PR adds the "Utilities > Display" page based on:
- the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/utilities/display/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/utilities/display.md))
- the [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/utilities/display/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/utilities/display.md))

The remaining code will be added once the responsive part of the CSS is added in the OUDS Web CSS.

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2659--boosted.netlify.app/docs/0.0/utilities/display/