### PR TITLE
[OUDS] Docs: add divider design doc link

### DIFF
--- a/site/content/docs/0.4/helpers/divider.md
+++ b/site/content/docs/0.4/helpers/divider.md
@@ -10,6 +10,10 @@ aliases:
 toc: true
 ---
 
+{{< callout info >}}
+You can find here the [OUDS Divider design guidelines](https://unified-design-system.orange.com/472794e18/p/629e1b-divider).
+{{< /callout >}}
+
 ## Horizontal rules
 
 Horizontal rules should use the `<hr>` tag, when the separator has semantic meaning (i.e., when it represents a topic change or a significant transition in the content). If the divider is purely decorative, prefer using a border CSS property on an HTML element or our [border utilities]({{< docsref "/utilities/borders" >}}), or even ensure to hide it from assistive technologies (e.g., `aria-hidden="true"`).


### PR DESCRIPTION
### Related issues

Add Divider desigin guideline documentation link

### Description

Update Divider documentation page with a link to Divider Design Guideline documentation

### Motivation & Context

Link design guideline documentation for developers

### Types of change

- Documentation

### Live previews

- <https://deploy-preview-3006--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [ ] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [ ] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] I have added JavaScript unit tests to cover my changes
- [x] I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly