### PR TITLE
Fix a11y audit: change caption style on accessibility statement to comply to a11y

### DIFF
--- a/site/assets/scss/_boosted.scss
+++ b/site/assets/scss/_boosted.scss
@@ -130,6 +130,12 @@ body {
   border-radius: 50%; // stylelint-disable-line property-disallowed-list
 }
 
+.bd-caption {
+  font-size: 1rem;
+  font-weight: 400;
+  text-align: center;
+}
+
 // .pie[data-value="1"]::before { transform: rotate(3.6deg); }
 // .pie[data-value="1"]::after { display: none; }
 // .pie[data-value="2"]::before { transform: rotate(7.2deg); }

--- a/site/content/docs/5.3/accessibility-statement/_index.md
+++ b/site/content/docs/5.3/accessibility-statement/_index.md
@@ -47,7 +47,7 @@ The compliance audit carried out by ORANGE SA reveals that:
 * The average compliance rate of the online service is 87%.
 
 <div class="table-responsive">
-  <table class="table table-striped"><caption>Summary by levels</caption>
+  <table class="table table-striped"><caption class="bd-caption">Summary by levels</caption>
     <thead><tr>
       <th scope="row">Level</th>
       <th scope="col" class="text-center">A</th>
@@ -92,7 +92,7 @@ The compliance audit carried out by ORANGE SA reveals that:
 
 <div class="table-responsive">
   <table class="table table-striped">
-    <caption>Compliance rate by pages according to the two levels of criteria A and AA</caption>
+    <caption class="bd-caption">Compliance rate by pages according to the two levels of criteria A and AA</caption>
     <tbody>
       <tr>
         <th scope="row">Criteria / Level</th>


### PR DESCRIPTION
### Related issues

#2667 

### Description

Change font size, weight and centering on tables' captions

### Motivation & Context

Accessibility audit reveled that captions looked too much as headings (very big by default) which can cause confusion

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2873--boosted.netlify.app/>
