### PR TITLE
fix(switch): Standalone switch fix

### DIFF
--- a/scss/forms/_control-item.scss
+++ b/scss/forms/_control-item.scss
@@ -559,6 +559,19 @@
 
 .switch-standalone {
   @extend %control-item-standalone;
+  padding: 0;
+
+  &:has(input:hover),
+  &:has(input:active),
+  &:has(input:focus-visible) {
+    background-color: transparent;
+    outline: 0;
+    box-shadow: none;
+  }
+
+  input:focus-visible {
+    @include focus-visible();
+  }
 }
 
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Closes #3019 

### Description

Removed the outline from the label to add it to the input itself.
Removed the padding and background-color from the label.

### Motivation & Context

Be aligned with the design.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3046--boosted.netlify.app/docs/forms/switch#standalone>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] I have added JavaScript unit tests to cover my changes
- [x] I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] My change introduces changes to the migration guide
- [x] My new component is well displayed in [Storybook](https://deploy-preview-3046--boosted.netlify.app/storybook)
- [x] My new component is compatible with RTL
- [x] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [x] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)