### PR TITLE
[OUDS] Docs: add 'Utilities > Float' page

### DIFF
--- a/site/content/docs/0.0/utilities/float.md
+++ b/site/content/docs/0.0/utilities/float.md
@@ -8,4 +8,46 @@ aliases:
 toc: true
 ---
 
-{{< callout-soon "page" >}}
+## Overview
+
+These utility classes float an element to the left or right, or disable floating, based on the current viewport size using the [CSS `float` property](https://developer.mozilla.org/en-US/docs/Web/CSS/float). `!important` is included to avoid specificity issues. These use the same viewport breakpoints as our grid system. Please be aware float utilities have no effect on flex items.
+
+{{< example >}}
+<div class="float-start">Float start on all viewport sizes</div><br>
+<div class="float-end">Float end on all viewport sizes</div><br>
+<div class="float-none">Don't float on all viewport sizes</div>
+{{< /example >}}
+
+<!--Use the [clearfix helper]({{< docsref "/helpers/clearfix" >}}) on a parent element to clear floats.-->
+
+<!--## Responsive
+
+Responsive variations also exist for each `float` value.
+
+{{< example >}}
+<div class="float-sm-end">Float end on viewports sized SM (small) or wider</div><br>
+<div class="float-md-end">Float end on viewports sized MD (medium) or wider</div><br>
+<div class="float-lg-end">Float end on viewports sized LG (large) or wider</div><br>
+<div class="float-xl-end">Float end on viewports sized XL (extra large) or wider</div><br>
+<div class="float-xxl-end">Float end on viewports sized XXL (extra extra large) or wider</div><br>
+{{< /example >}}
+
+Here are all the support classes:
+
+{{< markdown >}}
+{{< float.inline >}}
+{{- range $.Site.Data.breakpoints }}
+- `.float{{ .abbr }}-start`
+- `.float{{ .abbr }}-end`
+- `.float{{ .abbr }}-none`
+{{- end -}}
+{{< /float.inline >}}
+{{< /markdown >}}-->
+
+## CSS
+
+### Sass utilities API
+
+Float utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
+
+{{< scss-docs name="utils-float" file="scss/_utilities.scss" >}}

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -224,7 +224,6 @@
       draft: true
     - title: Flex
     - title: Float
-      draft: true
     - title: Interactions
       draft: true
     - title: Link


### PR DESCRIPTION
### Related issues

Listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2589.

### Description

This PR adds the "Utilities > Float" page based on:
- the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/utilities/float/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/utilities/float.md))
- the [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/utilities/float/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/utilities/float.md))

The remaining code will be added once the responsive part or the clearfix helper of the CSS is added in the OUDS Web CSS.

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2661--boosted.netlify.app/docs/0.0/utilities/float/