### PR TITLE
chore: update maintainers information

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     reviewers:
-      - julien-deramond
+      - louismaximepiton
     labels:
       - dependencies
       - v5

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-julien.deramond@orange.com.
+vincent.prothais@orange.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
       "email": "loic.laussel@orange.com"
     },
     {
-      "name": "Julien Déramond",
-      "email": "julien.deramond@orange.com"
+      "name": "Vincent Prothais",
+      "email": "vincent.prothais@orange.com"
     }
   ],
   "support": {

--- a/site/content/docs/5.3/getting-started/introduction.md
+++ b/site/content/docs/5.3/getting-started/introduction.md
@@ -38,7 +38,7 @@ To display basic tables, Orange Design System recommends using these compact tab
 
 ## Quick start
 
-Get started by including Boosted's production-ready CSS and JavaScript via CDN without the need for any build steps. See it in practice with this [Boosted CodePen demo](https://codepen.io/julien-deramond/pen/WNMxywB).
+Get started by including Boosted's production-ready CSS and JavaScript via CDN without the need for any build steps. See it in practice with this [Boosted CodePen demo](https://codepen.io/louismaximepiton/pen/eYqwzag).
 
 <br>
 

--- a/site/data/core-team.yml
+++ b/site/data/core-team.yml
@@ -1,11 +1,11 @@
 - name: Loïc Laussel
   user: Lausselloic
 
-- name: Julien Déramond
-  user: julien-deramond
-
 - name: Louis-Maxime Piton
   user: louismaximepiton
 
 - name: Hannah Issermann
   user: hannahiss
+
+- name: Vincent Prothais
+  user: vprothais


### PR DESCRIPTION
### Description

Dropping myself from the repository 😢 

<details>
<summary>Change a CodePen: Done</summary>
⚠️ In the introduction page, we have the following:

> Get started by including Boosted's production-ready CSS and JavaScript via CDN without the need for any build steps. See it in practice with this [Boosted CodePen demo](https://codepen.io/julien-deramond/pen/WNMxywB).

It would be nice if some of you could fork this CodePen demo and change in this PR the new URL 👌 
</details>

### Types of change

- Documentation update

### Live previews

- https://deploy-preview-2798--boosted.netlify.app/docs/5.3/about/team/