### PR TITLE
[OUDS] Docs: add 'Helpers > Visually Hidden' page

### DIFF
--- a/site/content/docs/0.0/helpers/visually-hidden.md
+++ b/site/content/docs/0.0/helpers/visually-hidden.md
@@ -9,4 +9,24 @@ aliases:
   - "/docs/0.0/helpers/screen-readers/"
 ---
 
-{{< callout-soon "helper" >}}
+Visually hide an element while still allowing it to be exposed to assistive technologies (such as screen readers) with `.visually-hidden`. Use `.visually-hidden-focusable` to visually hide an element by default, but to display it when it's focused (e.g. by a keyboard-only user). `.visually-hidden-focusable` can also be applied to a container–thanks to `:focus-within`, the container will be displayed when any child element of the container receives focus.
+
+{{< example >}}
+<h2 class="visually-hidden">Title for screen readers</h2>
+<a class="visually-hidden-focusable" href="#content">Skip to main content</a>
+<div class="visually-hidden-focusable">A container with a <a href="#">focusable element</a>.</div>
+{{< /example >}}
+
+Both `visually-hidden` and `visually-hidden-focusable` can also be used as mixins.
+
+```scss
+// Usage as a mixin
+
+.visually-hidden-title {
+  @include visually-hidden;
+}
+
+.skip-navigation {
+  @include visually-hidden-focusable;
+}
+```

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -205,7 +205,6 @@
     - title: Vertical rule
       draft: true
     - title: Visually hidden
-      draft: true
 
 - title: Utilities
   icon: braces-asterisk


### PR DESCRIPTION
### Related issues

Listed in #2589.

### Description

This PR adds the "Helpers > Visually hidden" page based on:
 - the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/helpers/visually-hidden/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/helpers/visually-hidden.md))
 - the previous [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/helpers/visually-hidden/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/helpers/visually-hidden.md))

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- <https://deploy-preview-2674--boosted.netlify.app/docs/0.0/helpers/visually-hidden/>
