### PR TITLE
[OUDS] Docs: add 'Utilities > Vertical align' page

### DIFF
--- a/site/content/docs/0.0/utilities/vertical-align.md
+++ b/site/content/docs/0.0/utilities/vertical-align.md
@@ -7,4 +7,44 @@ aliases:
   - "/docs/utilities/vertical-align/"
 ---
 
-{{< callout-soon "page" >}}
+Change the alignment of elements with the [`vertical-alignment`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) utilities. Please note that vertical-align only affects inline, inline-block, inline-table, and table cell elements.
+
+Choose from `.align-baseline`, `.align-top`, `.align-middle`, `.align-bottom`, `.align-text-bottom`, and `.align-text-top` as needed.
+
+To vertically center non-inline content (like `<div>`s and more), use our [flex box utilities]({{< docsref "/utilities/flex#align-items" >}}).
+
+With inline elements:
+
+{{< example >}}
+<span class="align-baseline">baseline</span>
+<span class="align-top">top</span>
+<span class="align-middle">middle</span>
+<span class="align-bottom">bottom</span>
+<span class="align-text-top">text-top</span>
+<span class="align-text-bottom">text-bottom</span>
+{{< /example >}}
+
+With table cells:
+
+{{< example >}}
+<table style="height: 100px;">
+  <tbody>
+    <tr>
+      <td class="align-baseline">baseline</td>
+      <td class="align-top">top</td>
+      <td class="align-middle">middle</td>
+      <td class="align-bottom">bottom</td>
+      <td class="align-text-top">text-top</td>
+      <td class="align-text-bottom">text-bottom</td>
+    </tr>
+  </tbody>
+</table>
+{{< /example >}}
+
+## CSS
+
+### Sass utilities API
+
+Vertical align utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
+
+{{< scss-docs name="utils-vertical-align" file="scss/_utilities.scss" >}}

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -246,7 +246,6 @@
     - title: Text
       draft: true
     - title: Vertical align
-      draft: true
     - title: Visibility
     - title: Z-index
       draft: true


### PR DESCRIPTION
### Related issues

Listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2589.

### Description

This PR adds the "Utilities > Vertical align" page based on:
- the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/utilities/vertical-align/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/utilities/vertical-align.md))
- the [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/utilities/vertical-align/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/utilities/vertical-align.md))

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2668--boosted.netlify.app/docs/0.0/utilities/vertical-align/