### PR TITLE
fix(forms): avoid .is-required element to be alone on a new line

### DIFF
--- a/scss/forms/_labels.scss
+++ b/scss/forms/_labels.scss
@@ -17,6 +17,7 @@
 }
 
 .is-required::after {
+  position: absolute;
   margin-left: $form-label-required-margin-left;
   color: $form-label-required-color;
   content: "*";


### PR DESCRIPTION
### Related issues

Closes #2758

### Description

This PR fixes the issue described at #2758 where the asterisk showing that a form control is required can be alone on a new line when the label length has exactly the same length as the corresponding input.

I tried different non-working solutions based on `word-wrap` and non breakable space without success. This PR relies on @jacques-lebourgeois's suggestion.

The only drawback I've found of this fix is that the asterisk, intead of going to the new line, stays on the same line but is displayed in the safe area; outside of the bounding box that we should use. However, I'd consider that as a minor issue.

See:

<img width="747" alt="Screenshot 2024-10-14 at 08 08 06" src="https://github.com/user-attachments/assets/300b8701-a72f-4e69-b194-eb190ebe0265">


### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

- https://deploy-preview-2760--boosted.netlify.app/docs/5.3/forms/overview/#required-field