### PR TITLE
fix(tac): do not display category container at all

### DIFF
--- a/site/src/scss/_tarteaucitron.scss
+++ b/site/src/scss/_tarteaucitron.scss
@@ -12,7 +12,6 @@
   transform: translateX(-50%);
 
   [role="heading"] {
-    display: block;
     font-weight: $font-weight-bold;
     color: $modal-content-color;
   }
@@ -81,6 +80,7 @@
 }
 
 @include tac("H1", true) {
+  display: block;
   margin-bottom: $spacer;
   font-size: $h2-font-size;
   letter-spacing: $h2-spacing;
@@ -164,7 +164,7 @@
   }
 }
 
-.catToggleBtn,
+.#{$tac-prefix}Title[role="heading"]:has(.catToggleBtn),
 .#{$tac-prefix}Hidden,
 .#{$tac-prefix}InfoBox,
 .#{$tac-prefix}ListCookies + br {

--- a/site/src/scss/_tarteaucitron.scss
+++ b/site/src/scss/_tarteaucitron.scss
@@ -12,6 +12,7 @@
   transform: translateX(-50%);
 
   [role="heading"] {
+    display: block;
     font-weight: $font-weight-bold;
     color: $modal-content-color;
   }
@@ -80,7 +81,7 @@
 }
 
 @include tac("H1", true) {
-  display: block;
+  // display: block;
   margin-bottom: $spacer;
   font-size: $h2-font-size;
   letter-spacing: $h2-spacing;
@@ -164,7 +165,7 @@
   }
 }
 
-.#{$tac-prefix}Title[role="heading"]:has(.catToggleBtn),
+[role="heading"]:has(.catToggleBtn),
 .#{$tac-prefix}Hidden,
 .#{$tac-prefix}InfoBox,
 .#{$tac-prefix}ListCookies + br {

--- a/site/src/scss/_tarteaucitron.scss
+++ b/site/src/scss/_tarteaucitron.scss
@@ -81,7 +81,6 @@
 }
 
 @include tac("H1", true) {
-  // display: block;
   margin-bottom: $spacer;
   font-size: $h2-font-size;
   letter-spacing: $h2-spacing;


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

partially closes #2862

### Description

Move `display: none` on `.catToggleBtn`to its parent which also is a heading.

### Motivation & Context

Removes the empty level 3 heading shown in HeadingsMap.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Live previews

Remove cookies and open HeadingsMap, then click on "Personalize" in the cookie banner.

- <https://deploy-preview-3058--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [ ] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [ ] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-3058--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)