### PR TITLE
[OUDS] Docs: Add 'Helper > Position' page

### DIFF
--- a/site/content/docs/0.0/helpers/position.md
+++ b/site/content/docs/0.0/helpers/position.md
@@ -8,4 +8,58 @@ aliases:
 toc: true
 ---
 
-{{< callout-soon "helper" >}}
+## Fixed top
+
+Position an element at the top of the viewport, from edge to edge. Be sure you understand the ramifications of fixed position in your project; you may need to add additional CSS.
+
+```html
+<div class="fixed-top">...</div>
+```
+
+## Fixed bottom
+
+Position an element at the bottom of the viewport, from edge to edge. Be sure you understand the ramifications of fixed position in your project; you may need to add additional CSS.
+
+```html
+<div class="fixed-bottom">...</div>
+```
+
+## Sticky top
+
+Position an element at the top of the viewport, from edge to edge, but only after you scroll past it.
+
+```html
+<div class="sticky-top">...</div>
+```
+
+<!--## Responsive sticky top
+
+Responsive variations also exist for `.sticky-top` utility.
+
+```html
+<div class="sticky-sm-top">Stick to the top on viewports sized SM (small) or wider</div>
+<div class="sticky-md-top">Stick to the top on viewports sized MD (medium) or wider</div>
+<div class="sticky-lg-top">Stick to the top on viewports sized LG (large) or wider</div>
+<div class="sticky-xl-top">Stick to the top on viewports sized XL (extra-large) or wider</div>
+<div class="sticky-xxl-top">Stick to the top on viewports sized XXL (extra-extra-large) or wider</div>
+```-->
+
+## Sticky bottom
+
+Position an element at the bottom of the viewport, from edge to edge, but only after you scroll past it.
+
+```html
+<div class="sticky-bottom">...</div>
+```
+
+<!--## Responsive sticky bottom
+
+Responsive variations also exist for `.sticky-bottom` utility.
+
+```html
+<div class="sticky-sm-bottom">Stick to the bottom on viewports sized SM (small) or wider</div>
+<div class="sticky-md-bottom">Stick to the bottom on viewports sized MD (medium) or wider</div>
+<div class="sticky-lg-bottom">Stick to the bottom on viewports sized LG (large) or wider</div>
+<div class="sticky-xl-bottom">Stick to the bottom on viewports sized XL (extra-large) or wider</div>
+<div class="sticky-xxl-bottom">Stick to the bottom on viewports sized XXL (extra-extra-large) or wider</div>
+```-->

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -195,7 +195,6 @@
     - title: Icon link
       draft: true
     - title: Position
-      draft: true
     - title: Ratio
       draft: true
     - title: Stacks


### PR DESCRIPTION
### Related issues

Listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2589.

### Description

This PR adds the "Helper > Position" page based on:
- the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/helpers/position/)(see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/helpers/position.md))
- the [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/helper/position/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/helper/position.md))

The remaining code will be added once the responsive part of the CSS is added in the OUDS Web CSS.

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2672--boosted.netlify.app/docs/0.0/helpers/position/