### PR TITLE
[OUDS] Docs: add 'Helpers > Clearfix' page

### DIFF
--- a/site/content/docs/0.0/helpers/clearfix.md
+++ b/site/content/docs/0.0/helpers/clearfix.md
@@ -4,10 +4,37 @@ title: Clearfix
 description: Quickly and easily clear floated content within a container by adding a clearfix utility.
 group: helpers
 aliases:
-  - "/helpers/"
-  - "/docs/helpers/"
-  - "/docs/0.0/helpers/"
-  - "/docs/helpers/clearfix/"
+- "/helpers/"
+- "/docs/helpers/"
+- "/docs/0.0/helpers/"
+- "/docs/helpers/clearfix/"
 ---
 
-{{< callout-soon "helper" >}}
+Easily clear `float`s by adding `.clearfix` **to the parent element**. Can also be used as a mixin.
+
+Use in HTML:
+
+```html
+<div class="clearfix">...</div>
+```
+
+The mixin source code:
+
+{{< scss-docs name="clearfix" file="scss/mixins/_clearfix.scss" >}}
+
+Use the mixin in SCSS:
+
+```scss
+.element {
+  @include clearfix;
+}
+```
+
+The following example shows how the clearfix can be used. Without the clearfix the wrapping div would not span around the buttons which would cause a broken layout.
+
+{{< example >}}
+<div class="bg-info clearfix">
+  <button type="button" class="btn btn-secondary float-start">Example Button floated left</button>
+  <button type="button" class="btn btn-secondary float-end">Example Button floated right</button>
+</div>
+{{< /example >}}

--- a/site/content/docs/0.0/helpers/clearfix.md
+++ b/site/content/docs/0.0/helpers/clearfix.md
@@ -4,10 +4,10 @@ title: Clearfix
 description: Quickly and easily clear floated content within a container by adding a clearfix utility.
 group: helpers
 aliases:
-- "/helpers/"
-- "/docs/helpers/"
-- "/docs/0.0/helpers/"
-- "/docs/helpers/clearfix/"
+  - "/helpers/"
+  - "/docs/helpers/"
+  - "/docs/0.0/helpers/"
+  - "/docs/helpers/clearfix/"
 ---
 
 Easily clear `float`s by adding `.clearfix` **to the parent element**. Can also be used as a mixin.
@@ -30,11 +30,11 @@ Use the mixin in SCSS:
 }
 ```
 
-The following example shows how the clearfix can be used. Without the clearfix the wrapping div would not span around the buttons which would cause a broken layout.
+<!-- The following example shows how the clearfix can be used. Without the clearfix the wrapping div would not span around the buttons which would cause a broken layout.
 
 {{< example >}}
 <div class="bg-info clearfix">
   <button type="button" class="btn btn-secondary float-start">Example Button floated left</button>
   <button type="button" class="btn btn-secondary float-end">Example Button floated right</button>
 </div>
-{{< /example >}}
+{{< /example >}} -->

--- a/site/content/docs/0.0/utilities/float.md
+++ b/site/content/docs/0.0/utilities/float.md
@@ -18,7 +18,7 @@ These utility classes float an element to the left or right, or disable floating
 <div class="float-none">Don't float on all viewport sizes</div>
 {{< /example >}}
 
-<!--Use the [clearfix helper]({{< docsref "/helpers/clearfix" >}}) on a parent element to clear floats.-->
+Use the [clearfix helper]({{< docsref "/helpers/clearfix" >}}) on a parent element to clear floats.
 
 <!--## Responsive
 

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -185,7 +185,6 @@
   icon_color: body-color
   pages:
     - title: Clearfix
-      draft: true
     - title: Color & background
       draft: true
     - title: Colored links


### PR DESCRIPTION
### Related issues

Listed in #2589.

### Description

This PR adds the "Helpers > Clearfix" page based on:
 - the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/helpers/clearfix/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/helpers/clearfix.md))
 - the previous [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/helpers/clearfix/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/helpers/clearfix.md))

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- <https://deploy-preview-2673--boosted.netlify.app/docs/0.0/helpers/clearfix/>