### PR TITLE
[OUDS] Docs: add 'Utilities > Z-index' page

### DIFF
--- a/site/content/docs/0.0/utilities/z-index.md
+++ b/site/content/docs/0.0/utilities/z-index.md
@@ -8,18 +8,18 @@ toc: true
 
 ## Example
 
-Use `z-index` utilities to stack elements on top of one another. Requires a `position` value other than `static`, which can be set with custom styles<!-- or using our [position utilities]({{< docsref "/utilities/position/" >}})-->.
+Use `z-index` utilities to stack elements on top of one another. Requires a `position` value other than `static`, which can be set with custom styles or using our [position utilities]({{< docsref "/utilities/position/" >}}).
 
 {{< callout >}}
 We call these "low-level" `z-index` utilities because of their default values of `-1` through `3`, which we use for the layout of overlapping components. <!--High-level `z-index` values are used for overlay components like modals and tooltips.-->
 {{< /callout >}}
 
 {{< example class="bd-example-zindex-levels position-relative" >}}
-<div class="z-3 position-absolute p-5 rounded-3"><span>z-3</span></div>
-<div class="z-2 position-absolute p-5 rounded-3"><span>z-2</span></div>
-<div class="z-1 position-absolute p-5 rounded-3"><span>z-1</span></div>
-<div class="z-0 position-absolute p-5 rounded-3"><span>z-0</span></div>
-<div class="z-n1 position-absolute p-5 rounded-3"><span>z-n1</span></div>
+<div class="z-3 position-absolute p-5"><span>z-3</span></div>
+<div class="z-2 position-absolute p-5"><span>z-2</span></div>
+<div class="z-1 position-absolute p-5"><span>z-1</span></div>
+<div class="z-0 position-absolute p-5"><span>z-0</span></div>
+<div class="z-n1 position-absolute p-5"><span>z-n1</span></div>
 {{< /example >}}
 
 <!--## Overlays

--- a/site/content/docs/0.0/utilities/z-index.md
+++ b/site/content/docs/0.0/utilities/z-index.md
@@ -6,4 +6,44 @@ group: utilities
 toc: true
 ---
 
-{{< callout-soon "page" >}}
+## Example
+
+Use `z-index` utilities to stack elements on top of one another. Requires a `position` value other than `static`, which can be set with custom styles<!-- or using our [position utilities]({{< docsref "/utilities/position/" >}})-->.
+
+{{< callout >}}
+We call these "low-level" `z-index` utilities because of their default values of `-1` through `3`, which we use for the layout of overlapping components. <!--High-level `z-index` values are used for overlay components like modals and tooltips.-->
+{{< /callout >}}
+
+{{< example class="bd-example-zindex-levels position-relative" >}}
+<div class="z-3 position-absolute p-5 rounded-3"><span>z-3</span></div>
+<div class="z-2 position-absolute p-5 rounded-3"><span>z-2</span></div>
+<div class="z-1 position-absolute p-5 rounded-3"><span>z-1</span></div>
+<div class="z-0 position-absolute p-5 rounded-3"><span>z-0</span></div>
+<div class="z-n1 position-absolute p-5 rounded-3"><span>z-n1</span></div>
+{{< /example >}}
+
+<!--## Overlays
+
+OUDS Web overlay components—dropdown, modal, offcanvas, popover, toast, and tooltip—all have their own `z-index` values to ensure a usable experience with competing "layers" of an interface.
+
+Read about them in the [`z-index` layout page]({{< docsref "/layout/z-index" >}}).-->
+
+<!--## Component approach
+
+On some components, we use our low-level `z-index` values to manage repeating elements that overlap one another (like buttons in a button group or items in a list group).
+
+Learn about our [`z-index` approach]({{< docsref "/extend/approach#z-index-scales" >}}).-->
+
+## CSS
+
+### Sass maps
+
+Customize this Sass map to change the available values and generated utilities.
+
+{{< scss-docs name="zindex-levels-map" file="scss/_variables.scss" >}}
+
+### Sass utilities API
+
+Position utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
+
+{{< scss-docs name="utils-zindex" file="scss/_utilities.scss" >}}

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -249,7 +249,6 @@
       draft: true
     - title: Visibility
     - title: Z-index
-      draft: true
 
 - title: Extend
   icon: tools

--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -1,4 +1,4 @@
-<nav class="bd-links w-100" id="bd-docs-nav" aria-label="Docs navigation">
+<nav class="bd-links w-100 pb-2" id="bd-docs-nav" aria-label="Docs navigation">
   {{- $url := split .Permalink "/" -}}
   {{- $page_slug := index $url (sub (len $url) 2) -}}
 

--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -1,4 +1,4 @@
-<nav class="bd-links w-100 pb-2" id="bd-docs-nav" aria-label="Docs navigation">
+<nav class="bd-links w-100" id="bd-docs-nav" aria-label="Docs navigation">
   {{- $url := split .Permalink "/" -}}
   {{- $page_slug := index $url (sub (len $url) 2) -}}
 


### PR DESCRIPTION
### Related issues

Listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2589.

### Description

This PR adds the "Utilities > Z-index" page based on:
- the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/utilities/z-index/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/utilities/z-index.md))
- the [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/utilities/z-index/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/utilities/z-index.md))

The remaining code will be added once the z-index component overlays will be added in the OUDS Web CSS.
`.rounded-3` could be reintegrated when the border-radius will be reintegrated in OUDS Web.

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2669--boosted.netlify.app/docs/0.0/utilities/z-index/