### PR TITLE
[OUDS] Add readonly on control item components

### DIFF
--- a/scss/forms/_control-item.scss
+++ b/scss/forms/_control-item.scss
@@ -22,6 +22,10 @@
     box-shadow: none;
   }
 
+  &:has([aria-readonly][role="checkbox"]) {
+    pointer-events: none;
+  }
+
   // Handle disabled
   &:has(input:disabled) {
     pointer-events: none;
@@ -157,7 +161,8 @@
     --#{$prefix}control-item-indicator-color: #{$ouds-color-action-selected};
   }
 
-  &[type="checkbox"] {
+  &[type="checkbox"],
+  &[role="checkbox"][aria-readonly] {
     @include border-radius($form-check-input-border-radius);
   }
 
@@ -165,12 +170,21 @@
     @include border-radius($form-check-radio-border-radius);
   }
 
-  &:indeterminate[type="checkbox"] {
+  &:indeterminate[type="checkbox"],
+  &[role="checkbox"][aria-readonly].control-item-readonly-indeterminate {
     --#{$prefix}control-item-indicator-border-width: #{px-to-rem($ouds-checkbox-border-width-selected)};
 
     &::before {
       background-color: currentcolor;
       mask-image: escape-svg($form-check-input-indeterminate-bg-image);
+    }
+  }
+
+  &[role="checkbox"][aria-checked="true"] {
+    --#{$prefix}control-item-indicator-border: #{$ouds-checkbox-border-width-selected};
+    &::before {
+      background-color: currentcolor;
+      mask-image: escape-svg($form-check-input-checked-bg-image);
     }
   }
 
@@ -204,7 +218,8 @@
     }
 
     &:focus-visible {
-      &[type="checkbox"] {
+      &[type="checkbox"],
+      &[role="checkbox"][aria-readonly] {
         --#{$prefix}control-item-indicator-border-width: #{px-to-rem($ouds-checkbox-border-width-selected-focus)};
       }
 
@@ -259,7 +274,8 @@
     }
   }
 
-  &:disabled {
+  &:disabled,
+  &[aria-readonly][role="checkbox"] {
     --#{$prefix}control-item-indicator-color: #{$ouds-color-action-disabled};
     pointer-events: none;
   }

--- a/site/content/docs/0.3/forms/checkbox.md
+++ b/site/content/docs/0.3/forms/checkbox.md
@@ -287,7 +287,47 @@ Add the `disabled` attribute and the associated `<label>` are automatically styl
 {{< /example >}}
 {{< /bootstrap-compatibility >}}
 
-<!-- TODO: Introduce Readonly ? -->
+### Read only
+
+To create a read only Checkbox the input should be replaced by a `span` element with `role="checkbox"`, `aria-readonly` and `aria-disabled` attributes. The Checkbox will be accessible to assistive technology thanks to `aria-labelledby` and `tabindex` but other interactions will be prevented.
+
+{{< example class="bd-example-indeterminate" stackblitz_add_js="true" >}}
+<div class="checkbox-item">
+  <div class="control-item-assets-container">
+    <span class="control-item-indicator" role="checkbox" aria-labelledby="checkboxReadonly" aria-readonly="true" aria-disabled="true" tabindex="0" aria-checked="false"></span>
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" id="checkboxReadonly">Label</label>
+  </div>
+</div>
+<div class="checkbox-item">
+  <div class="control-item-assets-container">
+    <span class="control-item-indicator" role="checkbox" aria-labelledby="checkboxReadonlyCheckedLabel checkboxReadonlyCheckedHelper" aria-readonly="true" tabindex="0" aria-checked="true"></span>
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" id="checkboxReadonlyCheckedLabel">Label</label>
+    <p class="control-item-helper" id="checkboxReadonlyCheckedHelper">Helper text</p>
+  </div>
+  <div class="control-item-assets-container">
+    <svg aria-hidden="true">
+      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+    </svg>
+  </div>
+</div>
+<div class="checkbox-item">
+  <div class="control-item-assets-container">
+    <span class="control-item-indicator control-item-readonly-indeterminate" role="checkbox" aria-labelledby="checkboxReadonlyIndeterminate" aria-readonly="true" tabindex="0" aria-checked="true"></span>
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" id="checkboxReadonlyIndeterminate">Label</label>
+  </div>
+  <div class="control-item-assets-container">
+    <svg aria-hidden="true">
+      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+    </svg>
+  </div>
+</div>
+{{< /example >}}
 
 ### Invalid
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

closes #2950

### Types of change

- New feature (non-breaking change which adds functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices; I have at least run axe

#### Design

- [ ] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [ ] My change is compatible with a responsive display

#### Development

- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review
