### PR TITLE
fix(examples): bad and duplicated alt names on images

### DIFF
--- a/site/content/docs/5.3/examples/download-app/index.html
+++ b/site/content/docs/5.3/examples/download-app/index.html
@@ -310,7 +310,7 @@ aliases:
             </svg>
             <p class="h3 pt-3 mb-3 mb-md-4">For iOS, simply hit the button below to download the app on your device.</p>
             <div class="mobile-steps mt-md-3" id="ios-steps">
-              <a href="https://apps.apple.com/app/id6446178285" target="_blank" rel="noopener" class="d-inline-block"><img loading="lazy" src="/docs/{{< param docs_version >}}/assets/img/examples/download-app/app-store-badge.svg" alt="Get it on App Store" height="60"></a>
+              <a href="https://apps.apple.com/app/id6446178285" target="_blank" rel="noopener" class="d-inline-block"><img loading="lazy" src="/docs/{{< param docs_version >}}/assets/img/examples/download-app/app-store-badge.svg" alt="Download on the App Store" height="60"></a>
             </div>
           </div>
           <div id="link-android" role="tabpanel" aria-labelledby="nav-link-android" class="col-12 col-sm-8 col-md-4 d-md-flex flex-column align-items-center mx-auto tab-pane">
@@ -328,7 +328,7 @@ aliases:
               <li>
                 <span class="tag mt-md-3 mb-3 border-primary">2</span>
                 <span class="d-inline-block fw-bold mb-3">Download the app on your device from the Google Play store</span>
-                <a href="https://play.google.com/apps/testing/com.orange.ods.app/" target="_blank" rel="noopener" class="d-inline-block"><img loading="lazy" src="/docs/{{< param docs_version >}}/assets/img/examples/download-app/google-play-badge.svg" alt="Get it on App Store" height="60"></a>
+                <a href="https://play.google.com/apps/testing/com.orange.ods.app/" target="_blank" rel="noopener" class="d-inline-block"><img loading="lazy" src="/docs/{{< param docs_version >}}/assets/img/examples/download-app/google-play-badge.svg" alt="Get it on Google Play Store" height="60"></a>
               </li>
             </ol>
           </div>


### PR DESCRIPTION
### Related issues

#2792 

### Description

Change alt attributes on images to:
- match the image text content
- have separate alt attributes on two different images

### Motivation & Context

Improve accessibiliy

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2835--boosted.netlify.app/docs/5.3/examples/download-app/>

Close #2792 