### PR TITLE
[OUDS] bullet list design re review after demo

### DIFF
--- a/scss/_bullet-list.scss
+++ b/scss/_bullet-list.scss
@@ -11,6 +11,7 @@
   list-style-type: "";
   @include get-font-size("body-large");
 
+  &.fs-bm,
   &.fs-bm ul,
   &.fs-bm ol {
     --#{$prefix}bullet-list-padding-block: #{$ouds-bullet-list-space-padding-block-body-medium};

--- a/site/src/content/docs/components/bullet-list.mdx
+++ b/site/src/content/docs/components/bullet-list.mdx
@@ -64,12 +64,12 @@ The list marker can be customized either by creating a CSS class defining the `-
 Define a CSS class with the desired SVG inside the `--bs-bullet-list-custom-marker` custom property. This will avoid repeating the SVG code if you plan to have several bullet lists with this same marker.
 
 <Example code={`<style>
-    .bullet-list-arrow {
-      --bs-bullet-list-custom-marker: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='1000' height='1000'><path d='M525 700H175a75.22 75.22 0 0 1-75-75V375a75.22 75.22 0 0 1 75-75h350V75l347.862 357.138A98.06 98.06 0 0 1 900 500a98.061 98.061 0 0 1-27.142 67.857L525 925V700Z'/></svg>")
+    .bullet-list-heart {
+      --bs-bullet-list-custom-marker: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill-rule='evenodd' d='M15.474 9.514 10 15.577 4.526 9.514l-.002-.003A2.868 2.868 0 0 1 8.69 5.572l.838.796.472.455.472-.455.838-.796.008-.008a2.868 2.868 0 0 1 4.159 3.947l-.003.003Zm1.251-5.302A4.78 4.78 0 0 0 10 4.18a4.78 4.78 0 0 0-6.815 6.7L10 18.393l6.815-7.514a4.78 4.78 0 0 0-.09-6.667Z' clip-rule='evenodd'/></svg>")
     }
   </style>
 
-  <ul class="bullet-list bullet-list-arrow">
+  <ul class="bullet-list bullet-list-heart">
       <li>Task</li>
       <li>Task
         <ul>


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

closes #3048

### Description

Use heart icon for all custom marker examples
Fixes the font size issue on bullet list first level


### Types of change

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices; I have at least run axe

#### Design

- [ ] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [ ] My change is compatible with a responsive display

#### Development

- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)
