### PR TITLE
docs(getting started): update 'Contents' page

### DIFF
--- a/site/content/docs/5.3/getting-started/contents.md
+++ b/site/content/docs/5.3/getting-started/contents.md
@@ -110,4 +110,6 @@ boosted/
 └── scss/
 ```
 
-The `scss/` and `js/` are the source code for our CSS and JavaScript. The `dist/` folder includes everything listed in the compiled download section above. The `site/docs/` folder includes the source code for our documentation, and `examples/` of Boosted usage. Beyond that, any other included file provides support for packages, license information, and development.
+The `scss/` and `js/` are the source code for our CSS and JavaScript. The `dist/` folder includes everything listed in the compiled download section above. The `site/content/docs/` folder includes the source code for our hosted documentation, including our live examples of Boosted usage.
+
+Beyond that, any other included file provides support for packages, license information, and development.


### PR DESCRIPTION
### Description

This PR updates the end of the 'Contents' page to retrieve the upstream paragraph available at https://raw.githubusercontent.com/twbs/bootstrap/main/site/content/docs/5.3/getting-started/contents.md.

The directory mentioned for the docs wasn't accurate, and finally, Bootstrap content works well for our repository as well. So let's keep the upstream content for an easier maintenance.

### Types of change

- Documentation (non-breaking change)

### Live previews

- <https://deploy-preview-2686--boosted.netlify.app/docs/5.3/getting-started/contents/>