### PR TITLE
[OUDS] Docs(helpers): add 'Stacks' page

### DIFF
--- a/site/content/docs/0.0/helpers/stacks.md
+++ b/site/content/docs/0.0/helpers/stacks.md
@@ -73,10 +73,10 @@ Use `.vstack` to stack buttons and other elements:
 Create an inline form with `.hstack`:
 
 <details>
-<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
+<summary>See Bootstrap examples that are incompatible with Orange Unified Design System.</summary>
 <br>
 {{< design-callout-alert >}}
-This variant with an **horizontal layout** (i.e. labels not above the input fields) should not be used because it does not respect the Orange Design System specifications.
+This variant with an **horizontal layout** (i.e. labels not above the input fields) should not be used because it does not respect the Orange Unified Design System specifications.
 {{< /design-callout-alert >}}
 
 {{< example >}}

--- a/site/content/docs/0.0/helpers/stacks.md
+++ b/site/content/docs/0.0/helpers/stacks.md
@@ -8,4 +8,87 @@ aliases:
 toc: true
 ---
 
-{{< callout-soon "helper" >}}
+Stacks offer a shortcut for applying a number of flexbox properties to quickly and easily create layouts in OUDS Web. All credit for the concept and implementation goes to the open source [Pylon project](https://almonk.github.io/pylon/).
+
+{{< callout warning >}}
+**Heads up!** Support for gap utilities with flexbox was recently added to Safari, so consider verifying your intended browser support. Grid layout should have no issues. [Read more](https://caniuse.com/flexbox-gap).
+{{< /callout >}}
+
+## Vertical
+
+Use `.vstack` to create vertical layouts. Stacked items are full-width by default. Use `.gap-*` utilities to add space between items.
+
+{{< example class="bd-example-flex" >}}
+<div class="vstack gap-3">
+  <div class="p-2">First item</div>
+  <div class="p-2">Second item</div>
+  <div class="p-2">Third item</div>
+</div>
+{{< /example >}}
+
+## Horizontal
+
+Use `.hstack` for horizontal layouts. Stacked items are vertically centered by default and only take up their necessary width. Use `.gap-*` utilities to add space between items.
+
+{{< example class="bd-example-flex" >}}
+<div class="hstack gap-3">
+  <div class="p-2">First item</div>
+  <div class="p-2">Second item</div>
+  <div class="p-2">Third item</div>
+</div>
+{{< /example >}}
+
+Using horizontal margin utilities like `.ms-auto` as spacers:
+
+{{< example class="bd-example-flex" >}}
+<div class="hstack gap-3">
+  <div class="p-2">First item</div>
+  <div class="p-2 ms-auto">Second item</div>
+  <div class="p-2">Third item</div>
+</div>
+{{< /example >}}
+
+<!--And with [vertical rules]({{< docsref "/helpers/vertical-rule" >}}):
+
+{{< example class="bd-example-flex" >}}
+<div class="hstack gap-3">
+  <div class="p-2">First item</div>
+  <div class="p-2 ms-auto">Second item</div>
+  <div class="vr"></div>
+  <div class="p-2">Third item</div>
+</div>
+{{< /example >}}-->
+
+<!--## Examples
+
+Use `.vstack` to stack buttons and other elements:
+
+{{< example >}}
+<div class="vstack gap-2 col-md-5 mx-auto">
+  <button type="button" class="btn btn-primary">Save changes</button>
+  <button type="button" class="btn btn-outline-secondary">Cancel</button>
+</div>
+{{< /example >}}
+
+Create an inline form with `.hstack`:
+
+<details>
+<summary>See Bootstrap examples that are incompatible with Orange Design System.</summary>
+<br>
+{{< design-callout-alert >}}
+This variant with an **horizontal layout** (i.e. labels not above the input fields) should not be used because it does not respect the Orange Design System specifications.
+{{< /design-callout-alert >}}
+
+{{< example >}}
+<div class="hstack gap-3">
+  <input class="form-control me-auto" type="text" placeholder="Add your item here..." aria-label="Add your item here...">
+  <button type="button" class="btn btn-primary">Submit</button>
+  <div class="vr"></div>
+  <button type="button" class="btn btn-outline-secondary">Reset</button>
+</div>
+{{< /example >}}
+</details>-->
+
+## CSS
+
+{{< scss-docs name="stacks" file="scss/helpers/_stacks.scss" >}}

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -196,7 +196,6 @@
     - title: Ratio
       draft: true
     - title: Stacks
-      draft: true
     - title: Stretched link
       draft: true
     - title: Text truncation


### PR DESCRIPTION
### Related issues

Listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2589.

### Description

This PR adds the "Helpers > Stacks" page based on:
- the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/helpers/stacks/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/helpers/stacks.md))
- the [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/helpers/stacks/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/helpers/stacks.md))

#### To add to #2589 

- Uncomment elements whenever `/helpers/vertical-rule` is added
- Uncomment elements whenever buttons are developed
- Uncomment elements whenever inputs are developed

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2681--boosted.netlify.app/docs/0.0/helpers/stacks