### PR TITLE
[OUDS] Docs: add 'Utilities > Interactions' page

### DIFF
--- a/site/content/docs/0.0/utilities/interactions.md
+++ b/site/content/docs/0.0/utilities/interactions.md
@@ -8,4 +8,37 @@ aliases:
 toc: false
 ---
 
-{{< callout-soon "page" >}}
+## Text selection
+
+Change the way in which the content is selected when the user interacts with it.
+
+{{< example >}}
+<p class="user-select-all">This paragraph will be entirely selected when clicked by the user.</p>
+<p class="user-select-auto">This paragraph has default select behavior.</p>
+<p class="user-select-none">This paragraph will not be selectable when clicked by the user.</p>
+{{< /example >}}
+
+## Pointer events
+
+OUDS Web provides `.pe-none` and `.pe-auto` classes to prevent or add element interactions.
+
+{{< example >}}
+<p><a href="#" class="pe-none" tabindex="-1" aria-disabled="true">This link</a> can not be clicked.</p>
+<p><a href="#" class="pe-auto">This link</a> can be clicked (this is default behavior).</p>
+<p class="pe-none"><a href="#" tabindex="-1" aria-disabled="true">This link</a> can not be clicked because the <code>pointer-events</code> property is inherited from its parent. However, <a href="#" class="pe-auto">this link</a> has a <code>pe-auto</code> class and can be clicked.</p>
+{{< /example >}}
+
+The `.pe-none` class (and the `pointer-events` CSS property it sets) only prevents interactions with a pointer (mouse, stylus, touch). Links and controls with `.pe-none` are, by default, still focusable and actionable for keyboard users. To ensure that they are completely neutralized even for keyboard users, you may need to add further attributes such as `tabindex="-1"` (to prevent them from receiving keyboard focus) and `aria-disabled="true"` (to convey the fact they are effectively disabled to assistive technologies), and possibly use JavaScript to completely prevent them from being actionable.
+
+If possible, the simpler solution is:
+
+- For form controls, add the `disabled` HTML attribute.
+- For links, remove the `href` attribute, making it a non-interactive anchor or placeholder link.
+
+## CSS
+
+### Sass utilities API
+
+Interaction utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
+
+{{< scss-docs name="utils-interaction" file="scss/_utilities.scss" >}}

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -226,7 +226,6 @@
     - title: Float
       draft: true
     - title: Interactions
-      draft: true
     - title: Link
       draft: true
     - title: Object fit


### PR DESCRIPTION
### Related issues

Listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2589.

### Description

This PR adds the "Utilities > Interactions" page based on:
- the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/utilities/interactions/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/utilities/interactions.md))
- the [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/utilities/interactions/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/utilities/interactions.md))

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2662--boosted.netlify.app/docs/0.0/utilities/interactions/