### PR TITLE
Fix a11y audit: All texts must be included in a semantic tag (design callouts)

### DIFF
--- a/site/layouts/shortcodes/design-callout-alert.html
+++ b/site/layouts/shortcodes/design-callout-alert.html
@@ -7,7 +7,7 @@
 <div class="alert alert-{{ $level }}">
   <span class="alert-icon"><span class="visually-hidden">{{ $level }}</span></span>
   <div>
-    <div class="alert-heading mb-1">
+    <p class="alert-heading mb-1">
       {{- if eq $level "danger" -}}
         Incompatibility with Orange Design System.
         <a href="/docs/{{ .Site.Params.docs_version }}/getting-started/introduction/">More information</a>
@@ -15,7 +15,7 @@
       {{- if eq $level "info" -}}
         Orange Design System recommendation.
       {{- end -}}
-    </div>
+    </p>
     <div>{{ .Inner | markdownify }}</div>
   </div>
 </div>


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#2667 issue 1-2

### Description

<!-- Describe your changes in detail -->
Change the `<div>` with a semantic `<p>` tag, so that the text and link of the design callouts is included into something. No visual change.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Accessibility issue from the audit, see #2667 

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2722--boosted.netlify.app/docs/getting-started/introduction/>
