### PR TITLE
doc: add a sub-paragraph for outlined invalid radio buttons

### DIFF
--- a/site/content/docs/0.3/forms/radio-button.md
+++ b/site/content/docs/0.3/forms/radio-button.md
@@ -91,14 +91,6 @@ You can display an outlined radio buttons by adding a `.radio-button-item-outlin
     <label class="control-item-label" for="radioOutlined2">Label</label>
   </div>
 </div>
-<div class="radio-button-item radio-button-item-outlined control-item-divider">
-  <div class="control-item-assets-container">
-    <input class="control-item-indicator is-invalid" type="radio" value="" id="radioOutlined3" name="radioOutlined">
-  </div>
-  <div class="control-item-text-container">
-    <label class="control-item-label" for="radioOutlined3">Label</label>
-  </div>
-</div>
 {{< /example >}}
 
 ### Divider
@@ -300,6 +292,29 @@ Add the `disabled` attribute and the associated `<label>` are automatically styl
 </div>
 {{< /example >}}
 {{< /bootstrap-compatibility >}}
+
+#### Outlined invalid
+
+ You can display an outlined invalid radio button by adding `.radio-button-item-outlined` to an invalid Radio button.
+
+{{< example >}}
+<div class="radio-button-item radio-button-item-outlined">
+  <div class="control-item-assets-container">
+    <input class="control-item-indicator is-invalid" type="radio" value="" name="outlinedInvalid" id="outlinedInvalid1">
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" for="outlinedInvalid1">Label</label>
+  </div>
+</div>
+<div class="radio-button-item radio-button-item-outlined">
+  <div class="control-item-assets-container">
+    <input class="control-item-indicator is-invalid" type="radio" value="" name="outlinedInvalid" id="outlinedInvalid2">
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" for="outlinedInvalid2">Label</label>
+  </div>
+</div>
+{{< /example >}}
 
 ## Group
 

--- a/site/content/docs/0.3/forms/radio-button.md
+++ b/site/content/docs/0.3/forms/radio-button.md
@@ -295,7 +295,7 @@ Add the `disabled` attribute and the associated `<label>` are automatically styl
 
 #### Outlined invalid
 
- You can display an outlined invalid radio button by adding `.radio-button-item-outlined` to an invalid Radio button.
+ This also works for outlined variant of the component.
 
 {{< example >}}
 <div class="radio-button-item radio-button-item-outlined">


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

closes #2947

### Description

Add a paragraph for outlined invalid Radio buttons

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2953--boosted.netlify.app/docs/0.3/forms/radio-button/#outlined-invalid>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-2953--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)
