### PR TITLE
[OUDS] display 2 controls with same config for all control items examples

### DIFF
--- a/site/content/docs/0.3/forms/checkbox.md
+++ b/site/content/docs/0.3/forms/checkbox.md
@@ -125,11 +125,20 @@ You can display an helper text by adding a `.control-item-helper` as a sibling o
 {{< example >}}
 <div class="checkbox-item">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="checkbox" aria-describedby="checkboxHelperTextDescription" id="checkboxHelperText" value="">
+    <input class="control-item-indicator" type="checkbox" aria-describedby="checkboxHelperTextDescription" id="checkboxHelperText" value="" checked>
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="checkboxHelperText">Label</label>
     <p class="control-item-helper" id="checkboxHelperTextDescription">Helper Text</p>
+  </div>
+</div>
+<div class="checkbox-item">
+  <div class="control-item-assets-container">
+    <input class="control-item-indicator" type="checkbox" aria-describedby="checkboxHelperTextDescription2" id="checkboxHelperText2" value="">
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" for="checkboxHelperText2">Label</label>
+    <p class="control-item-helper" id="checkboxHelperTextDescription2">Helper Text</p>
   </div>
 </div>
 {{< /example >}}

--- a/site/content/docs/0.3/forms/checkbox.md
+++ b/site/content/docs/0.3/forms/checkbox.md
@@ -5,9 +5,8 @@ description: Create consistent cross-browser and cross-device checkboxes.
 group: forms
 aliases:
   - "/docs/forms/checks/"
-  - "/docs/0.3/forms/checks/"
   - "/docs/forms/checks-radios/"
-  - "/docs/forms/checkbox"
+  - "/docs/forms/checkbox/"
 toc: true
 ---
 
@@ -20,24 +19,18 @@ You can find here the [OUDS Checkbox design guidelines](https://unified-design-s
 {{< example >}}
 <div class="checkbox-item">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="checkbox" value="" id="checkboxDefault">
+    <input class="control-item-indicator" type="checkbox" value="" id="checkboxDefault" checked>
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="checkboxDefault">Label</label>
   </div>
 </div>
-<div class="checkbox-item control-item-divider">
+<div class="checkbox-item">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="checkbox" value="" id="checkboxFullOption" checked aria-describedby="checkboxFullOptionHelper">
+    <input class="control-item-indicator" type="checkbox" value="" id="checkboxDefault2">
   </div>
   <div class="control-item-text-container">
-    <label class="control-item-label" for="checkboxFullOption">Label</label>
-    <p class="control-item-helper" id="checkboxFullOptionHelper">Helper text</p>
-  </div>
-  <div class="control-item-assets-container">
-    <svg aria-hidden="true">
-      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
-    </svg>
+    <label class="control-item-label" for="checkboxDefault2">Label</label>
   </div>
 </div>
 {{< /example >}}
@@ -148,7 +141,7 @@ You can reverse the component by adding `.control-item-reverse` to a `.checkbox-
 {{< example >}}
 <div class="checkbox-item control-item-reverse">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="checkbox" value="" id="checkboxReverse" name="checkboxReverse">
+    <input class="control-item-indicator" type="checkbox" value="" id="checkboxReverse" checked>
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="checkboxReverse">Label</label>
@@ -156,16 +149,10 @@ You can reverse the component by adding `.control-item-reverse` to a `.checkbox-
 </div>
 <div class="checkbox-item control-item-reverse">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="checkbox" value="" id="checkboxReverse2" name="checkboxReverse" aria-describedby="checkboxReverse2Description">
+    <input class="control-item-indicator" type="checkbox" value="" id="checkboxReverse2">
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="checkboxReverse2">Label</label>
-    <p class="control-item-helper" id="checkboxReverse2Description">Helper Text</p>
-  </div>
-  <div class="control-item-assets-container">
-    <svg aria-hidden="true">
-      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
-    </svg>
   </div>
 </div>
 {{< /example >}}
@@ -300,6 +287,14 @@ Add the `disabled` attribute and the associated `<label>` are automatically styl
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="checkboxInvalid">Label</label>
+  </div>
+</div>
+<div class="checkbox-item">
+  <div class="control-item-assets-container">
+    <input class="control-item-indicator is-invalid" type="checkbox" value="" id="checkboxInvalid2">
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" for="checkboxInvalid2">Label</label>
   </div>
 </div>
 {{< /example >}}

--- a/site/content/docs/0.3/forms/radio-button.md
+++ b/site/content/docs/0.3/forms/radio-button.md
@@ -24,19 +24,12 @@ You can find here the [OUDS Radio button design guidelines](https://unified-desi
     <label class="control-item-label" for="radioDefault">Label</label>
   </div>
 </div>
-<div class="radio-button-item control-item-divider">
+<div class="radio-button-item">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="radio" value="" id="radioFullOption" checked name="radioBasic" aria-describedby="radioFullOptionAdditionalText radioFullOptionHelper">
+    <input class="control-item-indicator" type="radio" value="" id="radioDefault2" name="radioBasic">
   </div>
   <div class="control-item-text-container">
-    <label class="control-item-label" for="radioFullOption">Label</label>
-    <p class="radio-button-additional-label" id="radioFullOptionAdditionalText">Additional label</p>
-    <p class="control-item-helper" id="radioFullOptionHelper">Helper text</p>
-  </div>
-  <div class="control-item-assets-container">
-    <svg width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
-      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
-    </svg>
+    <label class="control-item-label" for="radioDefault2">Label</label>
   </div>
 </div>
 {{< /example >}}
@@ -136,7 +129,7 @@ You can display an icon by adding `.control-item-assets-container` with an icon 
 </div>
 <div class="radio-button-item">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="radio" value="" id="radioWithIconFont"  name="radioIcon">
+    <input class="control-item-indicator" type="radio" value="" id="radioWithIconFont" name="radioIcon">
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="radioWithIconFont">Label</label>
@@ -149,32 +142,50 @@ You can display an icon by adding `.control-item-assets-container` with an icon 
 
 ### Additional label
 
-You can display an additional label for critical information for the option by adding a `.radio-button-additional-label` as a sibling of a `.control-item-label`.
+You can display an additional label for critical information for the option by adding a `.radio-button-additional-label` as a sibling of a `.control-item-label`, don't forget to make it accessible by adding an `aria-describedby` attribute on the input.
 
 {{< example >}}
 <div class="radio-button-item">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="radio" value="" id="radioAdditionalLabel">
+    <input class="control-item-indicator" type="radio" value="" id="radioAdditionalLabel" aria-describedby="radioAdditionalTextDescription" name="radioAdditionalLabel" checked>
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="radioAdditionalLabel">Label</label>
-    <p class="radio-button-additional-label">Additional label</p>
+    <p class="radio-button-additional-label" id="radioAdditionalTextDescription">Additional label</p>
+  </div>
+</div>
+<div class="radio-button-item">
+  <div class="control-item-assets-container">
+    <input class="control-item-indicator" type="radio" value="" id="radioAdditionalLabel2" aria-describedby="radioAdditionalTextDescription2" name="radioAdditionalLabel">
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" for="radioAdditionalLabel2">Label</label>
+    <p class="radio-button-additional-label" id="radioAdditionalTextDescription2">Additional label</p>
   </div>
 </div>
 {{< /example >}}
 
 ### Helper text
 
-You can display an helper text by adding a `.control-item-helper` as a sibling of a `.control-item-label`.
+You can display an helper text by adding a `.control-item-helper` as a sibling of a `.control-item-label`, don't forget to make it accessible by adding an `aria-describedby` attribute on the input.
 
 {{< example >}}
 <div class="radio-button-item">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="radio" value="" id="radioHelperText">
+    <input class="control-item-indicator" type="radio" value="" id="radioHelperText" aria-describedby="radioAdditionalTextHelper" name="radioTextHelper" checked>
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="radioHelperText">Label</label>
-    <p class="control-item-helper">Helper Text</p>
+    <p class="control-item-helper" id="radioAdditionalTextHelper">Helper Text</p>
+  </div>
+</div>
+<div class="radio-button-item">
+  <div class="control-item-assets-container">
+    <input class="control-item-indicator" type="radio" value="" id="radioHelperText2" aria-describedby="radioAdditionalTextHelper2" name="radioTextHelper">
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" for="radioHelperText2">Label</label>
+    <p class="control-item-helper" id="radioAdditionalTextHelper2">Helper Text</p>
   </div>
 </div>
 {{< /example >}}
@@ -186,10 +197,18 @@ You can reverse the component by adding `.control-item-reverse` to a `.radio-but
 {{< example >}}
 <div class="radio-button-item control-item-reverse">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="radio" value="" id="radioReverse">
+    <input class="control-item-indicator" type="radio" value="" id="radioReverse" name="radioReverse" checked>
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="radioReverse">Label</label>
+  </div>
+</div>
+<div class="radio-button-item control-item-reverse">
+  <div class="control-item-assets-container">
+    <input class="control-item-indicator" type="radio" value="" id="radioReverse2" name="radioReverse">
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" for="radioReverse2">Label</label>
   </div>
 </div>
 {{< /example >}}

--- a/site/content/docs/0.3/forms/radio-button.md
+++ b/site/content/docs/0.3/forms/radio-button.md
@@ -5,7 +5,7 @@ description: Create consistent cross-browser and cross-device radio buttons.
 group: forms
 aliases:
   - "/docs/forms/radio/"
-  - "/docs/0.2/forms/radio/"
+  - "/docs/forms/radio-button/"
 toc: true
 ---
 

--- a/site/content/docs/0.3/forms/switch.md
+++ b/site/content/docs/0.3/forms/switch.md
@@ -4,7 +4,7 @@ title: Switch
 description: Create consistent cross-browser and cross-device toggle switches.
 group: forms
 aliases:
-  - "/docs/forms/switch"
+  - "/docs/forms/switch/"
 toc: true
 ---
 

--- a/site/content/docs/0.3/forms/switch.md
+++ b/site/content/docs/0.3/forms/switch.md
@@ -18,24 +18,18 @@ You can find here the [OUDS Switch design guidelines](https://unified-design-sys
 {{< example >}}
 <div class="switch-item">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchDefault">
+    <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchDefault" checked>
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="switchDefault">Label</label>
   </div>
 </div>
-<div class="switch-item control-item-divider">
+<div class="switch-item">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchFullOption" checked aria-describedby="switchFullOptionHelper">
+    <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchDefault2">
   </div>
   <div class="control-item-text-container">
-    <label class="control-item-label" for="switchFullOption">Label</label>
-    <p class="control-item-helper" id="switchFullOptionHelper">Helper text</p>
-  </div>
-  <div class="control-item-assets-container">
-    <svg aria-hidden="true">
-      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
-    </svg>
+    <label class="control-item-label" for="switchDefault2">Label</label>
   </div>
 </div>
 {{< /example >}}
@@ -133,6 +127,15 @@ You can display an helper text by adding a `.control-item-helper` as a sibling o
     <p class="control-item-helper" id="switchHelperTextDescription">Helper Text</p>
   </div>
 </div>
+<div class="switch-item">
+  <div class="control-item-assets-container">
+    <input class="control-item-indicator" type="checkbox" role="switch" aria-describedby="switchHelperTextDescription2" id="switchHelperText2" value="">
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" for="switchHelperText2">Label</label>
+    <p class="control-item-helper" id="switchHelperTextDescription2">Helper Text</p>
+  </div>
+</div>
 {{< /example >}}
 
 ### Reverse
@@ -142,7 +145,7 @@ You can reverse the component by adding `.control-item-reverse` to a `.control-i
 {{< example >}}
 <div class="switch-item control-item-reverse">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchReverse" name="switchReverse">
+    <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchReverse" name="switchReverse" checked>
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="switchReverse">Label</label>
@@ -150,16 +153,10 @@ You can reverse the component by adding `.control-item-reverse` to a `.control-i
 </div>
 <div class="switch-item control-item-reverse">
   <div class="control-item-assets-container">
-    <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchReverse2" name="switchReverse" aria-describedby="switchReverse2Description">
+    <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchReverse2" name="switchReverse">
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="switchReverse2">Label</label>
-    <p class="control-item-helper" id="switchReverse2Description">Helper Text</p>
-  </div>
-  <div class="control-item-assets-container">
-    <svg aria-hidden="true">
-      <use xlink:href="/docs/{{< param docs_version >}}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
-    </svg>
   </div>
 </div>
 {{< /example >}}
@@ -219,7 +216,7 @@ Add the `disabled` attribute and the associated `<label>` are automatically styl
 
 ### Invalid
 
-You can display an invalid switch by adding `.is-invalid` to a `.control-item-indicator`. <!-- Please take a look at our [Validation]({{< docsref "/forms/validation" >}}) page to know more about this. -->
+You can display an invalid switch by adding `.is-invalid` to a `.control-item-indicator`. Please take a look at our [Validation]({{< docsref "/forms/validation" >}}) page to know more about this.
 
 {{< example >}}
 <div class="switch-item">
@@ -228,6 +225,14 @@ You can display an invalid switch by adding `.is-invalid` to a `.control-item-in
   </div>
   <div class="control-item-text-container">
     <label class="control-item-label" for="switchInvalid">Label</label>
+  </div>
+</div>
+<div class="switch-item">
+  <div class="control-item-assets-container">
+    <input class="control-item-indicator is-invalid" type="checkbox" role="switch" value="" id="switchInvalid2">
+  </div>
+  <div class="control-item-text-container">
+    <label class="control-item-label" for="switchInvalid2">Label</label>
   </div>
 </div>
 {{< /example >}}


### PR DESCRIPTION
### Related issues

closes #2954 

### Description

In addition to the work described in the issue, I fixed some redirects to control items.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2955--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [ ] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-2955--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)
