### PR TITLE
[OUDS] Add border color utilities to the Colors tokens PR

### DIFF
--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -20,6 +20,17 @@ $ouds-border-widths: (
   "thick":    $ouds-border-width-thick,
   "thicker":  $ouds-border-width-thicker,
 ) !default;
+
+$ouds-border-colors: (
+  "brand-primary": var(--#{$prefix}color-border-brand-primary),
+  "default": var(--#{$prefix}color-border-default),
+  "emphasized": var(--#{$prefix}color-border-emphasized),
+  "on-brand-primary": var(--#{$prefix}color-border-on-brand-primary),
+  "always-black": var(--#{$prefix}color-always-black),
+  "always-white": var(--#{$prefix}color-always-white),
+  "always-on-black": var(--#{$prefix}color-always-on-black),
+  "always-on-white": var(--#{$prefix}color-always-on-white),
+) !default;
 // scss-docs-end ouds-maps-borders
 
 // scss-docs-start ouds-maps-dimension
@@ -117,7 +128,7 @@ $ouds-opacities: (
 ) !default;
 // scss-docs-end ouds-maps-opacities
 
-// scss-docs-start ouds-maps-opacities
+// scss-docs-start ouds-maps-backgrounds
 $ouds-backgrounds: (
   "primary": var(--#{$prefix}color-bg-primary),
   "secondary": var(--#{$prefix}color-bg-secondary),
@@ -140,7 +151,7 @@ $ouds-backgrounds: (
   "always-white": var(--#{$prefix}color-always-white),
   "transparent": transparent,
 ) !default;
-// scss-docs-end ouds-maps-opacities
+// scss-docs-end ouds-maps-backgrounds
 // End mod
 
 // Re-assigned maps

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -202,12 +202,14 @@ $utilities: map-merge(
       local-vars: (
         "border-opacity": 1
       ),
-      values: $utilities-border-colors
+      values: $utilities-border-colors,
+      bootstrap-compatibility: true
     ),
     "subtle-border-color": (
       property: border-color,
       class: border,
-      values: $utilities-border-subtle
+      values: $utilities-border-subtle,
+      bootstrap-compatibility: true
     ),
     "border-width": (
       property: border-width,
@@ -269,6 +271,11 @@ $utilities: map-merge(
       property: border-style,
       class: border,
       values: $ouds-border-styles
+    ),
+    "border-color-ouds": (
+      property: border-color,
+      class: border,
+      values: $ouds-border-colors
     ),
     // scss-docs-end utils-borders-ouds
     // End mod

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -612,7 +612,7 @@ $border-widths: (
   5: $ouds-border-width-thicker * 1.25 // OUDS mod: instead of `$border-width * 2.5`
 ) !default;
 $border-style:                $ouds-border-style-default !default; // OUDS mod: instead of `solid`
-$border-color:                $ouds-color-border-default-light !default; // OUDS mod: instead of `$gray-300` // TODO LM: Decide whether to use default in here or in translucent
+$border-color:                $ouds-color-border-default-light !default; // OUDS mod: instead of `$gray-300`
 $border-color-translucent:    rgba($black, .175) !default;
 // scss-docs-end border-variables
 

--- a/scss/tests/customize/_ouds-web-bootstrap-utilities.test.scss
+++ b/scss/tests/customize/_ouds-web-bootstrap-utilities.test.scss
@@ -85,12 +85,14 @@ $utilities: ();
             local-vars: (
               "border-opacity": 1
             ),
-            values: $utilities-border-colors
+            values: $utilities-border-colors,
+            bootstrap-compatibility: true
           ),
           "subtle-border-color": (
             property: border-color,
             class: border,
-            values: $utilities-border-subtle
+            values: $utilities-border-subtle,
+            bootstrap-compatibility: true
           ),
           "border-width": (
             property: border-width,
@@ -149,6 +151,11 @@ $utilities: ();
             property: border-style,
             class: border,
             values: $ouds-border-styles
+          ),
+          "border-color-ouds": (
+            property: border-color,
+            class: border,
+            values: $ouds-border-colors
           ),
           "rounded": (
             property: border-radius,
@@ -1073,88 +1080,6 @@ $utilities: ();
           border: 0 !important;
         }
 
-        .border-primary {
-          --bs-border-opacity: 1;
-          border-color: rgba(var(--bs-primary-rgb), var(--bs-border-opacity)) !important;
-        }
-
-        .border-secondary {
-          --bs-border-opacity: 1;
-          border-color: rgba(var(--bs-secondary-rgb), var(--bs-border-opacity)) !important;
-        }
-
-        .border-success {
-          --bs-border-opacity: 1;
-          border-color: rgba(var(--bs-success-rgb), var(--bs-border-opacity)) !important;
-        }
-
-        .border-info {
-          --bs-border-opacity: 1;
-          border-color: rgba(var(--bs-info-rgb), var(--bs-border-opacity)) !important;
-        }
-
-        .border-warning {
-          --bs-border-opacity: 1;
-          border-color: rgba(var(--bs-warning-rgb), var(--bs-border-opacity)) !important;
-        }
-
-        .border-danger {
-          --bs-border-opacity: 1;
-          border-color: rgba(var(--bs-danger-rgb), var(--bs-border-opacity)) !important;
-        }
-
-        .border-light {
-          --bs-border-opacity: 1;
-          border-color: rgba(85, 85, 85, var(--bs-border-opacity)) !important;
-        }
-
-        .border-dark {
-          --bs-border-opacity: 1;
-          border-color: rgba(39, 39, 39, var(--bs-border-opacity)) !important;
-        }
-
-        .border-black {
-          --bs-border-opacity: 1;
-          border-color: rgba(var(--bs-black-rgb), var(--bs-border-opacity)) !important;
-        }
-
-        .border-white {
-          --bs-border-opacity: 1;
-          border-color: rgba(var(--bs-white-rgb), var(--bs-border-opacity)) !important;
-        }
-
-        .border-primary-subtle {
-          border-color: var(--bs-primary-border-subtle) !important;
-        }
-
-        .border-secondary-subtle {
-          border-color: var(--bs-secondary-border-subtle) !important;
-        }
-
-        .border-success-subtle {
-          border-color: var(--bs-success-border-subtle) !important;
-        }
-
-        .border-info-subtle {
-          border-color: var(--bs-info-border-subtle) !important;
-        }
-
-        .border-warning-subtle {
-          border-color: var(--bs-warning-border-subtle) !important;
-        }
-
-        .border-danger-subtle {
-          border-color: var(--bs-danger-border-subtle) !important;
-        }
-
-        .border-light-subtle {
-          border-color: var(--bs-light-border-subtle) !important;
-        }
-
-        .border-dark-subtle {
-          border-color: var(--bs-dark-border-subtle) !important;
-        }
-
         .border-top {
           border-top: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
         }
@@ -1205,6 +1130,38 @@ $utilities: ();
 
         .border-drag {
           border-style: dashed !important;
+        }
+
+        .border-brand-primary {
+          border-color: var(--bs-color-border-brand-primary) !important;
+        }
+
+        .border-default {
+          border-color: var(--bs-color-border-default) !important;
+        }
+
+        .border-emphasized {
+          border-color: var(--bs-color-border-emphasized) !important;
+        }
+
+        .border-on-brand-primary {
+          border-color: var(--bs-color-border-on-brand-primary) !important;
+        }
+
+        .border-always-black {
+          border-color: var(--bs-color-always-black) !important;
+        }
+
+        .border-always-white {
+          border-color: var(--bs-color-always-white) !important;
+        }
+
+        .border-always-on-black {
+          border-color: var(--bs-color-always-on-black) !important;
+        }
+
+        .border-always-on-white {
+          border-color: var(--bs-color-always-on-white) !important;
         }
 
         .rounded {
@@ -9973,12 +9930,14 @@ $utilities: ();
             local-vars: (
               "border-opacity": 1
             ),
-            values: $utilities-border-colors
+            values: $utilities-border-colors,
+            bootstrap-compatibility: true
           ),
           "subtle-border-color": (
             property: border-color,
             class: border,
-            values: $utilities-border-subtle
+            values: $utilities-border-subtle,
+            bootstrap-compatibility: true
           ),
           "border-width": (
             property: border-width,
@@ -10037,6 +9996,11 @@ $utilities: ();
             property: border-style,
             class: border,
             values: $ouds-border-styles
+          ),
+          "border-color-ouds": (
+            property: border-color,
+            class: border,
+            values: $ouds-border-colors
           ),
           "rounded": (
             property: border-radius,
@@ -11181,6 +11145,38 @@ $utilities: ();
 
         .border-drag {
           border-style: dashed !important;
+        }
+
+        .border-brand-primary {
+          border-color: var(--bs-color-border-brand-primary) !important;
+        }
+
+        .border-default {
+          border-color: var(--bs-color-border-default) !important;
+        }
+
+        .border-emphasized {
+          border-color: var(--bs-color-border-emphasized) !important;
+        }
+
+        .border-on-brand-primary {
+          border-color: var(--bs-color-border-on-brand-primary) !important;
+        }
+
+        .border-always-black {
+          border-color: var(--bs-color-always-black) !important;
+        }
+
+        .border-always-white {
+          border-color: var(--bs-color-always-white) !important;
+        }
+
+        .border-always-on-black {
+          border-color: var(--bs-color-always-on-black) !important;
+        }
+
+        .border-always-on-white {
+          border-color: var(--bs-color-always-on-white) !important;
         }
 
         .rounded-0 {

--- a/site/assets/scss/_callouts.scss
+++ b/site/assets/scss/_callouts.scss
@@ -11,7 +11,7 @@
   margin-bottom: $spacer; // OUDS mod
   color: var(--bd-callout-color, inherit);
   background-color: var(--bd-callout-bg, var(--#{$prefix}color-surface-status-neutral)); // OUDS mod
-  border-left: .25rem solid var(--bd-callout-border, var(--bs-gray-200)); // OUDS mod
+  // OUDS mod: no border-left
 
   h4 {
     margin-bottom: .25rem;
@@ -33,6 +33,6 @@
   .bd-callout-#{$variant} {
     --bd-callout-color: var(--bs-emphasis-color); // OUDS mod: instead of `var(--bs-#{$variant}-text-emphasis)`
     --bd-callout-bg: var(--#{$prefix}color-surface-status-#{if($variant == "danger", negative, $variant)}-muted); // OUDS mod: instead of `var(--bs-#{$variant}-bg-subtle)`
-    --bd-callout-border: var(--bs-#{$variant}-border-subtle);
+    // OUDS mod: no --bd-callout-border
   }
 }

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -288,6 +288,7 @@
 .bd-example-border-utils {
   [class^="border"] {
     display: inline-block;
+    flex-shrink: 0;
     width: 5rem;
     height: 5rem;
     margin: .25rem;
@@ -471,10 +472,6 @@
   letter-spacing: -.05rem;
 }
 // scss-docs-end sticker-fs-xl
-
-.border-subtle {
-  --bs-border-color: var(--bs-color-border-default);
-}
 
 .color-copy:hover > svg {
   transform: scale(1.07);

--- a/site/content/docs/0.0/content/reboot.md
+++ b/site/content/docs/0.0/content/reboot.md
@@ -140,14 +140,15 @@ The `<hr>` element has been simplified. Similar to browser defaults, `<hr>`s are
 
 {{< example >}}
 <hr>
+
+<hr class="border border-emphasized border-medium opacity-medium">
+<hr class="border border-brand-primary border-thick opacity-strong">
 {{< /example >}}
 
-<!-- Should be in example above <div class="text-success">
+<!-- Should be in example above
+<div class="text-success">
   <hr>
-</div>
-
-<hr class="border border-danger border-medium opacity-medium">
-<hr class="border border-primary border-thick opacity-strong">-->
+</div>-->
 
 <!-- ## Lists
 

--- a/site/content/docs/0.0/utilities/borders.md
+++ b/site/content/docs/0.0/utilities/borders.md
@@ -48,7 +48,56 @@ Or remove borders:
 
 {{< /bootstrap-compatibility >}}
 
-<!--## Color-->
+## Color
+
+Change the border color using utilities. The color utilities are generated from our `$ouds-border-colors` Sass map.
+
+{{< example class="bd-example-border-utils d-flex align-items-center flex-wrap" >}}
+<span class="border border-brand-primary"></span>
+<span class="border border-default"></span>
+<span class="border border-emphasized"></span>
+<div data-bs-theme="light" class="bg-brand-primary d-inline-flex m-shortest p-shorter"><span class="border border-on-brand-primary m-none bg-brand-primary"></span></div>
+<div data-bs-theme="light" class="bg-always-white d-inline-flex m-shortest p-shorter"><span class="border border-always-black m-none bg-always-white"></span></div>
+<div data-bs-theme="dark" class="bg-always-black d-inline-flex m-shortest p-shorter"><span class="border border-always-white m-none bg-always-black"></span></div>
+<div data-bs-theme="dark" class="bg-always-black d-inline-flex m-shortest p-shorter"><span class="border border-always-on-black m-none bg-always-black"></span></div>
+<div data-bs-theme="light" class="bg-always-white d-inline-flex m-shortest p-shorter"><span class="border border-always-on-white m-none bg-always-white"></span></div>
+{{< /example >}}
+
+{{< bootstrap-compatibility >}}
+
+{{< callout info >}}
+Border utilities like `.border-*` that generated from our original `$theme-colors` Sass map don't yet respond to color modes, however, any `.border-*-subtle` utility will. This will be resolved in v6.
+{{< /callout >}}
+
+{{< example class="bd-example-border-utils" >}}
+{{< border.inline >}}
+{{- range (index $.Site.Data "theme-colors") }}
+<span class="border border-{{ .name }}"></span>
+<span class="border border-{{ .name }}-subtle"></span>
+{{- end -}}
+{{< /border.inline >}}
+<span class="border border-black"></span>
+<span class="border border-white"></span>
+{{< /example >}}
+
+Or modify the default `border-color` of a component:
+
+{{< example >}}
+<div class="mb-4">
+  <label for="exampleFormControlInput1" class="form-label">Email address</label>
+  <input type="email" class="form-control border-brand-primary" id="exampleFormControlInput1" placeholder="name@example.com">
+</div>
+
+<div class="h4 pb-2 mb-4 text-danger border-bottom border-emphasized">
+  Dangerous heading
+</div>
+
+<div class="p-3 bg-info bg-opacity-10 border border-emphasized border-start-0 rounded-end">
+  Changing border color and width
+</div>
+{{< /example >}}
+
+{{< /bootstrap-compatibility >}}
 
 <!--## Opacity-->
 
@@ -182,7 +231,7 @@ Border semantic tokens are defined as Sass variables.
 
 {{< scss-docs name="border-radius-variables" file="scss/_variables.scss" >}}
 
-<!--Variables for setting `border-color` in `.border-{direction}-subtle` utilities in light and dark mode:
+<!-- TODO LM: Variables for setting `border-color` in `.border-{direction}-subtle` utilities in light and dark mode:
 
 {{< scss-docs name="theme-border-subtle-variables" file="scss/_variables.scss" >}}
 

--- a/site/content/docs/0.0/utilities/position.md
+++ b/site/content/docs/0.0/utilities/position.md
@@ -86,25 +86,25 @@ By adding `.translate-middle-x` or `.translate-middle-y` classes, elements can b
 </div>
 {{< /example >}}
 
-<!--## Examples
+## Examples
 
 Here are some real life examples of these classes:
 
 {{< example class="bd-example-position-examples d-flex justify-content-around align-items-center" >}}
-<button type="button" class="btn btn-primary position-relative">
+<!--<button type="button" class="btn btn-primary position-relative">
   Mails <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-secondary">+99 <span class="visually-hidden">unread messages</span></span>
 </button>
 
-<div class="position-relative py-short px-tallest text-bg-secondary border border-secondary">
-  Marker <svg width="1em" height="1em" viewBox="0 0 16 16" class="position-absolute top-100 start-50 translate-middle mt-shortest" fill="var(-bs-secondary)" xmlns="http://www.w3.org/2000/svg"><path d="M7.247 11.14L2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/></svg> // TODO: reinsert hyphens
-</div>
+<div class="position-relative py-short px-tallest text-bg-secondary border border-emphasized">
+  Marker <svg width="1em" height="1em" viewBox="0 0 16 16" class="position-absolute top-100 start-50 translate-middle mt-shortest" fill="var(-bs-color-bg-emphasized)" xmlns="http://www.w3.org/2000/svg"><path d="M7.247 11.14L2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/></svg>
+</div> // TODO LM: Reinsert hyphens
 
 <button type="button" class="btn btn-primary position-relative">
   Alerts <span class="position-absolute top-0 start-100 translate-middle badge border rounded-circle text-bg-warning p-short"><span class="visually-hidden">unread messages</span></span>
-</button>
+</button> -->
 {{< /example >}}
 
-You can use these classes with existing components to create new ones. Remember that you can extend its functionality by adding entries to the `$position-values` variable.
+<!--You can use these classes with existing components to create new ones. Remember that you can extend its functionality by adding entries to the `$position-values` variable.
 
 {{< example class="bd-example-position-examples" >}}
 <div class="position-relative m-tallest">

--- a/site/content/docs/0.0/utilities/text.md
+++ b/site/content/docs/0.0/utilities/text.md
@@ -47,7 +47,7 @@ Wrap text with a `.text-wrap` class.
 Prevent text from wrapping with a `.text-nowrap` class.
 
 {{< example >}}
-<div class="text-nowrap bg-secondary border border-dark" style="width: 8rem;">
+<div class="text-nowrap bg-secondary border" style="width: 8rem;">
   This text should overflow the parent.
 </div>
 {{< /example >}}

--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -37,7 +37,7 @@
 
     {{- if eq $show_preview true -}}
       <!-- OUDS mod: added `order-first` to handle the focus order -->
-      <div class="d-flex order-first align-items-center highlight-toolbar ps-tall pe-short py-shortest border-none border-top border-bottom border-subtle border-thin">
+      <div class="d-flex order-first align-items-center highlight-toolbar ps-tall pe-short py-shortest border-none border-top border-bottom border-thin">
         <small class="font-monospace text-body-secondary text-uppercase">{{ $lang }}</small>
         <div class="d-flex ms-auto">
           <button type="button" class="btn-edit text-nowrap"{{ with $stackblitz_add_js }} data-sb-js-snippet="{{ $stackblitz_add_js }}"{{ end }} title="Try it on StackBlitz">

--- a/site/layouts/shortcodes/js-docs.html
+++ b/site/layouts/shortcodes/js-docs.html
@@ -33,8 +33,8 @@
   {{- end -}}
 
   <div class="bd-example-snippet bd-code-snippet bd-file-ref">
-    <!-- OUDS mod: added `.border-thin` and `.border-subtle` -->
-    <div class="d-flex align-items-center highlight-toolbar ps-tall pe-short py-shortest border-bottom border-thin border-subtle">
+    <!-- OUDS mod: added `.border-thin` -->
+    <div class="d-flex align-items-center highlight-toolbar ps-tall pe-short py-shortest border-bottom border-thin">
       <!-- OUDS mod: added `me-5` -->
       <a class="me-huge font-monospace link-body-emphasis link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}/{{ $file | replaceRE `\\` "/" }}">
         {{- $file -}}

--- a/site/layouts/shortcodes/scss-docs.html
+++ b/site/layouts/shortcodes/scss-docs.html
@@ -46,8 +46,8 @@
   {{- end -}}
 
   <div class="bd-example-snippet bd-code-snippet bd-file-ref">
-    <!-- OUDS mod: added `.border-thin` and `.border-subtle` -->
-    <div class="d-flex align-items-center highlight-toolbar ps-tall pe-short py-shortest border-bottom border-thin border-subtle">
+    <!-- OUDS mod: added `.border-thin` -->
+    <div class="d-flex align-items-center highlight-toolbar ps-tall pe-short py-shortest border-bottom border-thin">
       <!-- OUDS mod: added `me-5` -->
       <a class="me-huge font-monospace link-body-emphasis link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}/{{ $file | replaceRE `\\` "/" }}">
         {{- $file -}}


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

NA

### Description

#### Remaining tasks and questions

:warning: Questions:
- [ ] What is the correspondence between Bootstrap border color utilities and ours ?
- [ ] What is the complete list of border color utilities that we should provide ?
- [ ] How much do we want to spend and be precised on the documentation ?

Tasks:

#### Done list

The following was done in the PR:
- Added new border color utilities
- Added paragraph about the colors inside borders page
- Changed all the `.border-*` calls in the doc
- Changed all the `border(|color):` calls in the not components

#### To be done after the PR is merged

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2823--boosted.netlify.app/docs/utilities/borders#color>