### PR TITLE
[OUDS] feat(utilities): rename `opacity-emphasis` to `opacity-strong`

### DIFF
--- a/scss/tests/customize/_ouds-web-bootstrap.test.scss
+++ b/scss/tests/customize/_ouds-web-bootstrap.test.scss
@@ -50,7 +50,7 @@ $utilities: ();
           opacity: .32 !important;
         }
 
-        .opacity-emphasis {
+        .opacity-strong {
           opacity: .64 !important;
         }
 
@@ -123,7 +123,7 @@ $utilities: ();
           opacity: .32 !important;
         }
 
-        .opacity-emphasis {
+        .opacity-strong {
           opacity: .64 !important;
         }
 

--- a/scss/tokens/_semantic.scss
+++ b/scss/tokens/_semantic.scss
@@ -9,7 +9,7 @@ $ouds-opacities: (
   "weaker":      $ouds-opacity-100,
   "weak":        $ouds-opacity-300,
   "medium":      $ouds-opacity-500,
-  "emphasis":    $ouds-opacity-700,
+  "strong":      $ouds-opacity-700,
   "opaque":      $ouds-opacity-900
 ) !default;
 // scss-docs-end ouds-opacities-variables-maps

--- a/site/content/docs/0.0/migration-from-boosted.md
+++ b/site/content/docs/0.0/migration-from-boosted.md
@@ -58,7 +58,7 @@ Technically, it means that you can get rid of the following things:
 ### Opacity
 
 - <span class="badge text-bg-danger">Breaking</span> `.opacity-0`, `.opacity-25`, `.opacity-50`, `.opacity-75` and `.opacity-100` have been removed from the default build. Please check the new [opacity values]({{< docsref "/utilities/opacity" >}}) directly in the documentation and adapt your websites to them. You can still have them using `$enable-bootstrap-compatibility`.
-- <span class="badge text-bg-success">New</span> Opacity utilities: `.opacity-transparent`, `.opacity-weaker`, `.opacity-weak`, `.opacity-medium`, `.opacity-emphasis` and `.opacity-opaque`.
+- <span class="badge text-bg-success">New</span> Opacity utilities: `.opacity-transparent`, `.opacity-weaker`, `.opacity-weak`, `.opacity-medium`, `.opacity-strong` and `.opacity-opaque`.
 
 ## CSS and Sass variables
 

--- a/site/content/docs/0.0/migration.md
+++ b/site/content/docs/0.0/migration.md
@@ -9,6 +9,12 @@ aliases:
 toc: true
 ---
 
+## v0.0.4
+
+#### Opacity
+
+- <span class="badge text-bg-danger">Breaking</span>: `.opacity-emphasis` has been renamed to `.opacity-strong`.
+
 ## v0.0.3
 
 ### Pre-compiled versions

--- a/site/content/docs/0.0/utilities/opacity.md
+++ b/site/content/docs/0.0/utilities/opacity.md
@@ -7,13 +7,13 @@ aliases:
   - "/docs/utilities/opacity/"
 ---
 
-The `opacity` property sets the opacity level for an element. The opacity level describes the semantic transparency level, where `opaque` is not transparent at all, `emphasis` to `weaker` are various levels of transparency, and `transparent` is completely transparent.
+The `opacity` property sets the opacity level for an element. The opacity level describes the semantic transparency level, where `opaque` is not transparent at all, `strong` to `weaker` are various levels of transparency, and `transparent` is completely transparent.
 
 Set the opacity of an element using `.opacity-{value}` utilities.
 
 <div class="bd-example d-sm-flex">
   <div class="opacity-opaque p-3 m-2 bg-primary fw-bold"></div>
-  <div class="opacity-emphasis p-3 m-2 bg-primary fw-bold"></div>
+  <div class="opacity-strong p-3 m-2 bg-primary fw-bold"></div>
   <div class="opacity-medium p-3 m-2 bg-primary fw-bold"></div>
   <div class="opacity-weak p-3 m-2 bg-primary fw-bold"></div>
   <div class="opacity-weaker p-3 m-2 bg-primary fw-bold"></div>
@@ -22,7 +22,7 @@ Set the opacity of an element using `.opacity-{value}` utilities.
 
 ```html
 <div class="opacity-opaque">...</div>
-<div class="opacity-emphasis">...</div>
+<div class="opacity-strong">...</div>
 <div class="opacity-medium">...</div>
 <div class="opacity-weak">...</div>
 <div class="opacity-weaker">...</div>


### PR DESCRIPTION
### Description

`opacity-emphasis` design token has been renamed to `opacity-strong`. This PR takes that into account for OUDS Web.

### Types of change

- New feature (non-breaking change which adds functionality)

### Live previews

- https://deploy-preview-2728--boosted.netlify.app/docs/0.0/utilities/opacity/
- https://deploy-preview-2728--boosted.netlify.app/docs/0.0/migration/
- https://deploy-preview-2728--boosted.netlify.app/docs/0.0/migration-from-boosted/