### PR TITLE
[OUDS] feat: update border width semantic tokens with new references and values

### DIFF
--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -16,9 +16,9 @@ $ouds-border-styles: (
 
 $ouds-border-widths: (
   "thin":     $ouds-border-width-thin,
+  "medium":   $ouds-border-width-medium,
   "thick":    $ouds-border-width-thick,
   "thicker":  $ouds-border-width-thicker,
-  "thickest": $ouds-border-width-thickest,
 ) !default;
 // scss-docs-end ouds-maps-borders
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -614,10 +614,10 @@ $container-padding-x: $grid-gutter-width !default;
 $border-width:                $ouds-border-width-default !default; // OUDS mod: instead of `.125rem`
 $border-widths: (
   1: $ouds-border-width-thin, // OUDS mod: instead of `$border-width * .5`
-  2: $ouds-border-width-thick, // OUDS mod: instead of `$border-width`
-  3: $ouds-border-width-thicker, // OUDS mod: instead of `$border-width * 1.5`
-  4: $ouds-border-width-thickest, // OUDS mod: instead of `$border-width * 2`
-  5: $ouds-border-width-thickest * 1.25 // OUDS mod: instead of `$border-width * 2.5`
+  2: $ouds-border-width-medium, // OUDS mod: instead of `$border-width`
+  3: $ouds-border-width-thick, // OUDS mod: instead of `$border-width * 1.5`
+  4: $ouds-border-width-thicker, // OUDS mod: instead of `$border-width * 2`
+  5: $ouds-border-width-thicker * 1.25 // OUDS mod: instead of `$border-width * 2.5`
 ) !default;
 $border-style:                $ouds-border-style-default !default; // OUDS mod: instead of `solid`
 $border-color:                $black !default; // OUDS mod: instead of `$gray-300`

--- a/scss/tests/customize/_ouds-web-bootstrap.test.scss
+++ b/scss/tests/customize/_ouds-web-bootstrap.test.scss
@@ -390,15 +390,15 @@ $utilities: ();
           border-width: 1px !important;
         }
 
-        .border-thick {
+        .border-medium {
           border-width: 2px !important;
         }
 
-        .border-thicker {
+        .border-thick {
           border-width: 3px !important;
         }
 
-        .border-thickest {
+        .border-thicker {
           border-width: 4px !important;
         }
 
@@ -1046,15 +1046,15 @@ $utilities: ();
           border-width: 1px !important;
         }
 
-        .border-thick {
+        .border-medium {
           border-width: 2px !important;
         }
 
-        .border-thicker {
+        .border-thick {
           border-width: 3px !important;
         }
 
-        .border-thickest {
+        .border-thicker {
           border-width: 4px !important;
         }
 

--- a/scss/tokens/_semantic.scss
+++ b/scss/tokens/_semantic.scss
@@ -17,10 +17,10 @@ $ouds-border-style-drag:          $ouds-border-style-dashed !default;
 $ouds-border-width-none:          $ouds-border-width-0 !default;
 $ouds-border-width-default:       $ouds-border-width-25 !default;
 $ouds-border-width-thin:          $ouds-border-width-25 !default;
-$ouds-border-width-thick:         $ouds-border-width-50 !default;
-$ouds-border-width-thicker:       $ouds-border-width-75 !default;
-$ouds-border-width-thickest:      $ouds-border-width-100 !default;
-// $ouds-border-width-interactive-primary-focus: $ouds-border-width-100 !default;
+$ouds-border-width-medium:        $ouds-border-width-50 !default;
+$ouds-border-width-thick:         $ouds-border-width-75 !default;
+$ouds-border-width-thicker:       $ouds-border-width-100 !default;
+// $ouds-border-width-outside-focus: $ouds-border-width-50 !default;
 // scss-docs-end ouds-semantic-border
 
 // Opacity

--- a/site/content/docs/0.0/migration-from-boosted.md
+++ b/site/content/docs/0.0/migration-from-boosted.md
@@ -63,7 +63,7 @@ Technically, it means that you can get rid of the following things:
 
 - <span class="badge text-bg-danger">Breaking</span> Border width utilities have been removed: `.border-0`, `.border-1`, `.border-2`, `.border-3`, `.border-4` and `.border-5`. Please check the new [border values]({{< docsref "/utilities/borders#width" >}}) directly in the documentation and adapt your websites to them. You can still have them using `$enable-bootstrap-compatibility`.
 
-- <span class="badge text-bg-success">New</span> Border width utilities: `.border-none`, `.border-thin`, `.border-thick`, `.border-thicker` and `.border-thickest`.
+- <span class="badge text-bg-success">New</span> Border width utilities: `.border-none`, `.border-thin`, `.border-medium`, `.border-thick`, and `.border-thicker`.
 
 - <span class="badge text-bg-danger">Breaking</span> Border radius utilities with many sizes have been removed. Please check the new [border values]({{< docsref "/utilities/borders#radius" >}}) directly in the documentation and adapt your websites to them. You can still have them using `$enable-bootstrap-compatibility`:
   - 0: `.rounded-0`, `.rounded-top-0`, `.rounded-bottom-0`, `.rounded-start-0` and `.rounded-end-0`.
@@ -131,10 +131,10 @@ Technically, it means that you can get rid of the following things:
       <li><code>$ouds-border-width-75</code></li>
       <li><code>$ouds-border-width-100</code></li>
       <li><code>$ouds-border-width-default</code></li>
+      <li><code>$ouds-border-width-medium</code></li>
       <li><code>$ouds-border-width-none</code></li>
       <li><code>$ouds-border-width-thick</code></li>
       <li><code>$ouds-border-width-thicker</code></li>
-      <li><code>$ouds-border-width-thickest</code></li>
       <li><code>$ouds-border-width-thin</code></li>
       <li><code>$ouds-opacity-0</code></li>
       <li><code>$ouds-opacity-100</code></li>

--- a/site/content/docs/0.0/migration.md
+++ b/site/content/docs/0.0/migration.md
@@ -17,7 +17,7 @@ toc: true
 
 - <span class="badge text-bg-success">New</span> Border operative utilities: `.border`, `.border-none`, `.border-top`, `.border-top-none`, `.border-bottom`, `.border-bottom-none`, `.border-start`, `.border-start-none`, `.border-end` and `.border-end-none`.
 
-- <span class="badge text-bg-success">New</span> Border width utilities: `.border-none`, `.border-thin`, `.border-thick`, `.border-thicker` and `.border-thickest`.
+- <span class="badge text-bg-success">New</span> Border width utilities: `.border-none`, `.border-thin`, `.border-medium`, `.border-thick`, and `.border-thicker`.
 
 - <span class="badge text-bg-success">New</span> Border radius utilities with all sizes:
   - Default: `.rounded`, `.rounded-top`, `.rounded-bottom`, `.rounded-start` and `.rounded-end`.
@@ -60,10 +60,10 @@ toc: true
       <li><code>$ouds-border-width-75</code></li>
       <li><code>$ouds-border-width-100</code></li>
       <li><code>$ouds-border-width-default</code></li>
+      <li><code>$ouds-border-width-medium</code></li>
       <li><code>$ouds-border-width-none</code></li>
       <li><code>$ouds-border-width-thick</code></li>
       <li><code>$ouds-border-width-thicker</code></li>
-      <li><code>$ouds-border-width-thickest</code></li>
       <li><code>$ouds-border-width-thin</code></li>
       <li><code>$ouds-opacity-medium</code></li>
       <li><code>$ouds-opacity-opaque</code></li>

--- a/site/content/docs/0.0/utilities/borders.md
+++ b/site/content/docs/0.0/utilities/borders.md
@@ -57,9 +57,9 @@ Or remove borders:
 {{< example class="bd-example-border-utils" >}}
 <span class="border border-none"></span>
 <span class="border border-thin"></span>
+<span class="border border-medium"></span>
 <span class="border border-thick"></span>
 <span class="border border-thicker"></span>
-<span class="border border-thickest"></span>
 {{< /example >}}
 
 {{< bootstrap-compatibility >}}


### PR DESCRIPTION
### Description

The references have changed for the border width semantic tokens.
The new semantic border width tokens are:

| Name | Value |
| ---- | ----- |
| border-width-none | border-width-0 |
| border-width-default | border-width-25 |
| border-width-thin | border-width-25 |
| border-width-medium | border-width-50 |
| border-width-thick | border-width-75 |
| border-width-thicker | border-width-100 |
| border-width-outside-focus | border-width-50 |

In summary:
* `border-width-thickest` doesn't exist anymore
* `border-width-medium` is new
* `border-width-interactive-primary-focus` doesn't exist anymore
* `border-width-outside-focus` is new
* `border-width-thick` has a different value
* `border-width-thicker` has a different value