### PR TITLE
[OUDS] Design review fix: invalid example with 2 radio buttons and was-validated

### DIFF
--- a/site/content/docs/0.3/forms/radio-button.md
+++ b/site/content/docs/0.3/forms/radio-button.md
@@ -274,10 +274,18 @@ Add the `disabled` attribute and the associated `<label>` are automatically styl
 {{< example >}}
 <div class="radio-button-item">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator is-invalid" type="radio" value="" id="radioInvalid">
+    <input class="control-item-indicator is-invalid" type="radio" value="" name="radioInvalid" id="radioInvalid">
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="radioInvalid">Label</label>
+  </div>
+</div>
+<div class="radio-button-item">
+  <div class="control-item-assets-container">
+    <input class="control-item-indicator is-invalid" type="radio" value="" name="radioInvalid" id="radioInvalid2">
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" for="radioInvalid2">Label</label>
   </div>
 </div>
 {{< /example >}}

--- a/site/content/docs/0.3/migration.md
+++ b/site/content/docs/0.3/migration.md
@@ -18,6 +18,10 @@ toc: true
 
 - <span class="badge text-bg-status-positive-emphasized">New</span> Checkbox component has been implemented.
 
+#### Radio buttons
+
+- <span class="badge text-bg-status-positive-emphasized">New</span> Radio button component has been implemented.
+
 ### CSS and Sass variables
 
 - <details class="mb-short">


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

closes #2946 

### Description

Add a second radio button in the invalid state example, require and enclose both in a `.was-validated` form to show the natural Invalid state via `:invalid` pseudo-class.

### Motivation & Context

Design review

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2948--boosted.netlify.app/docs/0.3/forms/radio-button/#invalid>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- (NA) I have added JavaScript unit tests to cover my changes
- (NA) I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- (NA) My change introduces changes to the migration guide
- (NA) My new component is well displayed in [Storybook](https://deploy-preview-2948--boosted.netlify.app/storybook)
- (NA) My new component is compatible with RTL
- (NA) Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- (NA) Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)
