### PR TITLE
feat(lib): remove focus-visible polyfill

### DIFF
--- a/build/generate-sri.mjs
+++ b/build/generate-sri.mjs
@@ -52,10 +52,6 @@ const files = [
   {
     file: 'node_modules/@popperjs/core/dist/umd/popper.min.js',
     configPropertyName: 'popper_hash'
-  },
-  {
-    file: 'node_modules/focus-visible/dist/focus-visible.min.js',
-    configPropertyName: 'focus_visible_hash'
   }
 ]
 

--- a/config.yml
+++ b/config.yml
@@ -52,8 +52,6 @@ cdn:
   popper:                         "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"
   popper_hash:                    "sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r"
   popper_esm:                     "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/esm/popper.min.js"
-  focus_visible:                  "https://cdn.jsdelivr.net/npm/focus-visible@5.2.1/dist/focus-visible.min.js"
-  focus_visible_hash:             "sha384-xRa5B8rCDfdg0npZcxAh+RXswrbFk3g6dlHVeABeluN8EIwdyljz/LqJgc2R3KNA"
 
 anchors:
   min:                  2

--- a/js/index.esm.js
+++ b/js/index.esm.js
@@ -5,8 +5,6 @@
  * --------------------------------------------------------------------------
  */
 
-import '../node_modules/focus-visible/dist/focus-visible.js' /* eslint-disable-line import/no-unassigned-import */ // OUDS mod
-
 export { default as Alert } from './src/alert.js'
 export { default as Button } from './src/button.js'
 export { default as Carousel } from './src/carousel.js'

--- a/js/index.umd.js
+++ b/js/index.umd.js
@@ -19,7 +19,6 @@ import ScrollSpy from './src/scrollspy.js'
 import Tab from './src/tab.js'
 import Toast from './src/toast.js'
 import Tooltip from './src/tooltip.js'
-import '../node_modules/focus-visible/dist/focus-visible.js' /* eslint-disable-line import/no-unassigned-import */ // OUDS mod
 
 export default {
   Alert,

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "eslint-plugin-markdown": "^5.1.0",
         "eslint-plugin-unicorn": "^55.0.0",
         "find-unused-sass-variables": "^6.1.0",
-        "focus-visible": "^5.2.1",
         "github-slugger": "^2.0.0",
         "globby": "^14.1.0",
         "hammer-simulator": "0.0.1",
@@ -9623,13 +9622,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/focus-visible": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.1.tgz",
-      "integrity": "sha512-8Bx950VD1bWTQJEH/AM6SpEk+SU55aVnp4Ujhuuxy3eMEBCRwBnTBnVXr9YAPvZL3/CNjCa8u4IWfNmEO53whA==",
-      "dev": true,
-      "license": "W3C"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "eslint-plugin-markdown": "^5.1.0",
     "eslint-plugin-unicorn": "^55.0.0",
     "find-unused-sass-variables": "^6.1.0",
-    "focus-visible": "^5.2.1",
     "github-slugger": "^2.0.0",
     "globby": "^14.1.0",
     "hammer-simulator": "0.0.1",

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -78,13 +78,11 @@
     background-color: var(--#{$prefix}accordion-btn-hover-bg); // OUDS mod
   }
 
-  &:focus {
+  &:focus-visible {
     // OUDS mod
-    &[data-focus-visible-added] {
-      z-index: $focus-visible-zindex; // Make sure the focused accordion button is displayed over its next sibling
-      outline-offset: add($focus-visible-outer-offset, var(--#{$prefix}accordion-border-width));
-      box-shadow: 0 0 0 add(var(--#{$prefix}accordion-border-width), $focus-visible-inner-width) var(--#{$prefix}color-border-focus-inset);
-    }
+    z-index: $focus-visible-zindex; // Make sure the focused accordion button is displayed over its next sibling
+    outline-offset: add($focus-visible-outer-offset, var(--#{$prefix}accordion-border-width));
+    box-shadow: 0 0 0 add(var(--#{$prefix}accordion-border-width), $focus-visible-inner-width) var(--#{$prefix}color-border-focus-inset);
     // End mod
   }
 }

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -80,13 +80,11 @@
       border: 0;
     }
 
-    &:focus {
-      &[data-focus-visible-added] {
-        border-right-width: var(--#{$prefix}btn-border-width);
+    &:focus-visible {
+      border-right-width: var(--#{$prefix}btn-border-width);
 
-        &::after {
-          display: none;
-        }
+      &::after {
+        display: none;
       }
     }
   }

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -81,7 +81,6 @@
   // OUDS mod: apply common styles to hover, focus visible and loading states
   &:hover,
   &:focus-visible,
-  &:focus[data-focus-visible-added],
   &.loading-indeterminate,
   &.loading-determinate,
   &:active,
@@ -100,8 +99,7 @@
 
   // OUDS mod: no .btn-check + &:hover
 
-  &:focus-visible,
-  &:focus[data-focus-visible-added] { // OUDS mod
+  &:focus-visible {
     z-index: $focus-visible-zindex; // OUDS mod
     color: var(--#{$prefix}btn-focus-color); // OUDS mod: instead of `var(--#{$prefix}btn-hover-color)`
     @include gradient-bg(var(--#{$prefix}btn-focus-bg)); // OUDS mod: instead of `var(--#{$prefix}btn-hover-bg)`

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -128,11 +128,9 @@
   }
 
   // scss-docs-start focus-visible-carousel
-  &:focus {
-    &[data-focus-visible-added] {
-      > span {
-        @include focus-visible();
-      }
+  &:focus-visible {
+    > span {
+      @include focus-visible();
     }
   }
   // scss-docs-end focus-visible-carousel
@@ -225,10 +223,8 @@
       }
     }
 
-    &:focus {
-      &[data-focus-visible-added] {
-        transform: none;
-      }
+    &:focus-visible {
+      transform: none;
     }
 
   }

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -208,11 +208,9 @@
   }
 
   // OUDS mod: focus
-  &:focus {
-    &[data-focus-visible-added] {
-      outline-offset: -$focus-visible-outer-width;
-      box-shadow: inset 0 0 0 add($focus-visible-inner-width, $focus-visible-outer-width) var(--#{$prefix}color-border-focus-inset);
-    }
+  &:focus-visible {
+    outline-offset: -$focus-visible-outer-width;
+    box-shadow: inset 0 0 0 add($focus-visible-inner-width, $focus-visible-outer-width) var(--#{$prefix}color-border-focus-inset);
   }
   // End mod
 }

--- a/scss/_links.scss
+++ b/scss/_links.scss
@@ -21,7 +21,7 @@
   background: transparent;
   border: 0;
 
-  &:has(svg, img, .icon):not(:hover, :active, :focus-visible, :focus[data-focus-visible]) {
+  &:has(svg, img, .icon):not(:hover, :active, :focus-visible) {
     text-decoration: none;
   }
 
@@ -52,8 +52,7 @@
 
   &:hover,
   &:active,
-  &:focus-visible,
-  &:focus[data-focus-visible] {
+  &:focus-visible {
     text-decoration: underline;
   }
 
@@ -82,9 +81,7 @@
   }
 
   &:focus-visible::before,
-  &:focus[data-focus-visible]::before,
-  &:focus-visible::after,
-  &:focus[data-focus-visible]::after {
+  &:focus-visible::after {
     background-color: var(--#{$prefix}link-arrow-focus-color);
   }
 

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -113,11 +113,9 @@
   }
 
   // OUDS mod: focus
-  &:focus {
-    &[data-focus-visible-added] {
-      outline-offset: subtract(-$focus-visible-outer-width, var(--#{$prefix}list-group-border-width));
-      box-shadow: inset 0 0 0 add($focus-visible-inner-width, $focus-visible-outer-width) var(--#{$prefix}color-border-focus-inset);
-    }
+  &:focus-visible {
+    outline-offset: subtract(-$focus-visible-outer-width, var(--#{$prefix}list-group-border-width));
+    box-shadow: inset 0 0 0 add($focus-visible-inner-width, $focus-visible-outer-width) var(--#{$prefix}color-border-focus-inset);
   }
   // End mod
 }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -40,13 +40,9 @@
     text-decoration: if($link-hover-decoration == underline, none, null);
   }
 
-  // OUDS mod: make sure the focused nav link is displayed over its next sibling
-  &:focus[data-focus-visible-added] {
-    z-index: $focus-visible-zindex;
+  &:focus-visible {
+    z-index: $focus-visible-zindex; // OUDS mod: make sure the focused nav link is displayed over its next sibling
   }
-  // End mod
-
-  // OUDS mod: no `&:focus-visible`
 
   // Disabled state lightens text
   &.disabled,

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -73,7 +73,7 @@
   }
 
   // OUDS mod: make sure the focused page link is displayed over its next sibling
-  &:focus[data-focus-visible-added] {
+  &:focus-visible {
     z-index: $focus-visible-zindex;
   }
   // End mod

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -84,29 +84,9 @@
 
 
 // OUDS mod: focus state
-//
-// 1. Default focus state
-// 2. Using the :focus-visible polyfill to hide outline defensively
-//    See https://github.com/WICG/focus-visible
-//    Note 1: this rule is not applied for our focus ring helper which
-//    handles itself outline and box shadow
-//    Note 2: this rule is also not applied for invalid select and invalid input files to ensure
-//    sufficient contrast between select elements on error focused vs. non focused
-// 3. Using the :focus-visible pseudo-class if supported by the browser
 // scss-docs-start focus-visibility
-:focus {
-  @include focus-visible(); // 1
-}
-
-.js-focus-visible :focus:not([data-focus-visible-added]):not(.focus-ring):not(.form-select:invalid):not(.form-control[type="file"]:invalid),
-.js-focus-visible .focus:not([data-focus-visible-added]):not(.focus-ring):not(.form-select:invalid):not(.form-control[type="file"]:invalid) { // 2
-  outline: 0 !important;
-  box-shadow: none;
-}
-
-:focus:not(:focus-visible):not(.focus-ring):not(.form-select:invalid):not(.form-control[type="file"]:invalid) { // 3
-  outline: 0 !important;
-  box-shadow: none;
+:focus-visible {
+  @include focus-visible();
 }
 // scss-docs-end focus-visibility
 // End mod
@@ -352,13 +332,12 @@ sup { top: -.5em; }
   }
 
 
-  .visited-links &:visited:not(.link, .link-chevron, .icon-link, :hover, :active, :focus-visible, :focus[data-focus-visible]),
-  &:visited.visited-links:not(.link, .link-chevron, .icon-link, :hover, :active, :focus-visible, :focus[data-focus-visible]) {
+  .visited-links &:visited:not(.link, .link-chevron, .icon-link, :hover, :active, :focus-visible),
+  &:visited.visited-links:not(.link, .link-chevron, .icon-link, :hover, :active, :focus-visible) {
     color: var(--#{$prefix}link-visited-color);
   }
 
-  &:focus-visible:not([aria-disabled="true"]),
-  &:focus[data-focus-visible-added]:not([aria-disabled="true"]) {
+  &:focus-visible:not([aria-disabled="true"]) {
     color: var(--#{$prefix}link-focus-color);
     text-decoration: $link-hover-decoration;
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1185,7 +1185,7 @@ $form-range-thumb-bg:                      var(--#{$prefix}body-bg) !default; //
 $form-range-thumb-border:                  var(--#{$prefix}border-width) solid var(--#{$prefix}color-border-emphasized) !default; // OUDS mod: instead of `0`
 $form-range-thumb-border-radius:           50% !default;
 $form-range-thumb-box-shadow:              0 .1rem .25rem rgba($black, .1) !default;
-$form-range-thumb-focus-box-shadow:        null !default; // OUDS mod
+// OUDS mod: no $form-range-thumb-focus-box-shadow
 $form-range-thumb-focus-box-shadow-width:  $input-focus-width !default; // For focus box shadow issue in Edge
 $form-range-thumb-hover-bg:                var(--#{$prefix}highlight-bg) !default; // OUDS mod
 $form-range-thumb-active-bg:               var(--#{$prefix}primary) !default; // OUDS mod: instead of `tint-color($component-active-bg, 70%)`

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -11,25 +11,16 @@
   appearance: none;
   background-color: transparent;
 
-  &:focus {
+  &:focus-visible {
     outline: 0;
-    box-shadow: none; // Bosted mod
+    box-shadow: none; // OUDS mod
 
     // Pseudo-elements must be split across multiple rulesets to have an effect.
-    // No box-shadow() mixin for focus accessibility.
-    &::-webkit-slider-thumb { box-shadow: $form-range-thumb-focus-box-shadow; }
-    &::-moz-range-thumb     { box-shadow: $form-range-thumb-focus-box-shadow; }
-
-    // OUDS mod: added `&[data-focus-visible-added]`
-    &[data-focus-visible-added] {
-      // OUDS mod: better focus visibility
-      &::-webkit-slider-thumb {
-        @include focus-visible();
-      }
-      &::-moz-range-thumb {
-        @include focus-visible();
-      }
-      // End mod
+    &::-webkit-slider-thumb {
+      @include focus-visible(); // OUDS mod: instead of `box-shadow`
+    }
+    &::-moz-range-thumb {
+      @include focus-visible(); // OUDS mod: instead of `box-shadow`
     }
   }
 

--- a/scss/forms/_quantity-selector.scss
+++ b/scss/forms/_quantity-selector.scss
@@ -43,21 +43,17 @@
       border-right-width: 0;
       @include button-icon($quantity-selector-icon-remove, $size: $quantity-selector-icon-width $quantity-selector-icon-remove-height, $pseudo: "after");
 
-      &:focus {
-        &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
-          padding-right: subtract(#{$quantity-selector-btn-padding-x}, var(--#{$prefix}border-width));
-          border-right-width: var(--#{$prefix}border-width);
-        }
+      &:focus-visible {
+        padding-right: subtract(#{$quantity-selector-btn-padding-x}, var(--#{$prefix}border-width));
+        border-right-width: var(--#{$prefix}border-width);
       }
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
         padding-right: $quantity-selector-btn-padding-x-sm;
         @include button-icon($quantity-selector-icon-remove-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-remove-height, $pseudo: "after");
 
-        &:focus {
-          &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
-            padding-right: subtract(#{$quantity-selector-btn-padding-x-sm}, var(--#{$prefix}border-width));
-          }
+        &:focus-visible {
+          padding-right: subtract(#{$quantity-selector-btn-padding-x-sm}, var(--#{$prefix}border-width));
         }
       }
     }
@@ -67,21 +63,17 @@
       border-left-width: 0;
       @include button-icon($quantity-selector-icon-add, $size: $quantity-selector-icon-width $quantity-selector-icon-add-height, $pseudo: "after");
 
-      &:focus {
-        &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
-          padding-left: subtract(#{$quantity-selector-btn-padding-x}, var(--#{$prefix}border-width));
-          border-left-width: var(--#{$prefix}border-width);
-        }
+      &:focus-visible {
+        padding-left: subtract(#{$quantity-selector-btn-padding-x}, var(--#{$prefix}border-width));
+        border-left-width: var(--#{$prefix}border-width);
       }
 
       &.btn-sm { // stylelint-disable-line selector-no-qualifying-type
         padding-left: $quantity-selector-btn-padding-x-sm;
         @include button-icon($quantity-selector-icon-add-sm, $width: 1rem, $height: 1rem, $size: $quantity-selector-icon-sm-width $quantity-selector-icon-sm-add-height, $pseudo: "after");
 
-        &:focus {
-          &[data-focus-visible-added] { // stylelint-disable-line selector-no-qualifying-type
-            padding-left: subtract(#{$quantity-selector-btn-padding-x-sm}, var(--#{$prefix}border-width));
-          }
+        &:focus-visible {
+          padding-left: subtract(#{$quantity-selector-btn-padding-x-sm}, var(--#{$prefix}border-width));
         }
       }
     }

--- a/scss/forms/_star-rating.scss
+++ b/scss/forms/_star-rating.scss
@@ -57,7 +57,7 @@
     mask-image: var(--#{$prefix}star-rating-checked-icon);
   }
 
-  > [data-focus-visible-added]:focus + label {
+  > :focus-visible + label {
     z-index: $focus-visible-zindex; // Make sure the focused star is displayed over its next sibling
     @include focus-visible();
     outline-offset: -1px;

--- a/site/src/content/docs/getting-started/accessibility.mdx
+++ b/site/src/content/docs/getting-started/accessibility.mdx
@@ -60,13 +60,13 @@ On browsers that support `prefers-reduced-motion`, and where the user has *not* 
 
 ### Focus visibility
 
-OUDS Web includes [WICG’s `:focus-visible` polyfill](https://github.com/WICG/focus-visible) to ensure an enhanced focus visibility for keyboard users while shutting down focus styles on active state.
-
-<ScssDocs name="focus-visibility" file="scss/_reboot.scss" />
-
 OUDS Web provides `focus-visible()` mixin to ensure a proper visible focus state:
 
 <ScssDocs name="focus-visible" file="scss/mixins/_focus.scss" />
+
+This mixin is applied by default on every `:focus-visible` element.
+
+<ScssDocs name="focus-visibility" file="scss/_reboot.scss" />
 
 This visible focus state is defined by an outer outline and an inner box shadow. Colors are switched in a dark context. Here are the basic variables that define this visible focus:
 

--- a/site/src/content/docs/getting-started/contents.mdx
+++ b/site/src/content/docs/getting-started/contents.mdx
@@ -93,10 +93,10 @@ OUDS Web includes a handful of options for including some or all of our compiled
 Similarly, we have options for including some or all of our compiled JavaScript.
 
 <BsTable class="table">
-| JS Files | `:focus-visible` Polyfill | Popper |
-| --- | --- | --- |
-| `ouds-web.bundle.js`<br /> `ouds-web.bundle.min.js`<br /> | Included | Included |
-| `ouds-web.js`<br /> `ouds-web.min.js`<br /> | Included | – |
+| JS Files | Popper |
+| --- | --- |
+| `ouds-web.bundle.js`<br /> `ouds-web.bundle.min.js`<br /> | Included |
+| `ouds-web.js`<br /> `ouds-web.min.js`<br /> | – |
 </BsTable>
 
 ## OUDS Web source code

--- a/site/src/content/docs/getting-started/introduction.mdx
+++ b/site/src/content/docs/getting-started/introduction.mdx
@@ -126,18 +126,6 @@ Curious which components explicitly require our JavaScript and Popper? If you’
 - Toasts for displaying, dismissing, and Close button tooltip
 - Tooltips and popovers for displaying and positioning (also requires [Popper](https://popper.js.org/docs/v2/)) */}
 
-## Required script
-
-OUDS Web includes [WICG’s `:focus-visible` polyfill](https://github.com/WICG/focus-visible) to ensure an enhanced focus visibility for keyboard users while shutting down focus styles on active state.
-
-<Callout type="warning">
-However, if you don’t need or want to use OUDS Web’s JavaScript files, you’ll still need to use the polyfill.
-</Callout>
-
-```html
-<script src="[[config:cdn.focus_visible]]" integrity="[[config:cdn.focus_visible_hash]]" crossorigin="anonymous"></script>
-```
-
 ## Important globals
 
 OUDS Web employs a handful of important global styles and settings, all of which are almost exclusively geared towards the *normalization* of cross browser styles. Let’s dive in.

--- a/site/src/content/docs/migrations/migration-from-boosted.mdx
+++ b/site/src/content/docs/migrations/migration-from-boosted.mdx
@@ -38,6 +38,8 @@ From now on, OUDS Web won’t embed Bootstrap elements that are not part of Oran
 
 - <span class="badge text-bg-status-warning-emphasized">Warning</span> The root selector have been tweaked for more flexibility on JS frameworks. Please don’t hesitate to contact us if you find any issue with it.
 
+- <span class="badge text-bg-status-negative-emphasized">Breaking</span> The focus-visible polyfill has been removed. So you no longer need it on your side, and you should replace all the calls to `:focus[data-focus-visible-added]` by `:focus-visible`.
+
 ## Fonts
 
 OUDS Web doesn’t use the Helvetica Neue font. Instead, it uses the system font stack. This means that the font will be slightly different depending on the operating system and browser being used.

--- a/site/src/content/docs/migrations/migration.mdx
+++ b/site/src/content/docs/migrations/migration.mdx
@@ -8,6 +8,12 @@ aliases:
 toc: true
 ---
 
+## v0.6.0
+
+### Contents
+
+- <span class="badge text-bg-status-negative-emphasized">Breaking</span> The focus-visible polyfill has been removed. So you no longer need it on your side, and you should replace all the calls to `:focus[data-focus-visible-added]` by `:focus-visible`.
+
 ## v0.5.0
 
 <hr />

--- a/site/src/libs/config.ts
+++ b/site/src/libs/config.ts
@@ -30,8 +30,6 @@ const configSchema = z.object({
     css_bootstrap_rtl_hash: z.string(),
     css_rtl: z.string().url(),
     css_rtl_hash: z.string(),
-    focus_visible: z.string(),
-    focus_visible_hash: z.string(),
     js: z.string().url(),
     js_hash: z.string(),
     js_bundle: z.string().url(),

--- a/site/src/scss/_search.scss
+++ b/site/src/scss/_search.scss
@@ -71,11 +71,9 @@
     }
   }
 
-  &:focus {
+  &:focus-visible {
+    @include focus-visible();
     border-radius: 0; // stylelint-disable-line property-disallowed-list
-    &[data-focus-visible-added] {
-      @include focus-visible();
-    }
   }
 
   .DocSearch-Search-Icon {
@@ -114,10 +112,8 @@
 .DocSearch-Reset {
   @include border-radius(0, 0);
 
-  &:focus {
-    &[data-focus-visible-added] {
-      @include focus-visible();
-    }
+  &:focus-visible {
+    @include focus-visible();
   }
 }
 
@@ -190,10 +186,8 @@
     color: var(--docsearch-highlight-color);
   }
 
-  &:focus {
-    &[data-focus-visible-added] {
-      @include focus-visible();
-    }
+  &:focus-visible {
+    @include focus-visible();
   }
 }
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Following #2929

### Description

Removed the focus-visible polyfill and all mentions.
Changed the Scss to adapt the new usage.

### Motivation & Context

Be aligned with our supported browserlist.
Lightweight our bundle.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3067--boosted.netlify.app/docs/getting-started/accessibility>
- <https://deploy-preview-3067--boosted.netlify.app/docs/getting-started/introduction>
- <https://deploy-preview-3067--boosted.netlify.app/docs/getting-started/contents>
- <https://deploy-preview-3067--boosted.netlify.app/migration>
- <https://deploy-preview-3067--boosted.netlify.app/migration-from-boosted>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] I have added JavaScript unit tests to cover my changes
- [x] I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] My change introduces changes to the migration guide
- [x] My new component is well displayed in [Storybook](https://deploy-preview-3067--boosted.netlify.app/storybook)
- [x] My new component is compatible with RTL
- [x] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [x] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)

<!------------------------>
<!-- /!\ Core Team Only -->
<!------------------------>

<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `hugo.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/src/content/docs/_index.html`?)
    - [ ] Move `site/src/content/docs/5.x` to `site/src/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/src/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/src/content/docs/5.1/**/*.md` should not always be modified
- [ ] if the year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities, and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc, and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (e.g. for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] Commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] Merge (on `v4-dev` or `main`)
- [ ] Tag your version, and push your tag
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in to NPM (with a personal account, for example), [you’d better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you’re releasing a pre-release, use `--tag`, e.g. for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch (don’t forget to update Storybook as well)
  - [ ] check every `index.html` used as redirections to redirect to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples’ HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurrences
- [ ] make an announcement in [GitHub Discussions](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/discussions/categories/announcements) (+ pin the new GH Discussion)
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach the zip file
  - paste the CHANGELOG / Ship list in the release’s description
- [ ] make an announcement on internal communication channels :tada:
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
-->