### PR TITLE
fix: link chevron disabled state

### DIFF
--- a/scss/_links.scss
+++ b/scss/_links.scss
@@ -57,6 +57,25 @@
     text-decoration: underline;
   }
 
+  // Chevron icon
+  &:not(.back) {
+    display: inline-block;
+  }
+
+  &.back::before,
+  &:not(.back)::after {
+    display: inline-block;
+    width: var(--#{$prefix}link-icon-size);
+    min-width: var(--#{$prefix}link-icon-size);
+    height: var(--#{$prefix}link-icon-size);
+    margin-right: var(--#{$prefix}link-arrow-gap);
+    vertical-align: middle;
+    content: "";
+    background-color: var(--#{$prefix}link-arrow-color);
+    mask: var(--#{$prefix}chevron-icon) center no-repeat;
+    mask-size: var(--#{$prefix}link-icon-size);
+  }
+
   &:hover::before,
   &:hover::after {
     background-color: var(--#{$prefix}link-arrow-hover-color);
@@ -74,34 +93,15 @@
     background-color: var(--#{$prefix}link-arrow-pressed-color);
   }
 
-  &[aria-disabled="true"]::before,
-  &[aria-disabled="true"]::after {
-    background-color: var(--#{$prefix}link-arrow-disabled-color);
-  }
-
-  &:not(.back) {
-    display: inline-block;
-  }
-
-  // Chevron icon
-  &.back::before,
-  &:not(.back)::after {
-    display: inline-block;
-    width: var(--#{$prefix}link-icon-size);
-    min-width: var(--#{$prefix}link-icon-size);
-    height: var(--#{$prefix}link-icon-size);
-    margin-right: var(--#{$prefix}link-arrow-gap);
-    vertical-align: middle;
-    content: "";
-    background-color: var(--#{$prefix}link-arrow-color);
-    mask: var(--#{$prefix}chevron-icon) center no-repeat;
-    mask-size: var(--#{$prefix}link-icon-size);
-  }
-
   &:not(.back)::after {
     margin-right: 0;
     margin-left: var(--#{$prefix}link-arrow-gap);
     transform: rotate(180deg) translateY(1px);
+  }
+
+  &[aria-disabled="true"]::before,
+  &[aria-disabled="true"]::after {
+    background-color: var(--#{$prefix}link-arrow-disabled-color);
   }
 }
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -2,6 +2,14 @@
 #{$ouds-root-selector},
 [data-bs-theme] {
   color: var(--#{$prefix}color-content-default);
+
+  // Link colors need to be defined here to ensure theme switching capabilities.
+  --#{$prefix}link-color: #{$ouds-link-color-content-enabled};
+  --#{$prefix}link-hover-color: #{$ouds-link-color-content-hover};
+  --#{$prefix}link-focus-color: #{$ouds-link-color-content-focus};
+  --#{$prefix}link-active-color: #{$ouds-link-color-content-pressed};
+  --#{$prefix}link-disabled-color: #{$ouds-color-action-disabled};
+  --#{$prefix}link-visited-color: #{$ouds-color-action-visited};
 }
 
 // Note that some of the following variables in `#{$ouds-root-selector}, [data-bs-theme="light"]` could be extracted into `#{$ouds-root-selector}` only selector since they are not modified by other color modes!
@@ -245,17 +253,6 @@
   // scss-docs-end root-body-variables
 
   --#{$prefix}heading-color: #{$headings-color};
-
-  // OUDS mod
-  // scss-docs-start root-link-var-ouds
-  --#{$prefix}link-color: #{$ouds-link-color-content-enabled};
-  --#{$prefix}link-hover-color: #{$ouds-link-color-content-hover};
-  --#{$prefix}link-focus-color: #{$ouds-link-color-content-focus};
-  --#{$prefix}link-active-color: #{$ouds-link-color-content-pressed};
-  --#{$prefix}link-disabled-color: #{$ouds-color-action-disabled};
-  --#{$prefix}link-visited-color: #{$ouds-color-action-visited};
-  // scss-docs-end root-link-var-ouds
-  // End mod
 
   @if $enable-bootstrap-compatibility {
     --#{$prefix}link-color-rgb: #{to-rgb($link-color)};


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2893

### Description

- [x] Fix the chevron color in the disabled state
- [x] Fix link color theme switching issue

### Motivation & Context

To be align with Link component design

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

