### PR TITLE
Ouds/main 2897 create component   bullet list

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -217,7 +217,7 @@ address {
 
 ol,
 ul {
-  padding-left: 2rem;
+  padding-left: 0; // OUDS mod: instead of 2rem
 }
 
 ol,
@@ -237,41 +237,50 @@ ul ol {
 // OUDS mod
 // Orange square list-style
 ul {
-  list-style-type: square;
+  list-style-type: none;
+  @include get-font-size("body-medium");
 }
 
+li {
+  padding: $ouds-bullet-list-space-padding-block-body-medium $ouds-bullet-list-space-padding-inline-level-0;
+}
 // Future-proof markers' color
 // See https://developer.mozilla.org/fr/docs/Web/CSS/::marker
-// stylelint-disable selector-max-type
-li::marker {
+li::before {
+  box-sizing: border-box;
+  display: inline-block;
+  width: var(--#{$prefix}icon-md-with-body-medium);
+  height: var(--#{$prefix}font-line-height-body-medium);
+  padding: calc(var(--#{$prefix}font-line-height-body-medium) - var(--#{$prefix}icon-md-with-body-medium)) 0; // stylelint-disable-line function-disallowed-list
+  padding-left: calc(var(--#{$prefix}icon-md-with-body-medium) - var(--#{$prefix}icon-md-with-body-small)); // stylelint-disable-line function-disallowed-list
   color: var(--#{$prefix}color-content-brand-primary);
   vertical-align: middle;
+  content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='currentColor'><rect x='5' y='5' width='6' height='6'/></svg>");
 
   ol & {
     color: inherit;
   }
 }
 
-li li::marker { color: var(--#{$prefix}color-content-muted); }
+// li li::marker { color: var(--#{$prefix}color-content-muted); }
 
-li li li::marker { color: var(--#{$prefix}color-content-disabled); } // TODO: Check the colors once the design is done
+// li li li::marker { color: var(--#{$prefix}color-content-disabled); } // TODO: Check the colors once the design is done
 
 // Bullet-proof markers' color
 // @todo To remove when ::marker support is OK
 // See https://caniuse.com/#search=%3A%3Amarker
-li::before {
-  color: var(--#{$prefix}color-content-brand-primary);
-  vertical-align: text-top;
+// li::before {
+//   color: var(--#{$prefix}color-content-brand-primary);
+//   vertical-align: text-top;
 
-  ol & {
-    color: inherit;
-  }
-}
+//   ol & {
+//     color: inherit;
+//   }
+// }
 
-li li::before { color: var(--#{$prefix}color-content-muted); }
+// li li::before { color: var(--#{$prefix}color-content-muted); }
 
-li li li::before { color: var(--#{$prefix}color-content-disabled); }
-// stylelint-enable selector-max-type
+// li li li::before { color: var(--#{$prefix}color-content-disabled); }
 // End mod
 
 dt {

--- a/scss/mixins/_lists.scss
+++ b/scss/mixins/_lists.scss
@@ -4,4 +4,12 @@
 @mixin list-unstyled {
   padding-left: 0;
   list-style: none;
+
+  li {
+    padding: 0;
+
+    &::before {
+      display: none;
+    }
+  }
 }

--- a/site/content/docs/0.4/components/bullet-list.md
+++ b/site/content/docs/0.4/components/bullet-list.md
@@ -1,0 +1,29 @@
+---
+layout: docs
+title: Bullet list
+description: List allows users to view individual, but related, text items grouped together.
+group: components
+aliases:
+  - "/docs/components/bullet-list/"
+toc: true
+---
+
+{{< callout info >}}
+You can find here the [OUDS Bullet list design guidelines](https://unified-design-system.orange.com/472794e18/p/48a788-button).
+{{< /callout >}}
+
+## Bullet list
+
+
+
+{{< example >}}
+<ul>
+    <li>This is a list</li>
+    <li>It has styling</li>
+    <li>To look nice</li>
+</ul>
+{{< /example >}}
+
+## Ordered list
+
+## Unstyled list

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -109,6 +109,7 @@
       draft: true
     - title: Breadcrumb
       draft: true
+    - title: Bullet list
     - title: Buttons
     - title: Button group
       draft: true


### PR DESCRIPTION
### Related issues

closes #2897

### Types of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would change existing functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)

<!------------------------>
<!-- /!\ Core Team Only -->
<!------------------------>

<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `hugo.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/content/docs/_index.html`?)
    - [ ] Move `site/content/docs/5.x` to `site/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/content/docs/5.1/**/*.md` should not always be modified
- [ ] if the year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities, and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc, and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (e.g. for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] Commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] Merge (on `v4-dev` or `main`)
- [ ] Tag your version, and push your tag
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in to NPM (with a personal account, for example), [you'd better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you're releasing a pre-release, use `--tag`, e.g. for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch (don't forget to update Storybook as well)
  - [ ] check every `index.html` used as redirections to redirect to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples' HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurrences
- [ ] make an announcement in [GitHub Discussions](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/discussions/categories/announcements) (+ pin the new GH Discussion)
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach the zip file
  - paste the CHANGELOG / Ship list in the release's description
- [ ] make an announcement on internal communication channels :tada:
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
-->
