### PR TITLE
[OUDS] Docs: add 'Helpers > Text truncation' page

### DIFF
--- a/site/content/docs/0.0/helpers/text-truncation.md
+++ b/site/content/docs/0.0/helpers/text-truncation.md
@@ -8,4 +8,18 @@ aliases:
 toc: false
 ---
 
-{{< callout-soon "helper" >}}
+For longer content, you can add a `.text-truncate` class to truncate the text with an ellipsis. **Requires `display: inline-block` or `display: block`.**
+
+{{< example >}}
+<!-- Block level -->
+<div class="row">
+  <div class="col-2 text-truncate">
+    This text is quite long, and will be truncated once displayed.
+  </div>
+</div>
+
+<!-- Inline level -->
+<span class="d-inline-block text-truncate" style="max-width: 150px;">
+  This text is quite long, and will be truncated once displayed.
+</span>
+{{< /example >}}

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -203,7 +203,6 @@
     - title: Stretched link
       draft: true
     - title: Text truncation
-      draft: true
     - title: Vertical rule
       draft: true
     - title: Visually hidden


### PR DESCRIPTION
### Related issues

Listed in #2589.

### Description

This PR adds the "Helpers > Text truncation" page based on:
 - the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/helpers/text-truncation/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/helpers/text-truncation.md))
 - the previous [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/helpers/text-truncation/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/helpers/text-truncation.md))

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- <https://deploy-preview-2670--boosted.netlify.app/docs/0.0/helpers/text-truncation/>
