### PR TITLE
docs: add info callout for invalid state

### DIFF
--- a/site/content/docs/0.4/forms/checkbox.md
+++ b/site/content/docs/0.4/forms/checkbox.md
@@ -287,6 +287,10 @@ Add the `disabled` attribute and the associated `<label>` are automatically styl
 
 ### Invalid
 
+{{< callout info >}}
+{{< partial "callouts/input-invalid.md" >}}
+{{< /callout >}}
+
  You can display an invalid checkbox by adding `.is-invalid` to a `.control-item-indicator`. Please take a look at our [Validation]({{< docsref "/forms/validation" >}}) page to know more about this.
 
 {{< example >}}

--- a/site/content/docs/0.4/forms/radio-button.md
+++ b/site/content/docs/0.4/forms/radio-button.md
@@ -280,6 +280,10 @@ Add the `disabled` attribute and the associated `<label>` are automatically styl
 
 ### Invalid
 
+{{< callout info >}}
+{{< partial "callouts/input-invalid.md" >}}
+{{< /callout >}}
+
  You can display an invalid radio button by adding `.is-invalid` to a `.control-item-indicator`. Please take a look at our [Validation]({{< docsref "/forms/validation" >}}) page to know more about this.
 
 {{< example >}}

--- a/site/content/docs/0.4/forms/switch.md
+++ b/site/content/docs/0.4/forms/switch.md
@@ -216,6 +216,10 @@ Add the `disabled` attribute and the associated `<label>` are automatically styl
 
 ### Invalid
 
+{{< callout info >}}
+{{< partial "callouts/input-invalid.md" >}}
+{{< /callout >}}
+
 You can display an invalid switch by adding `.is-invalid` to a `.control-item-indicator`. Please take a look at our [Validation]({{< docsref "/forms/validation" >}}) page to know more about this.
 
 {{< example >}}

--- a/site/layouts/partials/callouts/input-invalid.md
+++ b/site/layouts/partials/callouts/input-invalid.md
@@ -1,0 +1,1 @@
+This correspond to the Error state in OUDS, as html inputs use the term invalid when in error.

--- a/site/layouts/partials/callouts/input-invalid.md
+++ b/site/layouts/partials/callouts/input-invalid.md
@@ -1,1 +1,1 @@
-This correspond to the Error state in OUDS, as html inputs use the term invalid when in error.
+The invalid state is the equivalent of the 'Error' state that you can find in the design specification.


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

closes #2961

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

- New feature (non-breaking change which adds functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-2964--boosted.netlify.app/docs/forms/checkbox/#invalid>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-2964--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)
