### PR TITLE
fix: links in dark-mode inside light-mode

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -351,6 +351,15 @@ sup { top: -.5em; }
 
 // OUDS mod: define link properties in a placeholder to be reused in link component
 %link-properties {
+  // scss-docs-start root-link-var-ouds
+  --#{$prefix}link-color: #{$ouds-link-color-content-enabled};
+  --#{$prefix}link-hover-color: #{$ouds-link-color-content-hover};
+  --#{$prefix}link-focus-color: #{$ouds-link-color-content-focus};
+  --#{$prefix}link-active-color: #{$ouds-link-color-content-pressed};
+  --#{$prefix}link-disabled-color: #{$ouds-color-action-disabled};
+  --#{$prefix}link-visited-color: #{$ouds-color-action-visited};
+  // scss-docs-end root-link-var-ouds
+
   font-weight: $link-font-weight; // OUDS mod
   color: var(--#{$prefix}link-color); // OUDS mod: instead of rgba(var(--#{$prefix}link-color-rgb), var(--#{$prefix}link-opacity, 1));
   text-decoration: $link-decoration;

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -246,17 +246,6 @@
 
   --#{$prefix}heading-color: #{$headings-color};
 
-  // OUDS mod
-  // scss-docs-start root-link-var-ouds
-  --#{$prefix}link-color: #{$ouds-link-color-content-enabled};
-  --#{$prefix}link-hover-color: #{$ouds-link-color-content-hover};
-  --#{$prefix}link-focus-color: #{$ouds-link-color-content-focus};
-  --#{$prefix}link-active-color: #{$ouds-link-color-content-pressed};
-  --#{$prefix}link-disabled-color: #{$ouds-color-action-disabled};
-  --#{$prefix}link-visited-color: #{$ouds-color-action-visited};
-  // scss-docs-end root-link-var-ouds
-  // End mod
-
   @if $enable-bootstrap-compatibility {
     --#{$prefix}link-color-rgb: #{to-rgb($link-color)};
     --#{$prefix}link-decoration: #{$link-decoration};


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#2836 

### Description

Move color CSS vars of links from root to reboot

### Motivation & Context

Fix wrong link color in contextual dark-mode when page is in light-mode.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2895--boosted.netlify.app/>