### PR TITLE
fix(tac): port tac fix for duplicated h2 into our scss

### DIFF
--- a/site/src/scss/_tarteaucitron.scss
+++ b/site/src/scss/_tarteaucitron.scss
@@ -12,10 +12,15 @@
   transform: translateX(-50%);
 
   [role="heading"] {
-    display: block;
     font-weight: $font-weight-bold;
     color: $modal-content-color;
   }
+}
+
+// fixes https://github.com/AmauriC/tarteaucitron.js/issues/1347 (backport tac css)
+@include tac("-modal-open #tac_title", true)  {
+  /* stylelint-disable-next-line declaration-no-important */
+  display: none !important;
 }
 
 @include tac("Root") {


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

closes #2862

### Description

Port https://github.com/AmauriC/tarteaucitron.js/commit/40e164c1c3795272e66904092d6b00f003075953 into our tarteaucitron custom Scss

### Motivation & Context

This will hide the first h2 from tarteaucitron when the  Cookies management modal is open.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Live previews

Open the cookies mgmt modal and HeadingsMap, there should be only one h2 for Cookies management panel

- <https://deploy-preview-3065--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [ ] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [ ] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-3065--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)