### PR TITLE
[OUDS] Docs: Add 'Getting started > Browsers & devices' page

### DIFF
--- a/site/content/docs/0.0/getting-started/browsers-devices.md
+++ b/site/content/docs/0.0/getting-started/browsers-devices.md
@@ -14,7 +14,7 @@ OUDS Web supports the **latest, stable releases** of all major browsers and plat
 
 Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform's web view API, are not explicitly supported. However, OUDS Web should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
 
-You can find our supported range of browsers and their versions [in our `.browserslistrc file`]({{< param repo >}}/blob/v{{< param current_version >}}/.browserslistrc):
+You can find our supported range of browsers and their versions [in our `.browserslistrc file`]({{< param repo >}}/blob/v{{< param current_version >}}-ouds-web/.browserslistrc):
 
 ```text
 {{< rf.inline >}}

--- a/site/content/docs/0.0/getting-started/browsers-devices.md
+++ b/site/content/docs/0.0/getting-started/browsers-devices.md
@@ -8,4 +8,74 @@ aliases:
 toc: true
 ---
 
-{{< callout-soon "page" >}}
+## Supported browsers
+
+OUDS Web supports the **latest, stable releases** of all major browsers and platforms.
+
+Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform's web view API, are not explicitly supported. However, OUDS Web should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
+
+You can find our supported range of browsers and their versions [in our `.browserslistrc file`]({{< param repo >}}/blob/v{{< param current_version >}}/.browserslistrc):
+
+```text
+{{< rf.inline >}}
+{{- readFile ".browserslistrc" | chomp | htmlEscape -}}
+{{< /rf.inline >}}
+```
+
+We use [Autoprefixer](https://github.com/postcss/autoprefixer) to handle intended browser support via CSS prefixes, which uses [Browserslist](https://github.com/browserslist/browserslist) to manage these browser versions. Consult their documentation for how to integrate these tools into your projects.
+
+### Mobile devices
+
+Generally speaking, OUDS Web supports the latest versions of each major platform's default browsers. Note that proxy browsers (such as Opera Mini, Opera Mobile's Turbo mode, UC Browser Mini, Amazon Silk) are not supported.
+
+{{< bs-table "table" >}}
+| | Chrome | Firefox | Safari | Android Browser &amp; WebView |
+| --- | --- | --- | --- | --- |
+| **Android** | Supported | Supported | <span class="text-body-secondary">&mdash;</span> | v6.0+ |
+| **iOS** | Supported | Supported | Supported | <span class="text-body-secondary">&mdash;</span> |
+{{< /bs-table >}}
+
+### Desktop browsers
+
+Similarly, the latest versions of most desktop browsers are supported.
+
+{{< bs-table "table" >}}
+| | Chrome | Firefox | Microsoft Edge | Opera | Safari |
+| --- | --- | --- | --- | --- | --- |
+| **Mac** | Supported | Supported | Supported | Supported | Supported |
+| **Windows** | Supported | Supported | Supported | Supported | <span class="text-body-secondary">&mdash;</span> |
+{{< /bs-table >}}
+
+For Firefox, in addition to the latest normal stable release, we also support the latest [Extended Support Release (ESR)](https://www.mozilla.org/en-US/firefox/enterprise/) version of Firefox.
+
+Unofficially, OUDS Web should look and behave well enough in Chromium and Chrome for Linux, and Firefox for Linux, though they are not officially supported.
+
+## Internet Explorer
+
+Internet Explorer is not supported.
+
+<!--## Modals and dropdowns on mobile
+
+### Overflow and scrolling
+
+Support for `overflow: hidden;` on the `<body>` element is quite limited in iOS and Android. To that end, when you scroll past the top or bottom of a modal in either of those devices' browsers, the `<body>` content will begin to scroll. See [Chrome bug #175502](https://issues.chromium.org/issues/40301599) (fixed in Chrome v40) and [WebKit bug #153852](https://bugs.webkit.org/show_bug.cgi?id=153852).
+
+### iOS text fields and scrolling
+
+As of iOS 9.2, while a modal is open, if the initial touch of a scroll gesture is within the boundary of a textual `<input>` or a `<textarea>`, the `<body>` content underneath the modal will be scrolled instead of the modal itself. See [WebKit bug #153856](https://bugs.webkit.org/show_bug.cgi?id=153856).
+
+### Navbar Dropdowns
+
+The `.dropdown-backdrop` element isn't used on iOS in the nav because of the complexity of z-indexing. Thus, to close dropdowns in navbars, you must directly click the dropdown element (or [any other element which will fire a click event in iOS](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event#Safari_Mobile)).-->
+
+## Browser zooming
+
+Page zooming inevitably presents rendering artifacts in some components, both in OUDS Web and the rest of the web. Depending on the issue, we may be able to fix it (search first and then open an issue if need be). However, we tend to ignore these as they often have no direct solution other than hacky workarounds.
+
+## Validators
+
+In order to provide the best possible experience to old and buggy browsers, OUDS Web uses [CSS browser hacks](http://browserhacks.com/) in several places to target special CSS to certain browser versions in order to work around bugs in the browsers themselves. These hacks understandably cause CSS validators to complain that they are invalid. In a couple places, we also use bleeding-edge CSS features that aren't yet fully standardized, but these are used purely for progressive enhancement.
+
+These validation warnings don't matter in practice since the non-hacky portion of our CSS does fully validate and the hacky portions don't interfere with the proper functioning of the non-hacky portion, hence why we deliberately ignore these particular warnings.
+
+Our HTML docs likewise have some trivial and inconsequential HTML validation warnings due to our inclusion of a workaround for [a certain Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=654072).

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -11,7 +11,6 @@
     - title: Contents
       draft: true
     - title: Browsers & devices
-      draft: true
     - title: JavaScript
       draft: true
     - title: Webpack


### PR DESCRIPTION
### Related issues

Listed in https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2589.

### Description

This PR adds the "Getting started > Browsers & devices" page based on:
- the previous [corresponding Boosted page](https://boosted.orange.com/docs/5.3/getting-started/browsers-devices/) (see [code source](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/site/content/docs/5.3/getting-started/browsers-devices.md))
- the [corresponding Bootstrap page](https://getbootstrap.com/docs/5.3/getting-started/browsers-devices/) (see [code source](https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.3/getting-started/browsers-devices.md))

#### To add to #2589 

- [ ] Uncomment elements whenever modals are developed
- [ ] Uncomment elements whenever dropdowns are developed

### Types of change

- New documentation (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2684--boosted.netlify.app/docs/0.0/getting-started/browsers-devices