### PR TITLE
[OUDS] docs use right bg color in migration md

### DIFF
--- a/site/content/docs/0.4/migration.md
+++ b/site/content/docs/0.4/migration.md
@@ -23,7 +23,7 @@ toc: true
 
 #### Breadcrumb
 
-- <span class="badge text-bg-success">New</span> Breadcrumb component has been implemented.
+- <span class="badge text-bg-status-positive-emphasized">New</span> Breadcrumb component has been implemented.
 
 ## v0.4.1
 
@@ -102,13 +102,13 @@ toc: true
 
 #### Reboot
 
-- <span class="badge text-bg-success">New</span> Default link styles has been updated.
+- <span class="badge text-bg-status-positive-emphasized">New</span> Default link styles has been updated.
 
 ### Components
 
 #### Links
 
-- <span class="badge text-bg-success">New</span> Link component has been implemented.
+- <span class="badge text-bg-status-positive-emphasized">New</span> Link component has been implemented.
 
 ### Helpers
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

closes #2999 

### Description

Change text bg color class on some elements in migration.md

### Motivation & Context

We used the boostrap ones instead of OUDS'

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Live previews

- <https://deploy-preview-3011--boosted.netlify.app/>
