### PR TITLE
chore(deps-dev): bump pa11y-ci-reporter-html from 6.0.2 to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "npm-run-all2": "^6.2.2",
         "ods-storybook-theme": "^1.1.0",
         "pa11y-ci": "^3.1.0",
-        "pa11y-ci-reporter-html": "^6.0.2",
+        "pa11y-ci-reporter-html": "^7.0.0",
         "postcss": "^8.4.45",
         "postcss-cli": "^11.0.0",
         "rollup": "^4.21.2",
@@ -6602,12 +6602,12 @@
       }
     },
     "node_modules/ci-logger": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ci-logger/-/ci-logger-6.0.0.tgz",
-      "integrity": "sha512-YqknFCTo1fA19QeX2U3x7gLXBg6jUpTWu4WBli3Pj3/QLublWvZAXJm3fALFxzUv1N0Rn2Ki50PqAQX8yWHM6A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ci-logger/-/ci-logger-7.0.0.tgz",
+      "integrity": "sha512-mt2YIS+8AzhKcPybORt9NtiZcnRB4FbUJn9MTTgB7db2UrGGWAxgcu0WQylSTGeWGmJurAto7RoyZHSFRuIEAA==",
       "dev": true,
       "engines": {
-        "node": "^16.13.0 || ^18.12.0 || >=20.0.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0.0"
       }
     },
     "node_modules/clean-css": {
@@ -12308,20 +12308,17 @@
       }
     },
     "node_modules/pa11y-ci-reporter-html": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/pa11y-ci-reporter-html/-/pa11y-ci-reporter-html-6.0.2.tgz",
-      "integrity": "sha512-YU0x8oLHX3FNgZrljGizcxy863QWZeeeW/9M1Aml/iIjQdWllbsTXOavkZRnOWCHo+ZTkq0Qj27FgnxdLTtf4w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pa11y-ci-reporter-html/-/pa11y-ci-reporter-html-7.0.0.tgz",
+      "integrity": "sha512-avCNMhF5ksZ6U6n6HxV0NSSwrOjfgaRhNbUxwcY9pZxOEoV22aiyyZUgZgQaZXFhCNee/2H52FvoosbZ/+i6RA==",
       "dev": true,
       "dependencies": {
-        "ci-logger": "^6.0.0",
+        "ci-logger": "^7.0.0",
         "handlebars": "^4.7.8",
-        "pa11y-reporter-html-plus": "^2.0.1"
+        "pa11y-reporter-html-plus": "^4.0.1"
       },
       "engines": {
-        "node": "^16.13.0 || ^18.12.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "pa11y-ci": "^3.0.1"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0.0"
       }
     },
     "node_modules/pa11y-ci/node_modules/array-union": {
@@ -12362,15 +12359,15 @@
       }
     },
     "node_modules/pa11y-reporter-html-plus": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pa11y-reporter-html-plus/-/pa11y-reporter-html-plus-2.0.1.tgz",
-      "integrity": "sha512-AtGuXYhISm6SFBLVXhzBkRnT3lOu9n2ryIGHHJt/q1NFH6oMlcLXkVRHlhtM6ZiVIHLa5ObKlhCHPDlzwxheZQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pa11y-reporter-html-plus/-/pa11y-reporter-html-plus-4.0.1.tgz",
+      "integrity": "sha512-B4EIO9RWRX+b3cmgEtXCsGYcwIxK0MDjdhxALmoHy4VEUp04Xi1y7JR0h+HvhSDGE+X91S4XBINcgeyWaA35hQ==",
       "dev": true,
       "dependencies": {
         "handlebars": "^4.7.8"
       },
       "engines": {
-        "node": "^16.13.0 || ^18.12.0 || >=20.0.0"
+        "node": "^18.12.0 || >=20.0.0"
       }
     },
     "node_modules/pa11y/node_modules/axe-core": {
@@ -16031,9 +16028,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.1.tgz",
-      "integrity": "sha512-y/2wiW+ceTYR2TSSptAhfnEtpLaQ4Ups5zrjB2d3kuVxHj16j/QJwPl5PvuGy9uARb39J0+iKxcRPvtpsx4A4A==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
       "optional": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "npm-run-all2": "^6.2.2",
     "ods-storybook-theme": "^1.1.0",
     "pa11y-ci": "^3.1.0",
-    "pa11y-ci-reporter-html": "^6.0.2",
+    "pa11y-ci-reporter-html": "^7.0.0",
     "postcss": "^8.4.45",
     "postcss-cli": "^11.0.0",
     "rollup": "^4.21.2",


### PR DESCRIPTION
### Description

This PR supersedes https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2724 as pa11y tests are not executed in Dependabot PRs.

There are some things we need to test before merging this PR:
- [x] Automatic tests are green just by bumping the dependency
  - See https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/runs/10830125620/job/30049176670?pr=2735.
  - "Upload accessibility results" have been skipped as there are no errors 
- [x] Launching the tests locally still works as expected: the HTML report is created and all green
  -  `npm run docs ; npm run docs-accessibility` and `file:///Users/xxx/Orange-Boosted-Bootstrap/.pa11y/index.html` is clean
- [x] Create a voluntary a11y error detected by pa11y-ci by modifying `build/.pa11yci.json` to remove `#offcanvas` and  `#offcanvasDark` rules (see https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/pull/2735/commits/5777047970d09d42bfe4e4cbff6a93776b5581e7)
  - [x] CI pa11y-ci test must fail, and we should access to the HTML report
    - [CI results](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/runs/10830594602/job/30050696323?pr=2735)
  - [x] Locally, it must fail and generate and HTML report
    - `npm run docs ; npm run docs-accessibility`
    
![Screenshot 2024-09-12 at 14 15 07](https://github.com/user-attachments/assets/df06f203-671d-4a74-830b-0dd41278f484)
![Screenshot 2024-09-12 at 14 15 02](https://github.com/user-attachments/assets/e7ad7567-6340-4f95-944f-e3a27f595a4d)

    
- [x] Revert the fake tests 