### PR TITLE
[OUDS] Add background utilities to the Colors tokens PR

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/css/ouds-web.min.css",
-      "maxSize": "53.75 kB"
+      "maxSize": "54.0 kB"
     },
     {
       "path": "./dist/js/ouds-web.bundle.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,11 +2,11 @@
   "files": [
     {
       "path": "./dist/css/ouds-web-bootstrap.css",
-      "maxSize": "63.5 kB"
+      "maxSize": "63.75 kB"
     },
     {
       "path": "./dist/css/ouds-web-bootstrap.min.css",
-      "maxSize": "60.5 kB"
+      "maxSize": "60.75 kB"
     },
     {
       "path": "./dist/css/ouds-web-grid.css",

--- a/hugo.yml
+++ b/hugo.yml
@@ -80,6 +80,8 @@ params:
   icons_license:                    "https://design.orange.com/0c1af118d/p/92bb17-usage/t/63532c"
   icons_usage:                      "https://design.orange.com/0c1af118d/p/92bb17-usage"
   bootstrap:                        "https://getbootstrap.com"
+  ouds:
+    web:                            "https://unified-design-system.orange.com/" # TODO LM: replace this URL by the web one or even "https://oran.ge/ds-web" when it will changed
 
   algolia:
     appId:                          "F4PKENW3TB"

--- a/js/tests/visual/dropdown.html
+++ b/js/tests/visual/dropdown.html
@@ -10,7 +10,7 @@
     <div class="container-fluid">
       <h1>Dropdown <small>Bootstrap Visual Test</small></h1>
 
-      <nav class="navbar navbar-expand-md bg-light">
+      <nav class="navbar navbar-expand-md bg-always-white">
         <a class="navbar-brand" href="#">Navbar</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>

--- a/js/tests/visual/modal.html
+++ b/js/tests/visual/modal.html
@@ -13,7 +13,7 @@
     </style>
   </head>
   <body>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-always-black">
       <div class="container-fluid">
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>

--- a/js/tests/visual/scrollspy.html
+++ b/js/tests/visual/scrollspy.html
@@ -10,7 +10,7 @@
     </style>
   </head>
   <body data-bs-spy="scroll" data-bs-target=".navbar" data-bs-offset="70">
-    <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
+    <nav class="navbar navbar-expand-md navbar-dark bg-always-black fixed-top">
       <a class="navbar-brand text-white" href="#">Scrollspy test</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/js/tests/visual/toast.html
+++ b/js/tests/visual/toast.html
@@ -28,7 +28,7 @@
     <div class="notifications">
       <div id="toastAutoHide" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="2000">
         <div class="toast-header">
-          <span class="d-block bg-primary rounded me-short" style="width: 20px; height: 20px;"></span>
+          <span class="d-block bg-brand-primary rounded me-short" style="width: 20px; height: 20px;"></span>
           <strong class="me-auto">Bootstrap</strong>
           <small>11 mins ago</small>
         </div>
@@ -39,7 +39,7 @@
 
       <div class="toast" data-bs-autohide="false" role="alert" aria-live="assertive" aria-atomic="true">
         <div class="toast-header">
-          <span class="d-block bg-primary rounded me-short" style="width: 20px; height: 20px;"></span>
+          <span class="d-block bg-brand-primary rounded me-short" style="width: 20px; height: 20px;"></span>
           <strong class="me-auto">Bootstrap</strong>
           <small class="text-body-secondary">2 seconds ago</small>
           <button type="button" class="ms-short mb-shortest btn-close" data-bs-dismiss="toast"><span class="visually-hidden">Close</span></button><!--OUDS mod: a11y-->

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -1,3 +1,6 @@
 // Configuration file for OUDS Web
 
 $prefix: bs- !default;
+$color-mode-type: data !default; // `data` or `media-query`
+
+$ouds-root-selector: ":root" !default;

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -2,6 +2,10 @@
 //
 // Utility mixins and functions for evaluating source code across our variables, maps, and mixins.
 
+// OUDS mod: add color modes mixin
+@import "mixins/color-mode";
+// End mod
+
 // Ascending
 // Used to evaluate Sass maps like our grid breakpoints.
 @mixin _assert-ascending($map, $map-name) {

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -2,7 +2,7 @@
 //
 // Rows contain your columns.
 
-:root {
+#{$ouds-root-selector} {
   @each $name, $value in $grid-breakpoints {
     --#{$prefix}breakpoint-#{$name}: #{$value};
   }

--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -116,6 +116,31 @@ $ouds-opacities: (
   "opaque":     $ouds-opacity-opaque
 ) !default;
 // scss-docs-end ouds-maps-opacities
+
+// scss-docs-start ouds-maps-opacities
+$ouds-backgrounds: (
+  "primary": var(--#{$prefix}color-bg-primary),
+  "secondary": var(--#{$prefix}color-bg-secondary),
+  "tertiary": var(--#{$prefix}color-bg-tertiary),
+  "emphasized": var(--#{$prefix}color-bg-emphasized),
+  "brand-primary": var(--#{$prefix}color-surface-brand-primary),
+  "status-neutral-emphasized": var(--#{$prefix}color-surface-status-neutral-emphasized),
+  "status-neutral-muted": var(--#{$prefix}color-surface-status-neutral-muted),
+  "status-accent-emphasized": var(--#{$prefix}color-surface-status-accent-emphasized),
+  "status-accent-muted": var(--#{$prefix}color-surface-status-accent-muted),
+  "status-positive-emphasized": var(--#{$prefix}color-surface-status-positive-emphasized),
+  "status-positive-muted": var(--#{$prefix}color-surface-status-positive-muted),
+  "status-negative-emphasized": var(--#{$prefix}color-surface-status-negative-emphasized),
+  "status-negative-muted": var(--#{$prefix}color-surface-status-negative-muted),
+  "status-warning-emphasized": var(--#{$prefix}color-surface-status-warning-emphasized),
+  "status-warning-muted": var(--#{$prefix}color-surface-status-warning-muted),
+  "status-info-emphasized": var(--#{$prefix}color-surface-status-info-emphasized),
+  "status-info-muted": var(--#{$prefix}color-surface-status-info-muted),
+  "always-black": var(--#{$prefix}color-always-black),
+  "always-white": var(--#{$prefix}color-always-white),
+  "transparent": transparent,
+) !default;
+// scss-docs-end ouds-maps-opacities
 // End mod
 
 // Re-assigned maps

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -10,7 +10,7 @@
 
 // Helpers
 @import "mixins/breakpoints";
-@import "mixins/color-mode";
+// @import "mixins/color-mode";
 @import "mixins/color-scheme";
 @import "mixins/fonts"; // OUDS mod
 @import "mixins/image";

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -10,7 +10,7 @@
 
 // Helpers
 @import "mixins/breakpoints";
-// @import "mixins/color-mode";
+// OUDS mod: @import "mixins/color-mode"; is done inside the functions
 @import "mixins/color-scheme";
 @import "mixins/fonts"; // OUDS mod
 @import "mixins/image";

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -25,7 +25,7 @@
 // Ability to the value of the root font sizes, affecting the value of `rem`.
 // null by default, thus nothing is generated.
 
-:root {
+#{$ouds-root-selector} {
   @if $font-size-root != null {
     @include font-size(var(--#{$prefix}root-font-size));
   }

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -61,7 +61,7 @@
 //    See https://developer.mozilla.org/fr/docs/Web/CSS/font-synthesis
 
 // scss-docs-start reboot-body-rules
-body {
+#{$ouds-root-selector} > * {
   position: relative; // OUDS mod: required for back-to-top component
   margin: 0; // 1
   font-family: var(--#{$prefix}body-font-family);

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,15 +1,13 @@
 // OUDS mod
-:root,
+#{$ouds-root-selector},
 [data-bs-theme] {
   color: var(--#{$prefix}body-color);
-  background-color: var(--#{$prefix}body-bg);
 }
 
-// Note that some of the following variables in `:root, [data-bs-theme="light"]` could be extracted into `:root` only selector since they are not modified by other color modes!
+// Note that some of the following variables in `#{$ouds-root-selector}, [data-bs-theme="light"]` could be extracted into `#{$ouds-root-selector}` only selector since they are not modified by other color modes!
 // End mod
 
-:root,
-[data-bs-theme="light"] {
+@include color-mode(light, true) {
   color-scheme: light; // OUDS mod
 
   // Note: Custom variable values only support SassScript inside `#{}`.

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -1058,11 +1058,12 @@ $utilities: map-merge(
       values: map-merge(
         $utilities-bg-colors,
         (
-          "transparent": transparent,
+          // OUDS mod: no "transparent"
           "body-secondary": rgba(var(--#{$prefix}secondary-bg-rgb), var(--#{$prefix}bg-opacity)),
           "body-tertiary": rgba(var(--#{$prefix}tertiary-bg-rgb), var(--#{$prefix}bg-opacity)),
         )
-      )
+      ),
+      bootstrap-compatibility: true,
     ),
     "bg-opacity": (
       css-var: true,
@@ -1073,14 +1074,23 @@ $utilities: map-merge(
         50: .5,
         75: .75,
         100: 1
-      )
+      ),
+      bootstrap-compatibility: true,
     ),
     "subtle-background-color": (
       property: background-color,
       class: bg,
-      values: $utilities-bg-subtle
+      values: $utilities-bg-subtle,
+      bootstrap-compatibility: true,
     ),
     // scss-docs-end utils-bg-color
+    // scss-docs-start utils-bg-color-ouds
+    "background-color-ouds": (
+      property: background-color,
+      class: bg,
+      values: $ouds-backgrounds,
+    ),
+    // scss-docs-end utils-bg-color-ouds
     "gradient": (
       property: background-image,
       class: bg,

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -424,9 +424,9 @@ $enable-fixed-header:             true !default; // OUDS mod: used to apply scro
 $enable-bootstrap-compatibility:  false !default; // OUDS mod: used to enforce Bootstrap compatibility
 
 $enable-dark-mode:            true !default;
-$color-mode-type:             data !default; // `data` or `media-query`
+// $color-mode-type:             data !default; // `data` or `media-query`
 
-// OUDS mod: Prefix for :root CSS variables has been moved to `_config.scss`
+// OUDS mod: Prefix for $ouds-root-selector CSS variables has been moved to `_config.scss`
 
 // Gradient
 //

--- a/scss/mixins/_color-mode.scss
+++ b/scss/mixins/_color-mode.scss
@@ -1,9 +1,11 @@
+// Kept it quite simple using only light and dark modes, but you can extend it like in https://codepen.io/louismaximepiton/pen/vYbEvLO for example, to allow more color modes.
+// OUDS mod: add `$invert-mode`, root mode and root-inverted mode
 // scss-docs-start color-mode-mixin
-@mixin color-mode($mode: light, $root: false) {
+@mixin color-mode($mode: light, $root: false, $inverted-mode: if($mode == light, dark, light)) {
   @if $color-mode-type == "media-query" {
     @if $root == true {
       @media (prefers-color-scheme: $mode) {
-        :root {
+        #{$ouds-root-selector} {
           @content;
         }
       }
@@ -13,8 +15,19 @@
       }
     }
   } @else {
-    [data-bs-theme="#{$mode}"] {
-      @content;
+    @if $root == true and $mode == light {
+      #{$ouds-root-selector},
+      [data-bs-theme="#{$mode}"],
+      #{$ouds-root-selector}[data-bs-theme="#{$mode}"] [data-bs-theme="root"],
+      #{$ouds-root-selector}[data-bs-theme="#{$inverted-mode}"] [data-bs-theme="root-inverted"] {
+        @content;
+      }
+    } @else {
+      [data-bs-theme="#{$mode}"],
+      #{$ouds-root-selector}[data-bs-theme="#{$mode}"] [data-bs-theme="root"],
+      #{$ouds-root-selector}[data-bs-theme="#{$inverted-mode}"] [data-bs-theme="root-inverted"] {
+        @content;
+      }
     }
   }
 }

--- a/scss/mixins/_color-mode.scss
+++ b/scss/mixins/_color-mode.scss
@@ -14,20 +14,18 @@
         @content;
       }
     }
+  } @else if $root == true and $mode == light {
+    #{$ouds-root-selector},
+    [data-bs-theme="#{$mode}"],
+    #{$ouds-root-selector}[data-bs-theme="#{$mode}"] [data-bs-theme="root"],
+    #{$ouds-root-selector}[data-bs-theme="#{$inverted-mode}"] [data-bs-theme="root-inverted"] {
+      @content;
+    }
   } @else {
-    @if $root == true and $mode == light {
-      #{$ouds-root-selector},
-      [data-bs-theme="#{$mode}"],
-      #{$ouds-root-selector}[data-bs-theme="#{$mode}"] [data-bs-theme="root"],
-      #{$ouds-root-selector}[data-bs-theme="#{$inverted-mode}"] [data-bs-theme="root-inverted"] {
-        @content;
-      }
-    } @else {
-      [data-bs-theme="#{$mode}"],
-      #{$ouds-root-selector}[data-bs-theme="#{$mode}"] [data-bs-theme="root"],
-      #{$ouds-root-selector}[data-bs-theme="#{$inverted-mode}"] [data-bs-theme="root-inverted"] {
-        @content;
-      }
+    [data-bs-theme="#{$mode}"],
+    #{$ouds-root-selector}[data-bs-theme="#{$mode}"] [data-bs-theme="root"],
+    #{$ouds-root-selector}[data-bs-theme="#{$inverted-mode}"] [data-bs-theme="root-inverted"] {
+      @content;
     }
   }
 }

--- a/scss/tests/customize/_ouds-web-bootstrap-utilities.test.scss
+++ b/scss/tests/customize/_ouds-web-bootstrap-utilities.test.scss
@@ -764,13 +764,54 @@ $utilities: ();
             class: shadow,
             values: $ouds-elevations
           ),
+          "background-color": (
+            property: background-color,
+            class: bg,
+            local-vars: (
+              "bg-opacity": 1
+            ),
+            values: map-merge(
+              $utilities-bg-colors,
+              (
+                // OUDS mod: no "transparent"
+                "body-secondary": rgba(var(--#{$prefix}secondary-bg-rgb), var(--#{$prefix}bg-opacity)),
+                "body-tertiary": rgba(var(--#{$prefix}tertiary-bg-rgb), var(--#{$prefix}bg-opacity)),
+              )
+            ),
+            bootstrap-compatibility: true,
+          ),
+          "bg-opacity": (
+            css-var: true,
+            class: bg-opacity,
+            values: (
+              10: .1,
+              25: .25,
+              50: .5,
+              75: .75,
+              100: 1
+            ),
+            bootstrap-compatibility: true,
+          ),
+          "subtle-background-color": (
+            property: background-color,
+            class: bg,
+            values: $utilities-bg-subtle,
+            bootstrap-compatibility: true,
+          ),
+          "background-color-ouds": (
+            property: background-color,
+            class: bg,
+            values: $ouds-backgrounds,
+          ),
         ) !global;
 
         @import "../../utilities/api";
       }
       @include expect() {
         :root,
-        [data-bs-theme="light"] {
+        [data-bs-theme="light"],
+        :root[data-bs-theme="light"] [data-bs-theme="root"],
+        :root[data-bs-theme="dark"] [data-bs-theme="root-inverted"] {
           --bs-color-opacity-lower: rgba(0, 0, 0, 0.08); // stylelint-disable-line @stylistic/number-leading-zero
           --bs-color-opacity-lowest: rgba(0, 0, 0, 0.04); // stylelint-disable-line @stylistic/number-leading-zero
           --bs-color-opacity-transparent: rgba(0, 0, 0, 0);
@@ -884,7 +925,9 @@ $utilities: ();
           --bs-elevation-color-sticky-navigation-scrolled: rgba(0, 0, 0, 0.16); // stylelint-disable-line @stylistic/number-leading-zero
         }
 
-        [data-bs-theme="dark"] {
+        [data-bs-theme="dark"],
+        :root[data-bs-theme="dark"] [data-bs-theme="root"],
+        :root[data-bs-theme="light"] [data-bs-theme="root-inverted"] {
           --bs-color-opacity-lower: rgba(255, 255, 255, 0.08); // stylelint-disable-line @stylistic/number-leading-zero
           --bs-color-opacity-lowest: rgba(255, 255, 255, 0.04); // stylelint-disable-line @stylistic/number-leading-zero
           --bs-color-opacity-transparent: rgba(255, 255, 255, 0);
@@ -3408,6 +3451,86 @@ $utilities: ();
 
         .shadow-sticky-navigation-scrolled {
           box-shadow: 0 4px 4px -1px var(--bs-elevation-color-sticky-navigation-scrolled) !important;
+        }
+
+        .bg-primary {
+          background-color: var(--bs-color-bg-primary) !important;
+        }
+
+        .bg-secondary {
+          background-color: var(--bs-color-bg-secondary) !important;
+        }
+
+        .bg-tertiary {
+          background-color: var(--bs-color-bg-tertiary) !important;
+        }
+
+        .bg-emphasized {
+          background-color: var(--bs-color-bg-emphasized) !important;
+        }
+
+        .bg-brand-primary {
+          background-color: var(--bs-color-surface-brand-primary) !important;
+        }
+
+        .bg-status-neutral-emphasized {
+          background-color: var(--bs-color-surface-status-neutral-emphasized) !important;
+        }
+
+        .bg-status-neutral-muted {
+          background-color: var(--bs-color-surface-status-neutral-muted) !important;
+        }
+
+        .bg-status-accent-emphasized {
+          background-color: var(--bs-color-surface-status-accent-emphasized) !important;
+        }
+
+        .bg-status-accent-muted {
+          background-color: var(--bs-color-surface-status-accent-muted) !important;
+        }
+
+        .bg-status-positive-emphasized {
+          background-color: var(--bs-color-surface-status-positive-emphasized) !important;
+        }
+
+        .bg-status-positive-muted {
+          background-color: var(--bs-color-surface-status-positive-muted) !important;
+        }
+
+        .bg-status-negative-emphasized {
+          background-color: var(--bs-color-surface-status-negative-emphasized) !important;
+        }
+
+        .bg-status-negative-muted {
+          background-color: var(--bs-color-surface-status-negative-muted) !important;
+        }
+
+        .bg-status-warning-emphasized {
+          background-color: var(--bs-color-surface-status-warning-emphasized) !important;
+        }
+
+        .bg-status-warning-muted {
+          background-color: var(--bs-color-surface-status-warning-muted) !important;
+        }
+
+        .bg-status-info-emphasized {
+          background-color: var(--bs-color-surface-status-info-emphasized) !important;
+        }
+
+        .bg-status-info-muted {
+          background-color: var(--bs-color-surface-status-info-muted) !important;
+        }
+
+        .bg-always-black {
+          background-color: var(--bs-color-always-black) !important;
+        }
+
+        .bg-always-white {
+          background-color: var(--bs-color-always-white) !important;
+        }
+
+        .bg-transparent {
+          background-color: transparent !important;
         }
 
         @media (min-width: 390px) {
@@ -10529,13 +10652,54 @@ $utilities: ();
             class: shadow,
             values: $ouds-elevations
           ),
+          "background-color": (
+            property: background-color,
+            class: bg,
+            local-vars: (
+              "bg-opacity": 1
+            ),
+            values: map-merge(
+              $utilities-bg-colors,
+              (
+                // OUDS mod: no "transparent"
+                "body-secondary": rgba(var(--#{$prefix}secondary-bg-rgb), var(--#{$prefix}bg-opacity)),
+                "body-tertiary": rgba(var(--#{$prefix}tertiary-bg-rgb), var(--#{$prefix}bg-opacity)),
+              )
+            ),
+            bootstrap-compatibility: true,
+          ),
+          "bg-opacity": (
+            css-var: true,
+            class: bg-opacity,
+            values: (
+              10: .1,
+              25: .25,
+              50: .5,
+              75: .75,
+              100: 1
+            ),
+            bootstrap-compatibility: true,
+          ),
+          "subtle-background-color": (
+            property: background-color,
+            class: bg,
+            values: $utilities-bg-subtle,
+            bootstrap-compatibility: true,
+          ),
+          "background-color-ouds": (
+            property: background-color,
+            class: bg,
+            values: $ouds-backgrounds,
+          ),
         ) !global;
 
         @import "../../utilities/api";
       }
       @include expect() {
         :root,
-        [data-bs-theme="light"] {
+        [data-bs-theme="light"],
+        :root[data-bs-theme="light"] [data-bs-theme="root"],
+        :root[data-bs-theme="dark"] [data-bs-theme="root-inverted"] {
           --bs-color-opacity-lower: rgba(0, 0, 0, 0.08); // stylelint-disable-line @stylistic/number-leading-zero
           --bs-color-opacity-lowest: rgba(0, 0, 0, 0.04); // stylelint-disable-line @stylistic/number-leading-zero
           --bs-color-opacity-transparent: rgba(0, 0, 0, 0);
@@ -10649,7 +10813,9 @@ $utilities: ();
           --bs-elevation-color-sticky-navigation-scrolled: rgba(0, 0, 0, 0.16); // stylelint-disable-line @stylistic/number-leading-zero
         }
 
-        [data-bs-theme="dark"] {
+        [data-bs-theme="dark"],
+        :root[data-bs-theme="dark"] [data-bs-theme="root"],
+        :root[data-bs-theme="light"] [data-bs-theme="root-inverted"] {
           --bs-color-opacity-lower: rgba(255, 255, 255, 0.08); // stylelint-disable-line @stylistic/number-leading-zero
           --bs-color-opacity-lowest: rgba(255, 255, 255, 0.04); // stylelint-disable-line @stylistic/number-leading-zero
           --bs-color-opacity-transparent: rgba(255, 255, 255, 0);
@@ -13889,6 +14055,203 @@ $utilities: ();
 
         .shadow-sticky-navigation-scrolled {
           box-shadow: 0 4px 4px -1px var(--bs-elevation-color-sticky-navigation-scrolled) !important;
+        }
+
+        .bg-primary {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-primary-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-secondary {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-secondary-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-success {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-success-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-info {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-info-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-warning {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-warning-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-danger {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-danger-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-light {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-light-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-dark {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-dark-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-black {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-black-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-white {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-white-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-body {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-body-bg-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-body-secondary {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-secondary-bg-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-body-tertiary {
+          --bs-bg-opacity: 1;
+          background-color: rgba(var(--bs-tertiary-bg-rgb), var(--bs-bg-opacity)) !important;
+        }
+
+        .bg-opacity-10 {
+          --bs-bg-opacity: 0.1; // stylelint-disable-line @stylistic/number-leading-zero
+        }
+
+        .bg-opacity-25 {
+          --bs-bg-opacity: 0.25; // stylelint-disable-line @stylistic/number-leading-zero
+        }
+
+        .bg-opacity-50 {
+          --bs-bg-opacity: 0.5; // stylelint-disable-line @stylistic/number-leading-zero
+        }
+
+        .bg-opacity-75 {
+          --bs-bg-opacity: 0.75; // stylelint-disable-line @stylistic/number-leading-zero
+        }
+
+        .bg-opacity-100 {
+          --bs-bg-opacity: 1;
+        }
+
+        .bg-primary-subtle {
+          background-color: var(--bs-primary-bg-subtle) !important;
+        }
+
+        .bg-secondary-subtle {
+          background-color: var(--bs-secondary-bg-subtle) !important;
+        }
+
+        .bg-success-subtle {
+          background-color: var(--bs-success-bg-subtle) !important;
+        }
+
+        .bg-info-subtle {
+          background-color: var(--bs-info-bg-subtle) !important;
+        }
+
+        .bg-warning-subtle {
+          background-color: var(--bs-warning-bg-subtle) !important;
+        }
+
+        .bg-danger-subtle {
+          background-color: var(--bs-danger-bg-subtle) !important;
+        }
+
+        .bg-light-subtle {
+          background-color: var(--bs-light-bg-subtle) !important;
+        }
+
+        .bg-dark-subtle {
+          background-color: var(--bs-dark-bg-subtle) !important;
+        }
+
+        .bg-primary { // stylelint-disable-line no-duplicate-selectors
+          background-color: var(--bs-color-bg-primary) !important;
+        }
+
+        .bg-secondary { // stylelint-disable-line no-duplicate-selectors
+          background-color: var(--bs-color-bg-secondary) !important;
+        }
+
+        .bg-tertiary {
+          background-color: var(--bs-color-bg-tertiary) !important;
+        }
+
+        .bg-emphasized {
+          background-color: var(--bs-color-bg-emphasized) !important;
+        }
+
+        .bg-brand-primary {
+          background-color: var(--bs-color-surface-brand-primary) !important;
+        }
+
+        .bg-status-neutral-emphasized {
+          background-color: var(--bs-color-surface-status-neutral-emphasized) !important;
+        }
+
+        .bg-status-neutral-muted {
+          background-color: var(--bs-color-surface-status-neutral-muted) !important;
+        }
+
+        .bg-status-accent-emphasized {
+          background-color: var(--bs-color-surface-status-accent-emphasized) !important;
+        }
+
+        .bg-status-accent-muted {
+          background-color: var(--bs-color-surface-status-accent-muted) !important;
+        }
+
+        .bg-status-positive-emphasized {
+          background-color: var(--bs-color-surface-status-positive-emphasized) !important;
+        }
+
+        .bg-status-positive-muted {
+          background-color: var(--bs-color-surface-status-positive-muted) !important;
+        }
+
+        .bg-status-negative-emphasized {
+          background-color: var(--bs-color-surface-status-negative-emphasized) !important;
+        }
+
+        .bg-status-negative-muted {
+          background-color: var(--bs-color-surface-status-negative-muted) !important;
+        }
+
+        .bg-status-warning-emphasized {
+          background-color: var(--bs-color-surface-status-warning-emphasized) !important;
+        }
+
+        .bg-status-warning-muted {
+          background-color: var(--bs-color-surface-status-warning-muted) !important;
+        }
+
+        .bg-status-info-emphasized {
+          background-color: var(--bs-color-surface-status-info-emphasized) !important;
+        }
+
+        .bg-status-info-muted {
+          background-color: var(--bs-color-surface-status-info-muted) !important;
+        }
+
+        .bg-always-black {
+          background-color: var(--bs-color-always-black) !important;
+        }
+
+        .bg-always-white {
+          background-color: var(--bs-color-always-white) !important;
+        }
+
+        .bg-transparent {
+          background-color: transparent !important;
         }
 
         @media (min-width: 390px) {

--- a/scss/tests/mixins/_color-modes.test.scss
+++ b/scss/tests/mixins/_color-modes.test.scss
@@ -27,11 +27,15 @@
         }
       }
       @include expect() {
-        [data-bs-theme=dark] .element {
+        [data-bs-theme=dark] .element,
+        :root[data-bs-theme=dark] [data-bs-theme=root] .element,
+        :root[data-bs-theme=light] [data-bs-theme=root-inverted] .element {
           color: var(--bs-primary-text-emphasis);
           background-color: var(--bs-primary-bg-subtle);
         }
-        [data-bs-theme=dark] {
+        [data-bs-theme=dark],
+        :root[data-bs-theme=dark] [data-bs-theme=root],
+        :root[data-bs-theme=light] [data-bs-theme=root-inverted] {
           --custom-color: #679cec; // OUDS mod: instead of `#3aff8`
         }
       }

--- a/scss/tokens/_semantic-colors-custom-props.scss
+++ b/scss/tokens/_semantic-colors-custom-props.scss
@@ -1,5 +1,6 @@
-:root,
-[data-bs-theme="light"] {
+// scss-docs-start ouds-all-semantic-css-color
+// scss-docs-start ouds-semantic-css-color
+@include color-mode(light, true) {
   --#{$prefix}color-opacity-lower: #{$ouds-color-opacity-lower-light};
   --#{$prefix}color-opacity-lowest: #{$ouds-color-opacity-lowest-light};
   --#{$prefix}color-opacity-transparent: #{$ouds-color-opacity-transparent-light};
@@ -112,8 +113,9 @@
   --#{$prefix}elevation-color-sticky-emphasized: #{$ouds-elevation-color-sticky-emphasized-light};
   --#{$prefix}elevation-color-sticky-navigation-scrolled: #{$ouds-elevation-color-sticky-navigation-scrolled-light};
 }
+// scss-docs-end ouds-semantic-css-color
 
-[data-bs-theme="dark"] {
+@include color-mode(dark, true) {
   --#{$prefix}color-opacity-lower: #{$ouds-color-opacity-lower-dark};
   --#{$prefix}color-opacity-lowest: #{$ouds-color-opacity-lowest-dark};
   --#{$prefix}color-opacity-transparent: #{$ouds-color-opacity-transparent-dark};
@@ -226,3 +228,4 @@
   --#{$prefix}elevation-color-sticky-emphasized: #{$ouds-elevation-color-sticky-emphasized-dark};
   --#{$prefix}elevation-color-sticky-navigation-scrolled: #{$ouds-elevation-color-sticky-navigation-scrolled-dark};
 }
+// scss-docs-end ouds-all-semantic-css-color

--- a/site/assets/scss/_callouts.scss
+++ b/site/assets/scss/_callouts.scss
@@ -10,7 +10,7 @@
   margin-top: $spacer; // OUDS mod
   margin-bottom: $spacer; // OUDS mod
   color: var(--bd-callout-color, inherit);
-  background-color: var(--bd-callout-bg, var(--bs-gray-200)); // OUDS mod
+  background-color: var(--bd-callout-bg, var(--#{$prefix}color-surface-status-neutral)); // OUDS mod
   border-left: .25rem solid var(--bd-callout-border, var(--bs-gray-200)); // OUDS mod
 
   h4 {
@@ -32,7 +32,7 @@
 @each $variant in $bd-callout-variants {
   .bd-callout-#{$variant} {
     --bd-callout-color: var(--bs-emphasis-color); // OUDS mod: instead of `var(--bs-#{$variant}-text-emphasis)`
-    --bd-callout-bg: var(--bs-secondary-bg); // OUDS mod: instead of `var(--bs-#{$variant}-bg-subtle)`
+    --bd-callout-bg: var(--#{$prefix}color-surface-status-#{if($variant == "danger", negative, $variant)}-muted); // OUDS mod: instead of `var(--bs-#{$variant}-bg-subtle)`
     --bd-callout-border: var(--bs-#{$variant}-border-subtle);
   }
 }

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -207,7 +207,7 @@
     width: 9rem; // OUDS mod
     font-weight: $font-weight-bold; // OUDS mod
     color: var(--bs-secondary-color);
-    background-color: var(--bs-secondary-bg); // OUDS mod: instead of `var(--bs-tertiary-bg)`
+    background-color: var(--#{$prefix}color-bg-secondary); // OUDS mod: instead of `var(--bs-tertiary-bg)`
     border: var(--bs-border-width) solid var(--bs-color-border-default); // OUDS mod: instead of `var(--bs-border-width) solid var(--bs-border-color)`
 
     > div {
@@ -291,7 +291,7 @@
     width: 5rem;
     height: 5rem;
     margin: .25rem;
-    background-color: var(--bs-tertiary-bg);
+    background-color: var(--#{$prefix}color-bg-secondary);
   }
 }
 
@@ -307,13 +307,13 @@
 
   .position-relative {
     height: 12.5rem;
-    background-color: var(--bs-tertiary-bg);
+    background-color: var(--#{$prefix}color-bg-secondary);
   }
 
   .position-absolute {
     width: 2rem;
     height: 2rem;
-    background-color: var(--bs-body-color);
+    background-color: var(--#{$prefix}color-bg-emphasized);
     @include border-radius();
   }
 }
@@ -487,13 +487,13 @@
 .double-figure-svg {
   padding-top: 10px;
   padding-bottom: 10px;
-  background: linear-gradient(to bottom, $white, $white 50%, $ouds-color-functional-dark-gray-880 50%, $ouds-color-functional-dark-gray-880 100%);
+  background: linear-gradient(to bottom, $ouds-color-functional-white, $ouds-color-functional-white 50%, $ouds-color-functional-dark-gray-880 50%, $ouds-color-functional-dark-gray-880 100%);
 }
 
 .double-figure {
   padding-top: 10px;
   padding-bottom: 10px;
-  background: linear-gradient(to bottom, $white, $white calc((100% - 1.875rem) * .5), $ouds-color-functional-dark-gray-880 calc((100% - 1.875rem) * .5), $ouds-color-functional-dark-gray-880 calc(100% - 1.875rem), transparent calc(100% - 1.875rem)); // stylelint-disable-line function-disallowed-list
+  background: linear-gradient(to bottom, $ouds-color-functional-white, $ouds-color-functional-white calc((100% - 1.875rem) * .5), $ouds-color-functional-dark-gray-880 calc((100% - 1.875rem) * .5), $ouds-color-functional-dark-gray-880 calc(100% - 1.875rem), transparent calc(100% - 1.875rem)); // stylelint-disable-line function-disallowed-list
 
   figcaption {
     height: 1.875rem;

--- a/site/assets/scss/_masthead.scss
+++ b/site/assets/scss/_masthead.scss
@@ -27,7 +27,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    background-color: rgba(var(--bs-body-color-rgb), .075);
+    background-color: var(--#{$prefix}color-bg-secondary);
     @include border-radius(.5rem);
 
     @include media-breakpoint-up(lg) {

--- a/site/assets/scss/_ouds-web.scss
+++ b/site/assets/scss/_ouds-web.scss
@@ -1,5 +1,5 @@
 // stylelint-disable selector-max-id
-:root {
+#{$ouds-root-selector} {
   scroll-padding-top: $offset-top / 2;
 
   @include media-breakpoint-up(lg) {

--- a/site/assets/scss/_search.scss
+++ b/site/assets/scss/_search.scss
@@ -2,7 +2,7 @@
 
 // OUDS mod: the entire file is modified and is specific to OUDS Web
 
-:root {
+#{$ouds-root-selector} {
   // All available CSS vars and specific modifications for OUDS Web
   --docsearch-primary-color: var(--bs-primary);
   --docsearch-text-color: var(--bs-body-color);
@@ -130,7 +130,7 @@
 }
 
 .DocSearch-Commands-Key {
-  background-color: var(--bs-highlight-color);
+  background-color: var(--#{$prefix}color-action-highlighted);
 }
 
 .DocSearch-Hits {
@@ -152,18 +152,18 @@
 
   mark {
     color: var(--bs-highlight-color);
-    background: var(--bs-highlight-bg);
+    background: var(--#{$prefix}color-action-highlighted);
   }
 
   &[aria-selected="true"] {
     a {
-      background-color: var(--bs-highlight-bg);
+      background-color: var(--#{$prefix}color-action-highlighted);
     }
 
     mark {
       --docsearch-hit-active-color: var(--bs-body-color);
       text-decoration: none;
-      background: var(--bs-highlight-color);
+      background: var(--#{$prefix}color-action-highlighted);
     }
   }
 }

--- a/site/assets/scss/_subnav.scss
+++ b/site/assets/scss/_subnav.scss
@@ -3,6 +3,6 @@
 .bd-subnavbar {
   // The z-index is needed for the dropdown to stay on top of the content
   z-index: $zindex-dropdown - 1; // goes under the navbar + dropdown.
-  background-color: rgba(var(--bs-body-bg-rgb), .95);
+  background-color: var(--#{$prefix}color-bg-primary);
   box-shadow: 0 .5rem 1rem rgba(var(--bs-body-color-rgb), .05), inset 0 -1px 0 rgba(var(--bs-body-color-rgb), .15);
 }

--- a/site/assets/scss/_syntax.scss
+++ b/site/assets/scss/_syntax.scss
@@ -1,7 +1,6 @@
 // Note: Bootstrap stops at --base0F
 
-:root,
-[data-bs-theme="light"] {
+@include color-mode(light, true) {
   --base00: #{$white};
   --base01: #{$gray-700};
   --base02: #{$red-500};

--- a/site/assets/scss/_tarteaucitron.scss
+++ b/site/assets/scss/_tarteaucitron.scss
@@ -142,7 +142,7 @@
   bottom: add($spacer * -1.5, var(--bs-border-width));
   padding: $spacer / 4 $spacer / 2;
   color: $white;
-  background-color: var(--#{$prefix}color-always-black);
+  background-color: $ouds-color-functional-black;
 }
 
 @include tac("Allow", true) {

--- a/site/assets/scss/_tarteaucitron.scss
+++ b/site/assets/scss/_tarteaucitron.scss
@@ -37,7 +37,7 @@
   padding: $spacer calc((100% - var(--max-width, 312px)) / 2); // stylelint-disable-line function-disallowed-list
   font-weight: $font-weight-bold;
   color: $white;
-  background: $black;
+  background: $ouds-color-functional-black;
   border-top: var(--bs-border-width) solid var(--bs-color-border-default);
 
   &[style*="display: block"] {
@@ -142,7 +142,7 @@
   bottom: add($spacer * -1.5, var(--bs-border-width));
   padding: $spacer / 4 $spacer / 2;
   color: $white;
-  background-color: $black;
+  background-color: var(--#{$prefix}color-always-black);
 }
 
 @include tac("Allow", true) {

--- a/site/assets/scss/_toc.scss
+++ b/site/assets/scss/_toc.scss
@@ -65,7 +65,7 @@
   @include media-breakpoint-down(md) {
     nav {
       padding: $ouds-space-fixed-medium; // OUDS mod: instead of `1.25rem 1.25rem 1.25rem 1rem`
-      background-color: var(--bs-tertiary-bg);
+      background-color: var(--#{$prefix}color-bg-secondary);
       border: 1px solid var(--bs-color-border-emphasized);
       @include border-radius(var(--bs-border-radius));
     }

--- a/site/assets/scss/_variables.scss
+++ b/site/assets/scss/_variables.scss
@@ -11,8 +11,7 @@ $bd-violet:        lighten(saturate($bd-purple, 5%), 15%); // stylelint-disable-
 $bd-gutter-x: .625rem; // OUDS mod
 $bd-callout-variants: info, warning, danger !default;
 
-:root,
-[data-bs-theme="light"] {
+@include color-mode(light, true) {
   --bd-primary-light: #{$bd-primary-light}; // OUDS mod
   // OUDS mod: no --bd-purple
   --bd-violet: #{$bd-violet};
@@ -27,7 +26,7 @@ $bd-callout-variants: info, warning, danger !default;
   // OUDS mod: no --bd-sidebar-link-bg
   // OUDS mod: no --bd-callout-link
   // OUDS mod: no --bd-callout-code-color
-  --bd-pre-bg: var(--bs-tertiary-bg);
+  --bd-pre-bg: var(--#{$prefix}color-bg-secondary);
 }
 
 @include color-mode(dark, true) {
@@ -39,7 +38,7 @@ $bd-callout-variants: info, warning, danger !default;
   // OUDS mod: no --bd-sidebar-link-bg
   // OUDS mod: no --bd-callout-link
   // OUDS mod: no --bd-callout-code-color
-  --bd-pre-bg: var(--bs-tertiary-bg); // OUDS mod: instead of `#{adjust-color($gray-900, $lightness: -2.5%)}`
+  --bd-pre-bg: var(--#{$prefix}color-bg-secondary); // OUDS mod: instead of `#{adjust-color($gray-900, $lightness: -2.5%)}`
 }
 
 // OUDS mod

--- a/site/content/docs/0.0/content/reboot.md
+++ b/site/content/docs/0.0/content/reboot.md
@@ -26,7 +26,7 @@ Here are our guidelines and reasons for choosing what to override in Reboot:
 
 OUDS Web standards require `@import`s across all our CSS bundles (including `ouds-web.css`, `ouds-web-reboot.css`, and `ouds-web-grid.css`) to include `_root.scss`. This adds `:root` level CSS variables to all bundles, regardless of how many of them are used in that bundle. Ultimately OUDS Web will continue to see more [CSS variables]({{< docsref "/customize/css-variables" >}}) added over time, in order to provide more real-time customization without the need to always recompile Sass. Our approach is to take our source Sass variables and transform them into CSS variables. That way, even if you don't use CSS variables, you still have all the power of Sass. **This is still in-progress and will take time to fully implement.**
 
-For example, consider these `:root` CSS variables for common `<body>` styles:
+For example, consider these `:root` CSS variables for common `:root` styles:
 
 {{< scss-docs name="root-body-variables" file="scss/_root.scss" >}}
 
@@ -44,12 +44,12 @@ Which allows you to make real-time customizations however you like:
 
 ## Page defaults
 
-The `<html>` and `<body>` elements are updated to provide better page-wide defaults. More specifically:
+The `:root` and child elements are updated to provide better page-wide defaults. More specifically:
 
 - The `box-sizing` is globally set on every element—including `*::before` and `*::after`, to `border-box`. This ensures that the declared width of element is never exceeded due to padding or border.
-  - No base `font-size` is declared on the `<html>`, but `16px` is assumed (the browser default). `font-size: 1rem` is applied on the `<body>` for easy responsive type-scaling via media queries while respecting user preferences and ensuring a more accessible approach. This browser default can be overridden by modifying the `$font-size-root` variable.
-- The `<body>` also sets a global `font-family`, `font-weight`, `line-height`, and `color`. This is inherited later by some form elements to prevent font inconsistencies.
-- For safety, the `<body>` has a declared `background-color`, defaulting to `#fff`.
+  - No base `font-size` is declared on the `<html>`, but `16px` is assumed (the browser default). `font-size: 1rem` is applied on the `:root` children for easy responsive type-scaling via media queries while respecting user preferences and ensuring a more accessible approach. This browser default can be overridden by modifying the `$font-size-root` variable.
+- The `:root` children also sets a global `font-family`, `font-weight`, `line-height`, and `color`. This is inherited later by some form elements to prevent font inconsistencies.
+- For safety, the `:root` children has a declared `background-color`, defaulting to `#fff`.
 
 ## Native font stack
 

--- a/site/content/docs/0.0/content/typography.md
+++ b/site/content/docs/0.0/content/typography.md
@@ -14,10 +14,10 @@ OUDS Web sets basic global display, typography<!--, and link styles-->. When mor
 
 - Use a [native font stack]({{< docsref "/content/reboot#native-font-stack" >}}) that selects the best `font-family` for each OS and device.
 - For a more inclusive and accessible type scale, we use the browser's default root `font-size` (typically 16px) so visitors can customize their browser defaults as needed.
-- Use the `$font-family-base`, `$font-size-base`, and `$line-height-base` attributes as our typographic base applied to the `<body>`.
+- Use the `$font-family-base`, `$font-size-base`, and `$line-height-base` attributes as our typographic base applied to the `:root` children.
 - Use `max-width` on all font references for readability reasons. If you want to get rid of the `max-width`, please make sure to use our `.mw-none` [width utility]({{< docsref "/utilities/sizing" >}}).
-<!--- Set the global link color via `$link-color`.
-- Use `$body-bg` to set a `background-color` on the `<body>` (`#fff` by default).-->
+<!-- - Set the global link color via `$link-color`. -->
+- Use `$body-bg` to set a `background-color` on the `:root` children (`#fff` by default).
 
 These styles can be found within `_reboot.scss`, and the global variables are defined in `_variables.scss`. Make sure to set `$font-size-base` in `rem`.
 
@@ -158,7 +158,7 @@ Display headings are customizable via two variables, `$display-font-family` and 
 Since only [headings](#headings), [display headings](#display-headings) and `strong` text are meant to use **Bold** in main content, other contents should use `normal` font-weight. Each class sets `font-size` but also `line-height`, `letter-spacing`, and `max-width`. If you want to get rid of the `max-width`, please make sure to use our `.mw-none` [width utility]({{< docsref "/utilities/sizing" >}}). Here are the associated `font-size`s depending on the breakpoints. See our [Font utilities]({{< docsref "/utilities/text#font-size" >}}).
 
 {{< callout info >}}
-Body medium is set by default on `body` but we don't set the `max-width` property for usability reasons.
+Body medium is set by default on `:root` children but we don't set the `max-width` property for usability reasons.
 {{< /callout >}}
 
 {{< bs-table >}}

--- a/site/content/docs/0.0/customize/color-modes.md
+++ b/site/content/docs/0.0/customize/color-modes.md
@@ -206,17 +206,17 @@ Enable the built in dark color mode across your entire project by adding the `da
 </html>
 ```
 
-OUDS Web do ship with a built-in color mode picker, you can use the one from our own documentation if you like in our [Orange navbar section]({{< docsref "/components/orange-navbar#with-mode-selector" >}}). [Learn more in the JavaScript section.](#javascript)
+OUDS Web do ship with a built-in color mode picker, you can use the one from our own documentation<!-- if you like in our [Orange navbar section]({{< docsref "/components/orange-navbar#with-mode-selector" >}})-->. [Learn more in the JavaScript section.](#javascript)
 
 ### Building with Sass
 
 Our dark mode option is available to use for all users of OUDS Web, but it's controlled via data attributes instead of media queries and does not automatically toggle your project's color mode. You can disable our dark mode entirely via Sass by changing `$enable-dark-mode` to `false`.
 
-{{< callout warning >}}
+<!-- {{< callout warning >}}
 Please be aware that some of OUDS Web's components always use the contextual dark mode to have the same rendering both in light and dark mode, such as our [Orange navbar]({{< docsref "/components/orange-navbar" >}}) and [Footer]({{< docsref "/components/footer" >}}). Please respect this constraint.
 
 If you need to use them, you won't be able to disable the dark mode globally.
-{{< /callout >}}
+{{< /callout >}} -->
 
 #### Change default behavior
 
@@ -303,9 +303,9 @@ Outputs to:
 
 To allow visitors or users to toggle color modes, you'll need to create a toggle element to control the `data-bs-theme` attribute on the root element, `<html>`. We've built a toggler in our documentation that initially defers to a user's current system color mode, but provides an option to override that and pick a specific color mode.
 
-{{< callout info >}}
+<!-- {{< callout info >}}
 Check out our [Orange navbar mode selector variant]({{< docsref "/components/orange-navbar#with-mode-selector" >}}) to add a color mode selector to your navbar.
-{{< /callout >}}
+{{< /callout >}} -->
 
 Here's a look at the JavaScript that powers it. Feel free to inspect our own documentation navbar to see how it's implemented using HTML and CSS from our own components. It is suggested to include the JavaScript at the top of your page to reduce potential screen flickering during reloading of your site. Note that if you decide to use media queries for your color modes, your JavaScript may need to be modified or removed if you prefer an implicit control.
 

--- a/site/content/docs/0.0/customize/color-modes.md
+++ b/site/content/docs/0.0/customize/color-modes.md
@@ -1,11 +1,397 @@
 ---
 layout: docs
 title: Color modes
-description: OUDS Web supports color modes, or themes. Explore our default light color mode and the new dark mode, or create your own using our styles as your template.
+description: OUDS Web supports color modes, or themes. Explore our default light color mode and the dark mode.
 group: customize
 aliases:
   - "/docs/customize/color-modes/"
 toc: true
 ---
 
-{{< callout-soon "page" >}}
+{{< callout >}}
+**Try it yourself!** Download the source code and working demo for using Bootstrap with Stylelint, and the color modes from the [twbs/examples repository](https://github.com/twbs/examples/tree/main/color-modes). You can also [open the example in StackBlitz](https://stackblitz.com/github/twbs/examples/tree/main/color-modes?file=index.html).
+{{< /callout >}}
+
+## Modes
+
+Modes are a way to change the **color of the text and the components inside**. We provide 4 different modes that are `"light"`, `"dark"`, `"root"`, and `"root-inverted"`. The `"light"` and `"dark"` modes are static, while the `"root"` and `"root-inverted"` modes are dynamic.
+
+{{< callout warning >}}
+Be careful when using the `data-bs-theme` attribute on an element carrying one of our [`.bg-*` utilities]({{< docsref "/utilities/background" >}}), the `background-color` property will also be automatically changed to use the current defined color mode.
+{{< /callout >}}
+
+### Static color modes
+
+By default, we provide two static themes/modes that are `"light"` and `"dark"`. These themes are named static because once you've set the theme on an element it won't ever change whatever the main theme is. The `"light"` theme will set the text color to black and set the light variant for every components inside, while the `"dark"` theme will set the text color to white and set the dark variant for every components inside.
+
+{{< example >}}
+<div class="bg-emphasized p-short">
+  <div data-bs-theme="dark">
+    <p>Text and components in here will always be in dark mode</p>
+    <button class="btn btn-strong mb-short">Dark mode button</button>
+    <div class="bg-status-accent-emphasized p-short">
+      <div data-bs-theme="light">
+        <p>Text and components in here will always be in light mode</p>
+        <button class="btn btn-strong">Light mode button</button>
+      </div>
+    </div>
+  </div>
+</div>
+{{< /example >}}
+
+<!-- **OUDS Web supports color modes, starting with dark mode!** With OUDS Web, you can apply the different color modes as you see fit. We support a static light mode (default) and a static dark mode. Color modes can be toggled globally on the `<html>` element, or on specific components and elements, thanks to the `data-bs-theme` attribute.
+
+This `data-bs-theme` attribute will automatically apply the corresponding `color` property of the targeted element. Be careful, if you use the `data-bs-theme` attribute on an element carrying one of our [`.bg-*` utilities]({{< docsref "/utilities/background" >}}), the `background-color` property will also be automatically changed to use the current defined color mode.
+
+{{< example class="d-flex flex-column gap-tallest" >}}
+<div class="p-short">
+  <h1>Title</h1>
+  <p class="lead mb-none">This is a lead paragraph.</p>
+</div>
+<div class="p-short bg-primary" data-bs-theme="light">
+  <h1>Title</h1>
+  <p class="lead mb-none">This is a lead paragraph.</p>
+</div>
+<div class="p-short bg-primary" data-bs-theme="dark">
+  <h1>Title</h1>
+  <p class="lead mb-none">This is a lead paragraph.</p>
+</div>
+<div class="bg-status-neutral-emphasized p-short">
+  <div data-bs-theme="root-inverted">
+    <h1>Title</h1>
+    <p class="lead mb-none">This is a lead paragraph.</p>
+  </div>
+</div>
+{{< /example >}}
+
+{{< callout warning >}}
+Applying a color mode directly on a component or element (especially with some basic HTML elements, form controls, etc.), some unexpected rendering may occur. It is mostly related to the automatic change of `color` property linked to the color mode.
+
+Most of the time, the workaround will be to add a `data-bs-theme` attribute on a specific container of the component or element you want to apply a color mode to.
+{{< /callout >}}
+
+Alternatively, you can also switch to a media query implementation thanks to our color mode mixin—see [the usage section for details](#building-with-sass). Heads up though—this eliminates your ability to change themes on a per-component basis as shown below. -->
+
+#### `light` mode
+
+Light mode is the default mode of the page, it allows you to write using black text color and light mode components. To get the light theme independently from the cascade, you can set via <span class="user-select-all">`data-bs-theme="light"`</span> on any element. Feel free to change the color mode of the page to see the effect on the inside background example above.
+
+#### `dark` mode
+
+Dark mode allows you to write using light gray text color and dark mode components. To get the dark theme independently from the cascade, you can set via <span class="user-select-all">`data-bs-theme="dark"`</span> on any element. Feel free to change the color mode of the page to see the effect on the outside background example above.
+
+### Dynamic color modes
+
+We have two more dynamic themes that are `"root"` and `"root-inverted"`. These themes are named dynamic because they depend on the main element mode, so by changing the main mode, you're changing all those dynamic calls as well. The `"root"` theme will reset the color mode to the main theme of your page, while the `"root-inverted"` theme will reset the color mode to the opposite theme of your page.
+
+{{< callout info >}}
+Note that these themes **aren't meant to be used on the root element**.
+{{< /callout >}}
+
+{{< example >}}
+<div class="bg-status-neutral-emphasized p-short">
+  <div data-bs-theme="root-inverted">
+    <p>Text and components in here will always be inverted compared to the main mode</p>
+    <button class="btn btn-strong mb-short">Inverted mode button</button>
+    <div class="bg-status-neutral-emphasized p-short">
+      <div data-bs-theme="root">
+        <p>Text and components in here will always be reset to the main mode</p>
+        <button class="btn btn-strong">Main mode button</button>
+      </div>
+    </div>
+  </div>
+</div>
+{{< /example >}}
+
+#### `root-inverted` mode
+
+Here is an example of a block that inverts the main theme when it's placed inside a dark block. To get the inverted main theme independently from the cascade, set via <span class="user-select-all">`data-bs-theme="root-inverted"`</span> on any element but the main one. Feel free to change the color mode of the page to see the effect.
+
+#### `root` mode
+
+Here is an example of a block that follows the main theme when it's placed inside a dark block. To get the main theme independently from the cascade, set via <span class="user-select-all">`data-bs-theme="root"`</span> on any element but the main one. Feel free to change the color mode of the page to see the effect.
+
+<!-- TODO LM: Do we keep the example above or the example should be something that can happen ? Like a dropdown menu inside a header. -->
+
+## How to use
+
+You should apply a `[data-bs-theme]` attribute whenever **you need to change the text color** and the component variants inside.
+
+Here is a recap table of when to use which contextual theme. Prefer to use `light` and `dark` themes as much as possible to avoid unexpected rendering. The theme to use strongly depends on the context of use and there is no manner to automate it unfortunately.
+
+However, these 4 themes should be enough to deal with all of your use cases. If it's not the case, you are probably using them wrong. Since the implementation might be quite hard to understand, don't hesitate to contact us via our [GitHub discussions]({{< param repo >}}/discussions) with a reduced test case if you're having trouble implementing.
+
+{{< callout info >}}
+We usually use **2 different layers to set the `background-color` and the theme**. In some rare case you might want to set it on one element. <!-- TODO LM: Fill in the blank and explain -->
+{{< /callout >}}
+
+{{< bs-table >}}
+| Wanted local text color <br>inside main light mode | Wanted local text color <br>inside main dark mode | Theme that should be used |
+| --- | --- | --- |
+| Black | Black | <span class="user-select-all">`"light"`</span> |
+| White | White | <span class="user-select-all">`"dark"`</span> |
+| White | Black | <span class="user-select-all">`"root-inverted"`</span> |
+| Black | White | <span class="user-select-all">`"root"`</span> |
+{{< /bs-table >}}
+
+{{< callout warning >}}
+`root` theme should be used only in very specific occasions, most of the time it will cascade from the main theme.
+{{< /callout >}}
+
+## Examples
+
+Here are some examples of how to use the different `data-bs-theme` attribute on different use cases.
+
+{{< example class="d-flex justify-content-between flex-wrap gap-shortest" >}}
+<div class="dropdown" data-bs-theme="light">
+  <button class="btn btn-dropdown dropdown-toggle" type="button" id="dropdownMenuButtonLight" data-bs-toggle="dropdown" aria-expanded="false">
+    Always light dropdown
+  </button>
+  <ul class="dropdown-menu" aria-labelledby="dropdownMenuButtonLight">
+    <li><a class="dropdown-item active" href="#">Action</a></li>
+    <li><a class="dropdown-item" href="#">Action</a></li>
+    <li><a class="dropdown-item" href="#">Another action</a></li>
+    <li><a class="dropdown-item" href="#">Something else here</a></li>
+    <li><hr class="dropdown-divider"></li>
+    <li><a class="dropdown-item" href="#">Separated link</a></li>
+  </ul>
+</div>
+
+<div class="dropdown" data-bs-theme="dark">
+  <button class="btn btn-dropdown dropdown-toggle" type="button" id="dropdownMenuButtonDark" data-bs-toggle="dropdown" aria-expanded="false">
+    Always dark dropdown
+  </button>
+  <ul class="dropdown-menu" aria-labelledby="dropdownMenuButtonDark">
+    <li><a class="dropdown-item active" href="#">Action</a></li>
+    <li><a class="dropdown-item" href="#">Action</a></li>
+    <li><a class="dropdown-item" href="#">Another action</a></li>
+    <li><a class="dropdown-item" href="#">Something else here</a></li>
+    <li><hr class="dropdown-divider"></li>
+    <li><a class="dropdown-item" href="#">Separated link</a></li>
+  </ul>
+</div>
+
+<div data-bs-theme="root-inverted" class="dropdown">
+  <button class="btn btn-dropdown dropdown-toggle" type="button" id="dropdownMenuButtonRootInverted" data-bs-toggle="dropdown" aria-expanded="false">
+    Main inverted theme dropdown
+  </button>
+  <ul class="dropdown-menu" aria-labelledby="dropdownMenuButtonRootInverted">
+    <li><a class="dropdown-item active" href="#">Action</a></li>
+    <li><a class="dropdown-item" href="#">Action</a></li>
+    <li><a class="dropdown-item" href="#">Another action</a></li>
+    <li><a class="dropdown-item" href="#">Something else here</a></li>
+    <li><hr class="dropdown-divider"></li>
+    <li><a class="dropdown-item" href="#">Separated link</a></li>
+  </ul>
+</div>
+
+<div data-bs-theme="root-inverted" class="dropdown">
+  <button class="btn btn-dropdown dropdown-toggle" type="button" id="dropdownMenuButtonRoot" data-bs-toggle="dropdown" aria-expanded="false">
+    Main inverted theme dropdown and main theme dropdown menu
+  </button>
+  <ul data-bs-theme="root" class="dropdown-menu" aria-labelledby="dropdownMenuButtonRoot">
+    <li><a class="dropdown-item active" href="#">Action</a></li>
+    <li><a class="dropdown-item" href="#">Action</a></li>
+    <li><a class="dropdown-item" href="#">Another action</a></li>
+    <li><a class="dropdown-item" href="#">Something else here</a></li>
+    <li><hr class="dropdown-divider"></li>
+    <li><a class="dropdown-item" href="#">Separated link</a></li>
+  </ul>
+</div>
+{{< /example >}}
+
+## How it works
+
+- As shown above, color mode styles are controlled by the `data-bs-theme` attribute. This attribute can be applied to the `<html>` element (using `light` or `dark`), or to any other element or OUDS Web component. If applied to the `<html>` element, it will apply to everything. If applied to a component or element, it will be scoped to that specific component or element.
+
+- `root` and `root-inverted` are some automated modes compared to the root mode.
+
+- For each color mode you wish to support, you'll need to add new overrides for the shared global CSS variables. We do this already in our `_root.scss` stylesheet for dark mode, with light mode being the default values. In writing color mode specific styles, use the mixin:
+
+  ```scss
+  // Color mode variables in _root.scss
+  @include color-mode(dark) {
+    // CSS variable overrides here...
+  }
+  ```
+
+- We use a custom `_variables-dark.scss` to power those shared global CSS variable overrides for dark mode. This file isn't required for your own custom color modes, but it's required for our dark mode for two reasons. First, it's better to have a single place to reset global colors. Second, some Sass variables had to be overridden for background images embedded in our CSS for accordions, form components, and more.
+
+## Usage
+
+### Enable dark mode
+
+Enable the built in dark color mode across your entire project by adding the `data-bs-theme="dark"` attribute to the `<html>` element. This will apply the dark color mode to all components and elements, other than those with a specific `data-bs-theme` attribute applied. Building on the [quick start template]({{< docsref "/getting-started/introduction#quick-start" >}}):
+
+```html
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OUDS Web demo</title>
+    <link href="{{< param "cdn.css" >}}" rel="stylesheet" integrity="{{< param "cdn.css_hash" >}}" crossorigin="anonymous">
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    <script src="{{< param "cdn.js_bundle" >}}" integrity="{{< param "cdn.js_bundle_hash" >}}" crossorigin="anonymous"></script>
+  </body>
+</html>
+```
+
+OUDS Web do ship with a built-in color mode picker, you can use the one from our own documentation if you like in our [Orange navbar section]({{< docsref "/components/orange-navbar#with-mode-selector" >}}). [Learn more in the JavaScript section.](#javascript)
+
+### Building with Sass
+
+Our dark mode option is available to use for all users of OUDS Web, but it's controlled via data attributes instead of media queries and does not automatically toggle your project's color mode. You can disable our dark mode entirely via Sass by changing `$enable-dark-mode` to `false`.
+
+{{< callout warning >}}
+Please be aware that some of OUDS Web's components always use the contextual dark mode to have the same rendering both in light and dark mode, such as our [Orange navbar]({{< docsref "/components/orange-navbar" >}}) and [Footer]({{< docsref "/components/footer" >}}). Please respect this constraint.
+
+If you need to use them, you won't be able to disable the dark mode globally.
+{{< /callout >}}
+
+#### Change default behavior
+
+We use a custom Sass mixin, `color-mode()`, to help you control _how_ color modes are applied. By default, we use a `data` attribute approach, allowing you to create more user-friendly experiences where your visitors can choose to have an automatic dark mode or control their preference (like in our own docs here). This is also an easy and scalable way to add different themes and more custom color modes beyond light and dark.
+
+In case you want to use media queries and only make color modes automatic, you can change the mixin's default type via Sass variable. Consider the following snippet and its compiled CSS output.
+
+```scss
+$color-mode-type: data;
+
+@include color-mode(dark) {
+  .element {
+    color: var(--bs-primary-text-emphasis);
+    background-color: var(--bs-primary-bg-subtle);
+  }
+}
+```
+
+Outputs to:
+
+```css
+[data-bs-theme=dark] .element {
+  color: var(--bs-primary-text-emphasis);
+  background-color: var(--bs-primary-bg-subtle);
+}
+```
+
+And when setting to `media-query`:
+
+```scss
+$color-mode-type: media-query;
+
+@include color-mode(dark) {
+  .element {
+    color: var(--bs-primary-text-emphasis);
+    background-color: var(--bs-primary-bg-subtle);
+  }
+}
+```
+
+Outputs to:
+
+```css
+@media (prefers-color-scheme: dark) {
+  .element {
+    color: var(--bs-primary-text-emphasis);
+    background-color: var(--bs-primary-bg-subtle);
+  }
+}
+```
+
+#### Change the root selector
+
+You can also change the root selector from where the theme variables are set. By default, it's set to `:root`, but you can change it to any other selector. This is useful if you want to apply the theme to another element, for instance in Angular where you can't access easily the `<html>` element.
+
+```scss
+$ouds-root-selector: "#app";
+
+@include "@ouds/web";
+```
+
+Outputs to:
+
+```css
+#app,
+[data-bs-theme="light"],
+#app[data-bs-theme="light"] [data-bs-theme="root"],
+#app[data-bs-theme="dark"] [data-bs-theme="root-inverted"] {
+  /* Your light mode variables definition */
+}
+
+[data-bs-theme="dark"],
+#app[data-bs-theme="dark"] [data-bs-theme="root"],
+#app[data-bs-theme="light"] [data-bs-theme="root-inverted"] {
+  /* Your dark mode variables definition */
+}
+
+/* Further OUDS Web CSS */
+```
+
+<!-- OUDS mod: moved in `custom-libraries.md` the title ## Custom color modes -->
+
+## JavaScript
+
+To allow visitors or users to toggle color modes, you'll need to create a toggle element to control the `data-bs-theme` attribute on the root element, `<html>`. We've built a toggler in our documentation that initially defers to a user's current system color mode, but provides an option to override that and pick a specific color mode.
+
+{{< callout info >}}
+Check out our [Orange navbar mode selector variant]({{< docsref "/components/orange-navbar#with-mode-selector" >}}) to add a color mode selector to your navbar.
+{{< /callout >}}
+
+Here's a look at the JavaScript that powers it. Feel free to inspect our own documentation navbar to see how it's implemented using HTML and CSS from our own components. It is suggested to include the JavaScript at the top of your page to reduce potential screen flickering during reloading of your site. Note that if you decide to use media queries for your color modes, your JavaScript may need to be modified or removed if you prefer an implicit control.
+
+{{< example lang="js" show_preview="false" >}}
+{{< js.inline >}}
+{{- readFile (path.Join "site/static/docs" .Site.Params.docs_version "assets/js/color-modes.js") -}}
+{{< /js.inline >}}
+{{< /example >}}
+
+<!-- ## Adding theme colors -->
+
+## CSS
+
+### Sass tokens
+
+#### Raw tokens
+
+Colors raw tokens as Sass variables. **Not to be used as-is**.
+
+{{< scss-docs name="ouds-raw-color" file="scss/tokens/_raw.scss" >}}
+
+#### Semantic tokens
+
+Color semantic tokens as Sass variables. **Should not be used as-is**. Prefer use our [CSS semantic tokens](#css-semantic-tokens).
+
+{{< scss-docs name="ouds-semantic-color" file="scss/tokens/_semantic.scss" >}}
+
+### Variables
+
+We have our OUDS semantic CSS variables, which transform over light and dark modes. These are the variables you'll use in your own custom CSS to style components and elements.
+
+{{< scss-docs name="ouds-all-semantic-css-color" file="scss/tokens/_semantic-colors-custom-props.scss" >}}
+
+{{< bootstrap-compatibility false >}}
+
+Dozens of root level CSS variables are repeated as overrides for dark mode. These are scoped to the color mode selector, which defaults to `data-bs-theme` but [can be configured](#building-with-sass) to use a `prefers-color-scheme` media query. Use these variables as a guideline for generating your own new color modes.
+
+{{< scss-docs name="root-dark-mode-vars" file="scss/_root.scss" >}}
+
+{{< /bootstrap-compatibility >}}
+
+### Sass variables
+
+{{< bootstrap-compatibility false >}}
+
+CSS variables for our dark color mode are partially generated from dark mode specific Sass variables in `_variables-dark.scss`. This also includes some custom overrides for changing the colors of embedded SVGs used throughout our components.
+
+{{< scss-docs name="sass-dark-mode-vars" file="scss/_variables-dark.scss" >}}
+
+{{< /bootstrap-compatibility >}}
+
+### Sass mixins
+
+Styles for dark mode, and any custom color modes you create, can be scoped appropriately to the `data-bs-theme` attribute selector or media query with the customizable `color-mode()` mixin. See the [Sass usage section](#building-with-sass) for more details.
+
+{{< scss-docs name="color-mode-mixin" file="scss/mixins/_color-mode.scss" >}}

--- a/site/content/docs/0.0/customize/color-modes.md
+++ b/site/content/docs/0.0/customize/color-modes.md
@@ -39,39 +39,6 @@ By default, we provide two static themes/modes that are `"light"` and `"dark"`. 
 </div>
 {{< /example >}}
 
-<!-- **OUDS Web supports color modes, starting with dark mode!** With OUDS Web, you can apply the different color modes as you see fit. We support a static light mode (default) and a static dark mode. Color modes can be toggled globally on the `<html>` element, or on specific components and elements, thanks to the `data-bs-theme` attribute.
-
-This `data-bs-theme` attribute will automatically apply the corresponding `color` property of the targeted element. Be careful, if you use the `data-bs-theme` attribute on an element carrying one of our [`.bg-*` utilities]({{< docsref "/utilities/background" >}}), the `background-color` property will also be automatically changed to use the current defined color mode.
-
-{{< example class="d-flex flex-column gap-tallest" >}}
-<div class="p-short">
-  <h1>Title</h1>
-  <p class="lead mb-none">This is a lead paragraph.</p>
-</div>
-<div class="p-short bg-primary" data-bs-theme="light">
-  <h1>Title</h1>
-  <p class="lead mb-none">This is a lead paragraph.</p>
-</div>
-<div class="p-short bg-primary" data-bs-theme="dark">
-  <h1>Title</h1>
-  <p class="lead mb-none">This is a lead paragraph.</p>
-</div>
-<div class="bg-status-neutral-emphasized p-short">
-  <div data-bs-theme="root-inverted">
-    <h1>Title</h1>
-    <p class="lead mb-none">This is a lead paragraph.</p>
-  </div>
-</div>
-{{< /example >}}
-
-{{< callout warning >}}
-Applying a color mode directly on a component or element (especially with some basic HTML elements, form controls, etc.), some unexpected rendering may occur. It is mostly related to the automatic change of `color` property linked to the color mode.
-
-Most of the time, the workaround will be to add a `data-bs-theme` attribute on a specific container of the component or element you want to apply a color mode to.
-{{< /callout >}}
-
-Alternatively, you can also switch to a media query implementation thanks to our color mode mixin—see [the usage section for details](#building-with-sass). Heads up though—this eliminates your ability to change themes on a per-component basis as shown below. -->
-
 #### `light` mode
 
 Light mode is the default mode of the page, it allows you to write using black text color and light mode components. To get the light theme independently from the cascade, you can set via <span class="user-select-all">`data-bs-theme="light"`</span> on any element. Feel free to change the color mode of the page to see the effect on the inside background example above.

--- a/site/content/docs/0.0/customize/color-palette.md
+++ b/site/content/docs/0.0/customize/color-palette.md
@@ -40,7 +40,7 @@ This section exposes all the existing colors inside the OUDS Web palette. These 
         </button>
         <figcaption class="py-shortest">
           <code class="user-select-all">{{ $color.hex }}</code>
-          <hr class="my-shortest bg-transparent border-top" style="border-color:{{ $color.hex }} !important">
+          <hr class="my-shortest border-top" style="border-color:{{ $color.hex }} !important">
           <var class="user-select-all">{{- $color.variable -}}</var>
         </figcaption>
       </figure>
@@ -128,7 +128,8 @@ Here's how you should use these in your Sass:
 }
 ```
 
-<!-- [Color]({{< docsref "/utilities/colors" >}}) and [background]({{< docsref "/utilities/background" >}}) utility classes are also available for setting `color` and `background-color`. -->
+<!-- [Color]({{< docsref "/utilities/colors" >}}) and -->
+[Background]({{< docsref "/utilities/background" >}}) utility classes are also available for setting <!--`color` and -->`background-color`.
 </details>
 
 ## CSS

--- a/site/content/docs/0.0/customize/custom-libraries.md
+++ b/site/content/docs/0.0/customize/custom-libraries.md
@@ -66,7 +66,7 @@ While the primary use case for [color modes]({{< docsref "/customize/color-modes
 
 For example, you can create a "blue theme" with the selector `data-bs-theme="blue"`. In your custom Sass or CSS file, add the new selector and override any global or component CSS variables as needed. If you're using Sass, you can also use Sass's functions within your CSS variable overrides.
 
-{{< scss-docs name="custom-color-mode" file="site/assets/scss/_content.scss" >}}
+{< scss-docs name="custom-color-mode" file="site/assets/scss/_content.scss" >}}
 
 <div class="bd-example bg-body" data-bs-theme="blue">
   <div class="h4">Example blue theme</div>

--- a/site/content/docs/0.0/customize/custom-libraries.md
+++ b/site/content/docs/0.0/customize/custom-libraries.md
@@ -60,9 +60,7 @@ In the absence of a designer, it’s advisable to reach out to the [OUDS Web cor
 
 You are responsible for building and deploying your documentation. You can start with our existing documentation, modifying or removing sections as needed to fit your new design. Alternatively, you may choose to build your documentation from scratch using any preferred framework.
 
-### Custom color modes
-
-<!-- TODO LM: Do we Ouds ify this paragraph or remove it ? -->
+<!-- ### Custom color modes
 
 While the primary use case for [color modes]({{< docsref "/customize/color-modes" >}}) is light and dark mode, custom color modes are also possible. Create your own `data-bs-theme` selector with a custom value as the name of your color mode, then modify our Sass and CSS variables as needed. We opted to create a separate `_variables-dark.scss` stylesheet to house Boosted's dark mode specific Sass variables, but that's not required for you.
 
@@ -95,4 +93,4 @@ For example, you can create a "blue theme" with the selector `data-bs-theme="blu
 <div class="bg-body" data-bs-theme="blue">
   ...
 </div>
-```
+``` -->

--- a/site/content/docs/0.0/customize/custom-libraries.md
+++ b/site/content/docs/0.0/customize/custom-libraries.md
@@ -59,3 +59,40 @@ In the absence of a designer, it’s advisable to reach out to the [OUDS Web cor
 ### Building and deploying documentation
 
 You are responsible for building and deploying your documentation. You can start with our existing documentation, modifying or removing sections as needed to fit your new design. Alternatively, you may choose to build your documentation from scratch using any preferred framework.
+
+### Custom color modes
+
+<!-- TODO LM: Do we Ouds ify this paragraph or remove it ? -->
+
+While the primary use case for [color modes]({{< docsref "/customize/color-modes" >}}) is light and dark mode, custom color modes are also possible. Create your own `data-bs-theme` selector with a custom value as the name of your color mode, then modify our Sass and CSS variables as needed. We opted to create a separate `_variables-dark.scss` stylesheet to house Boosted's dark mode specific Sass variables, but that's not required for you.
+
+For example, you can create a "blue theme" with the selector `data-bs-theme="blue"`. In your custom Sass or CSS file, add the new selector and override any global or component CSS variables as needed. If you're using Sass, you can also use Sass's functions within your CSS variable overrides.
+
+{{< scss-docs name="custom-color-mode" file="site/assets/scss/_content.scss" >}}
+
+<div class="bd-example bg-body" data-bs-theme="blue">
+  <div class="h4">Example blue theme</div>
+  <p>Some paragraph text to show how the blue theme might look with written copy.</p>
+
+  <hr class="my-4">
+
+  <div class="dropdown">
+    <button class="btn btn-dropdown dropdown-toggle" type="button" id="dropdownMenuButtonCustom" data-bs-toggle="dropdown" aria-expanded="false">
+      Dropdown button
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="dropdownMenuButtonCustom">
+      <li><a class="dropdown-item active" href="#">Action</a></li>
+      <li><a class="dropdown-item" href="#">Action</a></li>
+      <li><a class="dropdown-item" href="#">Another action</a></li>
+      <li><a class="dropdown-item" href="#">Something else here</a></li>
+      <li><hr class="dropdown-divider"></li>
+      <li><a class="dropdown-item" href="#">Separated link</a></li>
+    </ul>
+  </div>
+</div>
+
+```html
+<div class="bg-body" data-bs-theme="blue">
+  ...
+</div>
+```

--- a/site/content/docs/0.0/customize/options.md
+++ b/site/content/docs/0.0/customize/options.md
@@ -15,13 +15,13 @@ You can find and customize these variables for key global options in OUDS Web's 
 | Variable                          | Values                                | Description                                                                            |
 | --------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------- |
 | `$ouds-dimension-base`            | `4px` (default), or any value > 0     | Specifies the default spacer value to programmatically generate our [spacer utilities]({{< docsref "/utilities/spacing" >}}). |
+| `$enable-dark-mode`               | `true` (default) or `false`           | Enables built-in [dark mode support]({{< docsref "/customize/color-modes#dark-mode" >}}) across the project and its components. |
 | `$enable-bootstrap-compatibility` | `true` or `false` (default)           | Enforces Bootstrap compatibility. |
 | `$enable-grid-classes`            | `true` (default) or `false`           | Enables the generation of CSS classes for the grid system (e.g. `.row`, `.col-md-1`, etc.). |
 | `$enable-container-classes`       | `true` (default) or `false`           | Enables the generation of CSS classes for layout containers. |
 | `$enable-negative-margins`        | `true` or `false` (default)           | Enables the generation of [negative margin utilities]({{< docsref "/utilities/spacing#negative-margin" >}}). |
 | `$enable-deprecation-messages`    | `true` (default) or `false`           | Set to `false` to hide warnings when using any of the deprecated mixins and functions that are planned to be removed in Bootstrap `v6`. |
 | `$enable-important-utilities`     | `true` (default) or `false`           | Enables the `!important` suffix in utility classes. |
-| `$enable-dark-mode`               | `true` (default) or `false`           | Enables built-in [dark mode support]({{< docsref "/customize/color-modes#dark-mode" >}}) across the project and its components. |
 <!--| `$enable-rounded`              | `true` or `false` (default)           | Enables predefined `border-radius` styles on various components. |
 | `$enable-shadows`              | `true` or `false` (default)           | Enables predefined decorative `box-shadow` styles on various components. Does not affect `box-shadow`s used for focus states. |
 | `$enable-gradients`            | `true` or `false` (default)           | Enables predefined gradients via `background-image` styles on various components. |

--- a/site/content/docs/0.0/customize/options.md
+++ b/site/content/docs/0.0/customize/options.md
@@ -21,8 +21,8 @@ You can find and customize these variables for key global options in OUDS Web's 
 | `$enable-negative-margins`        | `true` or `false` (default)           | Enables the generation of [negative margin utilities]({{< docsref "/utilities/spacing#negative-margin" >}}). |
 | `$enable-deprecation-messages`    | `true` (default) or `false`           | Set to `false` to hide warnings when using any of the deprecated mixins and functions that are planned to be removed in Bootstrap `v6`. |
 | `$enable-important-utilities`     | `true` (default) or `false`           | Enables the `!important` suffix in utility classes. |
-<!--| `$enable-dark-mode`            | `true` (default) or `false`           | Enables built-in [dark mode support]({{< docsref "/customize/color-modes#dark-mode" >}}) across the project and its components. |
-| `$enable-rounded`              | `true` or `false` (default)           | Enables predefined `border-radius` styles on various components. |
+| `$enable-dark-mode`               | `true` (default) or `false`           | Enables built-in [dark mode support]({{< docsref "/customize/color-modes#dark-mode" >}}) across the project and its components. |
+<!--| `$enable-rounded`              | `true` or `false` (default)           | Enables predefined `border-radius` styles on various components. |
 | `$enable-shadows`              | `true` or `false` (default)           | Enables predefined decorative `box-shadow` styles on various components. Does not affect `box-shadow`s used for focus states. |
 | `$enable-gradients`            | `true` or `false` (default)           | Enables predefined gradients via `background-image` styles on various components. |
 | `$enable-transitions`          | `true` (default) or `false`           | Enables predefined `transition`s on various components. |

--- a/site/content/docs/0.0/examples/grid-system/index.html
+++ b/site/content/docs/0.0/examples/grid-system/index.html
@@ -29,7 +29,7 @@ aliases:
       <span class="bg-col legend border me-short"></span>Columns color (<code>#a5daf3</code>)
     </p>
     <p class="d-flex align-items-center">
-      <span class="bg-white legend border me-short"></span>Gutters color (<code>#fff</code>)
+      <span class="bg-always-white legend border me-short"></span>Gutters color (<code>#fff</code>)
     </p>
   </div>
 

--- a/site/content/docs/0.0/getting-started/browsers-devices.md
+++ b/site/content/docs/0.0/getting-started/browsers-devices.md
@@ -58,11 +58,11 @@ Internet Explorer is not supported.
 
 ### Overflow and scrolling
 
-Support for `overflow: hidden;` on the `<body>` element is quite limited in iOS and Android. To that end, when you scroll past the top or bottom of a modal in either of those devices' browsers, the `<body>` content will begin to scroll. See [Chrome bug #175502](https://issues.chromium.org/issues/40301599) (fixed in Chrome v40) and [WebKit bug #153852](https://bugs.webkit.org/show_bug.cgi?id=153852).
+Support for `overflow: hidden;` on the `:root` children elements is quite limited in iOS and Android. To that end, when you scroll past the top or bottom of a modal in either of those devices' browsers, the `:root` children content will begin to scroll. See [Chrome bug #175502](https://issues.chromium.org/issues/40301599) (fixed in Chrome v40) and [WebKit bug #153852](https://bugs.webkit.org/show_bug.cgi?id=153852).
 
 ### iOS text fields and scrolling
 
-As of iOS 9.2, while a modal is open, if the initial touch of a scroll gesture is within the boundary of a textual `<input>` or a `<textarea>`, the `<body>` content underneath the modal will be scrolled instead of the modal itself. See [WebKit bug #153856](https://bugs.webkit.org/show_bug.cgi?id=153856).
+As of iOS 9.2, while a modal is open, if the initial touch of a scroll gesture is within the boundary of a textual `<input>` or a `<textarea>`, the `:root` children content underneath the modal will be scrolled instead of the modal itself. See [WebKit bug #153856](https://bugs.webkit.org/show_bug.cgi?id=153856).
 
 ### Navbar Dropdowns
 

--- a/site/content/docs/0.0/helpers/clearfix.md
+++ b/site/content/docs/0.0/helpers/clearfix.md
@@ -33,7 +33,7 @@ Use the mixin in SCSS:
 <!-- The following example shows how the clearfix can be used. Without the clearfix the wrapping div would not span around the buttons which would cause a broken layout.
 
 {{< example >}}
-<div class="bg-info clearfix">
+<div class="bg-status-info-emphasized clearfix">
   <button type="button" class="btn btn-secondary float-start">Example Button floated left</button>
   <button type="button" class="btn btn-secondary float-end">Example Button floated right</button>
 </div>

--- a/site/content/docs/0.0/helpers/icon.md
+++ b/site/content/docs/0.0/helpers/icon.md
@@ -314,7 +314,7 @@ Here are the rules to follow for decorative icons. Be careful using these icons'
 
 <div class="bd-example">
   <div class="d-flex mb-medium">
-    <div class="bg-secondary d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
+    <div class="bg-emphasized d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
       <svg class="decorative-2xs-icon text-info" width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
         <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#vector"/>
       </svg>
@@ -325,7 +325,7 @@ Here are the rules to follow for decorative icons. Be careful using these icons'
     </div>
   </div>
   <div class="d-flex mb-medium">
-    <div class="bg-secondary d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
+    <div class="bg-emphasized d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
       <svg class="decorative-xs-icon text-info" width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
         <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#vector"/>
       </svg>
@@ -336,7 +336,7 @@ Here are the rules to follow for decorative icons. Be careful using these icons'
     </div>
   </div>
   <div class="d-flex mb-medium">
-    <div class="bg-secondary d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
+    <div class="bg-emphasized d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
       <svg class="decorative-sm-icon text-info" width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
         <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#vector"/>
       </svg>
@@ -347,7 +347,7 @@ Here are the rules to follow for decorative icons. Be careful using these icons'
     </div>
   </div>
   <div class="d-flex mb-medium">
-    <div class="bg-secondary d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
+    <div class="bg-emphasized d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
       <svg class="decorative-md-icon text-info" width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
         <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#vector"/>
       </svg>
@@ -358,7 +358,7 @@ Here are the rules to follow for decorative icons. Be careful using these icons'
     </div>
   </div>
   <div class="d-flex mb-medium">
-    <div class="bg-secondary d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
+    <div class="bg-emphasized d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
       <svg class="decorative-lg-icon text-info" width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
         <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#vector"/>
       </svg>
@@ -369,7 +369,7 @@ Here are the rules to follow for decorative icons. Be careful using these icons'
     </div>
   </div>
   <div class="d-flex mb-medium">
-    <div class="bg-secondary d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
+    <div class="bg-emphasized d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
       <svg class="decorative-xl-icon text-info" width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
         <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#vector"/>
       </svg>
@@ -380,7 +380,7 @@ Here are the rules to follow for decorative icons. Be careful using these icons'
     </div>
   </div>
   <div class="d-flex mb-medium">
-    <div class="bg-secondary d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
+    <div class="bg-emphasized d-inline-flex align-items-center justify-content-center me-medium flex-shrink-0" style="width: 6.25rem; height: 6.25rem;">
       <svg class="decorative-2xl-icon text-info" width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
         <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#vector"/>
       </svg>

--- a/site/content/docs/0.0/helpers/stretched-link.md
+++ b/site/content/docs/0.0/helpers/stretched-link.md
@@ -38,7 +38,7 @@ Most custom components do not have `position: relative` by default, so we need t
 {{< /example >}}
 
 {{< example >}}
-<div class="row g-none bg-body-secondary position-relative">
+<div class="row g-none bg-secondary position-relative">
   <div class="col-md-6 mb-md-none p-md-tallest">
     {{< placeholder width="100%" height="200" class="w-100" text="false" title="Generic placeholder image" >}}
   </div>
@@ -68,7 +68,7 @@ If the stretched link doesn't seem to work, the [containing block](https://devel
     <p class="card-text">
       <a href="#" class="stretched-link text-danger" style="position: relative;">Stretched link will not work here, because <code>position: relative</code> is added to the link</a>
     </p>
-    <p class="card-text bg-body-tertiary" style="transform: rotate(0);">
+    <p class="card-text bg-secondary" style="transform: rotate(0);">
       This <a href="#" class="text-warning stretched-link">stretched link</a> will only be spread over the <code>p</code>-tag, because a transform is applied to it.
     </p>
   </div>

--- a/site/content/docs/0.0/utilities/api.md
+++ b/site/content/docs/0.0/utilities/api.md
@@ -196,8 +196,8 @@ Output:
 
 ### Local CSS variables
 
-Use the `local-vars` option to specify a Sass map that will generate local CSS variables within the utility class's ruleset. Please note that it may require additional work to consume those local CSS variables in the generated CSS rules. <!--For example, consider our `.bg-*` utilities:-->
-<!--
+Use the `local-vars` option to specify a Sass map that will generate local CSS variables within the utility class's ruleset. Please note that it may require additional work to consume those local CSS variables in the generated CSS rules. For example, consider our `.bg-*` utilities:
+
 ```scss
 $utilities: (
   "background-color": (
@@ -220,10 +220,15 @@ Output:
 
 ```css
 .bg-primary {
-  -bs-bg-opacity: 1; // TODO: reinsert hyphens
-  background-color: rgba(var(-bs-primary-rgb), var(-bs-bg-opacity)) !important; // TODO: reinsert hyphens
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-primary-rgb), var(--bs-bg-opacity)) !important;
 }
-```-->
+/* ... */
+.bg-transparent {
+  --bs-bg-opacity: 1;
+  background-color: transparent !important;
+}
+```
 
 ### States
 

--- a/site/content/docs/0.0/utilities/background.md
+++ b/site/content/docs/0.0/utilities/background.md
@@ -8,4 +8,268 @@ aliases:
 toc: true
 ---
 
-{{< callout-soon "page" >}}
+{{< callout info >}}
+{{< partial "callouts/warning-color-assistive-technologies.md" >}}
+{{< /callout >}}
+
+## Background color
+
+Background utilities like `.bg-*` are generated from our `$ouds-backgrounds` Sass map and respond to color modes.
+
+Similar to the contextual text color classes, set the background of an element to any contextual class. Background utilities **do not set `color`**, so depending on the cases you'll want to use an additional:
+* `[data-bs-theme]` [color mode attribute]({{< docsref "/customize/color-modes#how-to-use" >}}) when the element using a background utility contains complex sub-elements such as components that need to respond to color modes
+<!-- * `.text-*` [color utilities]({{< docsref "/utilities/colors" >}}) when the background color remains the same in light and dark mode
+* `.text-bg-*` [color & background helper]({{< docsref "/helpers/color-background" >}}) from our [theme colors]({{< docsref "/customize/color-theme#theming" >}}) -->
+
+{{< bootstrap-compatibility >}}
+
+Here are the equivalent Bootstrap background that you shouldn't be using. Prefer using the classes above according to [our design system]({{< param ouds.web >}}).
+
+<!-- TODO LM: Check whenever the mapping with Bootstrap is done -->
+{{< example >}}
+{{< colors.inline >}}
+{{- range (index $.Site.Data "theme-colors") }}
+<div class="p-3 mb-2 bg-{{ .name }}{{ if .contrast_color }} text-{{ .contrast_color }}{{ else }} text-white{{ end }}">.bg-{{ .name }}</div>
+<div class="p-3 mb-2 bg-{{ .name }}-subtle text-{{ .name }}-emphasis">.bg-{{ .name }}-subtle</div>
+{{- end -}}
+{{< /colors.inline >}}
+<div class="p-3 mb-2 bg-body-secondary">.bg-body-secondary</div>
+<div class="p-3 mb-2 bg-body-tertiary">.bg-body-tertiary</div>
+<div class="p-3 mb-2 bg-body text-body">.bg-body</div>
+<div class="p-3 mb-2 bg-black text-white">.bg-black</div>
+<div class="p-3 mb-2 bg-white text-dark">.bg-white</div>
+<div class="p-3 mb-2 bg-transparent text-body">.bg-transparent</div>
+{{< /example >}}
+
+{{< /bootstrap-compatibility >}}
+
+### `data-bs-theme` attribute
+
+Here are the nominal cases you should be using, when there is no other theme interferences than the root one, using `data-bs-theme` attribute:
+
+{{< callout info >}}
+Please note that we use `[data-bs-theme]` attribute on a child element to avoid interfering with the parent theme. This is a workaround to avoid switching the colors between light and dark modes and keep having the good ones displayed.
+{{< /callout >}}
+
+{{< example >}}
+<p class="bg-primary p-tall fw-bold">.bg-primary</p>
+<p class="bg-secondary p-tall fw-bold">.bg-secondary</p>
+<p class="bg-tertiary p-tall fw-bold">.bg-tertiary</p>
+<p class="bg-emphasized p-tall fw-bold"><span data-bs-theme="dark">.bg-emphasized</span></p>
+<p class="bg-brand-primary p-tall fw-bold"><span data-bs-theme="light">.bg-brand-primary</span></p>
+<p class="bg-status-neutral-emphasized p-tall fw-bold"><span data-bs-theme="root-inverted">.bg-status-neutral-emphasized</span></p>
+<p class="bg-status-neutral-muted p-tall fw-bold">.bg-status-neutral-muted</p>
+<p class="bg-status-accent-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-accent-emphasized</span></p>
+<p class="bg-status-accent-muted p-tall fw-bold">.bg-status-accent-muted</p>
+<p class="bg-status-positive-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-positive-emphasized</span></p>
+<p class="bg-status-positive-muted p-tall fw-bold">.bg-status-positive-muted</p>
+<p class="bg-status-negative-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-negative-emphasized</span></p>
+<p class="bg-status-negative-muted p-tall fw-bold">.bg-status-negative-muted</p>
+<p class="bg-status-warning-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-warning-emphasized</span></p>
+<p class="bg-status-warning-muted p-tall fw-bold">.bg-status-warning-muted</p>
+<p class="bg-status-info-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-info-emphasized</span></p>
+<p class="bg-status-info-muted p-tall fw-bold">.bg-status-info-muted</p>
+<p class="bg-always-black p-tall fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
+<p class="bg-always-white p-tall fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>
+<p class="bg-transparent p-tall fw-bold">.bg-transparent</p>
+{{< /example >}}
+
+#### Inside a static theme
+
+Here is a more complex example to understand how to use `[data-bs-theme]` in specific static contexts. In here you should only use the inverse static theme by replacing all `data-bs-theme="root-inverted"` by `data-bs-theme="light"`. So if you're in a dark theme context, use only `data-bs-theme="light"` when and if needed and respectively.
+
+<details class="mb-tall px-short">
+  <summary class="py-short">You're in a static <code>light</code> context</summary>
+
+  {{< example class="p-none" >}}
+  <div class="bg-brand-primary p-tall">
+    <div data-bs-theme="light">
+      <p class="bg-primary p-tall fw-bold">.bg-primary</p>
+      <p class="bg-secondary p-tall fw-bold">.bg-secondary</p>
+      <p class="bg-tertiary p-tall fw-bold">.bg-tertiary</p>
+      <p class="bg-emphasized p-tall fw-bold"><span data-bs-theme="dark">.bg-emphasized</span></p>
+      <p class="bg-brand-primary p-tall fw-bold">.bg-brand-primary</p>
+      <p class="bg-status-neutral-emphasized p-tall fw-bold"><span data-bs-theme="dark">.bg-status-neutral-emphasized</span></p>
+      <p class="bg-status-neutral-muted p-tall fw-bold">.bg-status-neutral-muted</p>
+      <p class="bg-status-accent-emphasized p-tall fw-bold">.bg-status-accent-emphasized</p>
+      <p class="bg-status-accent-muted p-tall fw-bold">.bg-status-accent-muted</p>
+      <p class="bg-status-positive-emphasized p-tall fw-bold">.bg-status-positive-emphasized</p>
+      <p class="bg-status-positive-muted p-tall fw-bold">.bg-status-positive-muted</p>
+      <p class="bg-status-negative-emphasized p-tall fw-bold">.bg-status-negative-emphasized</p>
+      <p class="bg-status-negative-muted p-tall fw-bold">.bg-status-negative-muted</p>
+      <p class="bg-status-warning-emphasized p-tall fw-bold">.bg-status-warning-emphasized</p>
+      <p class="bg-status-warning-muted p-tall fw-bold">.bg-status-warning-muted</p>
+      <p class="bg-status-info-emphasized p-tall fw-bold">.bg-status-info-emphasized</p>
+      <p class="bg-status-info-muted p-tall fw-bold">.bg-status-info-muted</p>
+      <p class="bg-always-black p-tall fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
+      <p class="bg-always-white p-tall fw-bold">.bg-always-white</p>
+      <p class="bg-transparent p-tall fw-bold">.bg-transparent</p>
+    </div>
+  </div>
+  {{< /example >}}
+
+</details>
+
+<details class="mb-tall px-short">
+  <summary class="py-short">You're in a static <code>dark</code> context</summary>
+
+  {{< example class="p-none" >}}
+  <div class="bg-emphasized p-tall">
+    <div data-bs-theme="dark">
+      <p class="bg-primary p-tall fw-bold">.bg-primary</p>
+      <p class="bg-secondary p-tall fw-bold">.bg-secondary</p>
+      <p class="bg-tertiary p-tall fw-bold">.bg-tertiary</p>
+      <p class="bg-emphasized p-tall fw-bold">.bg-emphasized</p>
+      <p class="bg-brand-primary p-tall fw-bold"><span data-bs-theme="light">.bg-brand-primary</span></p>
+      <p class="bg-status-neutral-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-neutral-emphasized</span></p>
+      <p class="bg-status-neutral-muted p-tall fw-bold">.bg-status-neutral-muted</p>
+      <p class="bg-status-accent-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-accent-emphasized</span></p>
+      <p class="bg-status-accent-muted p-tall fw-bold">.bg-status-accent-muted</p>
+      <p class="bg-status-positive-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-positive-emphasized</span></p>
+      <p class="bg-status-positive-muted p-tall fw-bold">.bg-status-positive-muted</p>
+      <p class="bg-status-negative-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-negative-emphasized</span></p>
+      <p class="bg-status-negative-muted p-tall fw-bold">.bg-status-negative-muted</p>
+      <p class="bg-status-warning-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-warning-emphasized</span></p>
+      <p class="bg-status-warning-muted p-tall fw-bold">.bg-status-warning-muted</p>
+      <p class="bg-status-info-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-info-emphasized</span></p>
+      <p class="bg-status-info-muted p-tall fw-bold">.bg-status-info-muted</p>
+      <p class="bg-always-black p-tall fw-bold">.bg-always-black</p>
+      <p class="bg-always-white p-tall fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>
+      <p class="bg-transparent p-tall fw-bold">.bg-transparent</p>
+    </div>
+  </div>
+  {{< /example >}}
+
+</details>
+
+#### Inside a dynamic theme
+
+Here is a more complex example to understand how to use `[data-bs-theme]` in specific dynamic contexts. In here you should only replace `data-bs-theme="root-inverted"` by `data-bs-theme="root"` and respectively.
+
+<details class="mb-tall px-short">
+  <summary class="py-short">You're in a dynamic <code>root-inverted</code> context</summary>
+
+  {{< example class="p-none" >}}
+  <div class="bg-status-neutral-emphasized p-tall">
+    <div data-bs-theme="root-inverted">
+      <p class="bg-primary p-tall fw-bold">.bg-primary</p>
+      <p class="bg-secondary p-tall fw-bold">.bg-secondary</p>
+      <p class="bg-tertiary p-tall fw-bold">.bg-tertiary</p>
+      <p class="bg-emphasized p-tall fw-bold"><span data-bs-theme="dark">.bg-emphasized</span></p>
+      <p class="bg-brand-primary p-tall fw-bold"><span data-bs-theme="light">.bg-brand-primary</span></p>
+      <p class="bg-status-neutral-emphasized p-tall fw-bold"><span data-bs-theme="root">.bg-status-neutral-emphasized</span></p>
+      <p class="bg-status-neutral-muted p-tall fw-bold">.bg-status-neutral-muted</p>
+      <p class="bg-status-accent-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-accent-emphasized</span></p>
+      <p class="bg-status-accent-muted p-tall fw-bold">.bg-status-accent-muted</p>
+      <p class="bg-status-positive-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-positive-emphasized</span></p>
+      <p class="bg-status-positive-muted p-tall fw-bold">.bg-status-positive-muted</p>
+      <p class="bg-status-negative-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-negative-emphasized</span></p>
+      <p class="bg-status-negative-muted p-tall fw-bold">.bg-status-negative-muted</p>
+      <p class="bg-status-warning-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-warning-emphasized</span></p>
+      <p class="bg-status-warning-muted p-tall fw-bold">.bg-status-warning-muted</p>
+      <p class="bg-status-info-emphasized p-tall fw-bold"><span data-bs-theme="light">.bg-status-info-emphasized</span></p>
+      <p class="bg-status-info-muted p-tall fw-bold">.bg-status-info-muted</p>
+      <p class="bg-always-black p-tall fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
+      <p class="bg-always-white p-tall fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>
+      <p class="bg-transparent p-tall fw-bold">.bg-transparent</p>
+    </div>
+  </div>
+  {{< /example >}}
+
+</details>
+
+<!-- ## Background gradient -->
+
+<!-- ## Opacity -->
+
+## CSS
+
+<!-- In addition to the following Sass functionality, consider reading about our included [CSS custom properties]({{< docsref "/customize/css-variables" >}}) (aka CSS variables) for colors and more. -->
+
+### Sass tokens
+
+#### Raw tokens
+
+Colors raw tokens as Sass variables. **Not to be used as-is**.
+
+{{< scss-docs name="ouds-raw-color" file="scss/tokens/_raw.scss" >}}
+
+#### Semantic tokens
+
+Color semantic tokens as Sass variables. **Should not be used as-is**. Prefer use our [CSS semantic tokens](#css-semantic-tokens).
+
+{{< scss-docs name="ouds-semantic-color" file="scss/tokens/_semantic.scss" >}}
+
+### CSS semantic tokens
+
+Color semantic tokens as CSS variables.
+
+{{< scss-docs name="ouds-semantic-css-color" file="scss/tokens/_semantic-colors-custom-props.scss" >}}
+
+The same happens for the dark mode by replacing `-light` by `-dark`.
+
+<!-- TODO LM the rest of it -->
+
+### Sass variables
+
+<!-- Most `background-color` utilities are generated by our theme colors, reassigned from our generic color palette variables. -->
+
+<!-- {{< scss-docs name="color-variables" file="scss/_variables.scss" >}}
+
+{{< scss-docs name="theme-color-variables" file="scss/_variables.scss" >}}
+
+{{< scss-docs name="theme-color-dark-variables" file="scss/_variables-dark.scss" >}} -->
+
+<!-- OUDS mod: no background gradient -->
+
+Grayscale colors are also available, but only a subset are used to generate any utilities.
+
+{{< scss-docs name="gray-color-variables" file="scss/_variables.scss" >}}
+
+Variables for setting `background-color` in `.bg-*-subtle` utilities in light and dark mode:
+
+{{< scss-docs name="theme-bg-subtle-variables" file="scss/_variables.scss" >}}
+
+{{< scss-docs name="theme-bg-subtle-dark-variables" file="scss/_variables-dark.scss" >}}
+
+### Sass maps
+
+Theme colors are then put into a Sass map so we can loop over them to generate our utilities, component modifiers, and more.
+
+{{< scss-docs name="theme-colors-map" file="scss/_variables.scss" >}}
+
+{{< scss-docs name="theme-colors-dark-map" file="scss/_variables-dark.scss" >}}
+
+Grayscale colors are also available as a Sass map. **This map is not used to generate any utilities.**
+
+{{< scss-docs name="gray-colors-map" file="scss/_variables.scss" >}}
+
+RGB colors are generated from a separate Sass map:
+
+{{< scss-docs name="theme-colors-rgb" file="scss/_maps.scss" >}}
+
+{{< scss-docs name="theme-colors-rgb-dark" file="scss/_maps.scss" >}}
+
+Background color opacities build on that with their own map that's consumed by the utilities API:
+
+{{< scss-docs name="utilities-bg-colors" file="scss/_maps.scss" >}}
+
+Color mode background colors are also available as a Sass map:
+
+{{< scss-docs name="theme-bg-subtle-map" file="scss/_maps.scss" >}}
+
+{{< scss-docs name="theme-bg-subtle-dark-map" file="scss/_maps.scss" >}}
+
+### Sass mixins
+
+**No mixins are used to generate our background utilities**, but we do have some additional mixins for other situations where you'd like to create your own gradients.
+
+{{< scss-docs name="gradient-bg-mixin" file="scss/mixins/_gradients.scss" >}}
+
+<!-- OUDS mod: no background gradient -->
+
+### Sass utilities API
+
+Background utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
+
+{{< scss-docs name="utils-bg-color" file="scss/_utilities.scss" >}}

--- a/site/content/docs/0.0/utilities/opacity.md
+++ b/site/content/docs/0.0/utilities/opacity.md
@@ -13,12 +13,12 @@ The `opacity` property sets the opacity level for an element. The opacity level 
 Set the opacity of an element using `.opacity-{value}` utilities.
 
 <div class="bd-example d-sm-flex">
-  <div class="opacity-opaque p-tall m-short bg-primary fw-bold"></div>
-  <div class="opacity-strong p-tall m-short bg-primary fw-bold"></div>
-  <div class="opacity-medium p-tall m-short bg-primary fw-bold"></div>
-  <div class="opacity-weak p-tall m-short bg-primary fw-bold"></div>
-  <div class="opacity-weaker p-tall m-short bg-primary fw-bold"></div>
-  <div class="opacity-invisible p-tall m-short bg-primary fw-bold"></div>
+  <div class="opacity-opaque p-tall m-short bg-brand-primary fw-bold"></div>
+  <div class="opacity-strong p-tall m-short bg-brand-primary fw-bold"></div>
+  <div class="opacity-medium p-tall m-short bg-brand-primary fw-bold"></div>
+  <div class="opacity-weak p-tall m-short bg-brand-primary fw-bold"></div>
+  <div class="opacity-weaker p-tall m-short bg-brand-primary fw-bold"></div>
+  <div class="opacity-invisible p-tall m-short bg-brand-primary fw-bold"></div>
 </div>
 
 ```html
@@ -41,11 +41,11 @@ Set the `opacity` of an element using `.opacity-{value}` utilities.
   - Removed div text content to avoid a11y issue with semi-transparent text
 -->
 <div class="bd-example d-sm-flex">
-  <div class="opacity-100 p-tall m-short bg-primary fw-bold"></div>
-  <div class="opacity-75 p-tall m-short bg-primary fw-bold"></div>
-  <div class="opacity-50 p-tall m-short bg-primary fw-bold"></div>
-  <div class="opacity-25 p-tall m-short bg-primary fw-bold"></div>
-  <div class="opacity-0 p-tall m-short bg-primary fw-bold"></div>
+  <div class="opacity-100 p-tall m-short bg-brand-primary fw-bold"></div>
+  <div class="opacity-75 p-tall m-short bg-brand-primary fw-bold"></div>
+  <div class="opacity-50 p-tall m-short bg-brand-primary fw-bold"></div>
+  <div class="opacity-25 p-tall m-short bg-brand-primary fw-bold"></div>
+  <div class="opacity-0 p-tall m-short bg-brand-primary fw-bold"></div>
 </div>
 
 ```html

--- a/site/content/docs/0.0/utilities/overflow.md
+++ b/site/content/docs/0.0/utilities/overflow.md
@@ -51,7 +51,7 @@ Adjust the `overflow-x` property to affect the overflow of content horizontally.
     <div><code>.overflow-x-visible</code> example </div>
     <div>on an element with set width and height dimensions.</div>
   </div>
-  <div class="overflow-x-scroll p-tall bg-body w-100 border" style="max-width: 200px; max-height: 100px;white-space: nowrap;">
+  <div class="overflow-x-scroll p-tall bg-primary w-100 border" style="max-width: 200px; max-height: 100px;white-space: nowrap;">
     <div><code>.overflow-x-scroll</code> example on an element</div>
     <div> with set width and height dimensions.</div>
   </div>

--- a/site/content/docs/0.0/utilities/shadows.md
+++ b/site/content/docs/0.0/utilities/shadows.md
@@ -18,14 +18,14 @@ Box-shadow styles are referred to as 'elevation' within the design system.
 You can <!--also -->quickly add or remove a shadow with our `box-shadow` utility classes. Includes support for `.shadow-none` and new semantic helpers.
 
 {{< example class="overflow-hidden" >}}
-<div class="shadow-none p-tall mb-huge bg-body-tertiary">No shadow</div>
-<div class="shadow-default p-tall mb-huge bg-body-tertiary">Default shadow</div>
-<div class="shadow-drag p-tall mb-huge bg-body-tertiary">Drag shadow</div>
-<div class="shadow-emphasized p-tall mb-huge bg-body-tertiary">Emphasized shadow</div>
-<div class="shadow-raised p-tall mb-huge bg-body-tertiary">Raised shadow</div>
-<div class="shadow-sticky-default p-tall mb-huge bg-body-tertiary">Sticky default shadow</div>
-<div class="shadow-sticky-emphasized p-tall mb-huge bg-body-tertiary">Sticky emphasized shadow</div>
-<div class="shadow-sticky-navigation-scrolled p-tall mb-huge bg-body-tertiary">Sticky navigation shadow</div>
+<div class="shadow-none p-tall mb-huge bg-secondary">No shadow</div>
+<div class="shadow-default p-tall mb-huge bg-secondary">Default shadow</div>
+<div class="shadow-drag p-tall mb-huge bg-secondary">Drag shadow</div>
+<div class="shadow-emphasized p-tall mb-huge bg-secondary">Emphasized shadow</div>
+<div class="shadow-raised p-tall mb-huge bg-secondary">Raised shadow</div>
+<div class="shadow-sticky-default p-tall mb-huge bg-secondary">Sticky default shadow</div>
+<div class="shadow-sticky-emphasized p-tall mb-huge bg-secondary">Sticky emphasized shadow</div>
+<div class="shadow-sticky-navigation-scrolled p-tall mb-huge bg-secondary">Sticky navigation shadow</div>
 {{< /example >}}
 
 {{< bootstrap-compatibility >}}
@@ -33,10 +33,10 @@ You can <!--also -->quickly add or remove a shadow with our `box-shadow` utility
 Includes support for three default sizes (which have associated variables to match).
 
 {{< example class="overflow-hidden" >}}
-<div class="shadow-none p-3 mb-5 bg-body-tertiary">No shadow</div>
-<div class="shadow-sm p-3 mb-5 bg-body-tertiary">Small shadow</div>
-<div class="shadow p-3 mb-5 bg-body-tertiary">Regular shadow</div>
-<div class="shadow-lg p-3 mb-5 bg-body-tertiary">Larger shadow</div>
+<div class="shadow-none p-3 mb-5 bg-secondary">No shadow</div>
+<div class="shadow-sm p-3 mb-5 bg-secondary">Small shadow</div>
+<div class="shadow p-3 mb-5 bg-secondary">Regular shadow</div>
+<div class="shadow-lg p-3 mb-5 bg-secondary">Larger shadow</div>
 {{< /example >}}
 
 {{< /bootstrap-compatibility >}}

--- a/site/content/docs/0.0/utilities/text.md
+++ b/site/content/docs/0.0/utilities/text.md
@@ -47,7 +47,7 @@ Wrap text with a `.text-wrap` class.
 Prevent text from wrapping with a `.text-nowrap` class.
 
 {{< example >}}
-<div class="text-nowrap bg-body-secondary border border-dark" style="width: 8rem;">
+<div class="text-nowrap bg-secondary border border-dark" style="width: 8rem;">
   This text should overflow the parent.
 </div>
 {{< /example >}}

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -39,7 +39,6 @@
     - title: Color theme
       draft: true
     - title: Color modes
-      draft: true
     - title: Components
       draft: true
     - title: CSS variables
@@ -194,7 +193,6 @@
   pages:
     - title: API
     - title: Background
-      draft: true
     - title: Borders
     - title: Colors
       draft: true

--- a/site/layouts/partials/skippy.html
+++ b/site/layouts/partials/skippy.html
@@ -1,9 +1,9 @@
 <a id="top"></a><!-- OUDS mod: anchor for back-to-top link -->
 <div class="skippy visually-hidden-focusable overflow-hidden position-fixed top-0 end-0 start-0">
   <nav aria-label="Skip links" class="container-fluid container-max-width py-shortest ps-huge">
-    <a class="d-inline-flex p-short ms-tall bg-black" href="#content">Skip to main content</a>
+    <a class="d-inline-flex p-short ms-tall bg-always-black" href="#content">Skip to main content</a>
     {{ if (eq .Page.Layout "docs") -}}
-    <a class="d-none d-md-inline-flex p-short bg-black" href="#bd-docs-nav">Skip to docs navigation</a>
+    <a class="d-none d-md-inline-flex p-short bg-always-black" href="#bd-docs-nav">Skip to docs navigation</a>
     {{- end }}
   </nav>
 </div>


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

NA

### Description

#### Remaining tasks and questions

:warning: Questions:
- [ ] Naming of the dynamic themes ? Can be changed later so postponed for now
- [ ] Choose whether we use theme or mode naming
- [ ] How to handle duplicate `.bg-primary`, `.bg-secondary`, etc ...

Tasks:

#### Done list

The following was done in the PR:
- Added two themes `root` and `root-inverted`
- Added Background page
- Added Color modes page
- Added the background utilities
- Added a new way to determine the root selector 
- Changed all calls to background and background-color
- Added tests

#### To be done after the PR is merged

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2807--boosted.netlify.app/docs/utilities/background>