### PR TITLE
feat(component): Add Chip component

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,11 +2,11 @@
   "files": [
     {
       "path": "./dist/css/ouds-web-bootstrap.css",
-      "maxSize": "66.5 kB"
+      "maxSize": "67.25 kB"
     },
     {
       "path": "./dist/css/ouds-web-bootstrap.min.css",
-      "maxSize": "63.0 kB"
+      "maxSize": "63.75 kB"
     },
     {
       "path": "./dist/css/ouds-web-grid.css",
@@ -34,11 +34,11 @@
     },
     {
       "path": "./dist/css/ouds-web.css",
-      "maxSize": "58.0 kB"
+      "maxSize": "58.5 kB"
     },
     {
       "path": "./dist/css/ouds-web.min.css",
-      "maxSize": "54.5 kB"
+      "maxSize": "55.0 kB"
     },
     {
       "path": "./dist/js/ouds-web.bundle.js",

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: row;
   gap: 0 8px; // TODO: update values once the component is developed
+  margin: 0;
   overflow: auto;
 }
 
@@ -22,7 +23,7 @@
   }
 }
 
-.chip-filter, // Sort what should be inside filter, suggestion, filter-expanded, both or all
+.chip-filter,
 .chip-suggestion {
   --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-enabled};
   --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-enabled};
@@ -46,7 +47,7 @@
   border: var(--#{$prefix}chip-border-width) solid var(--#{$prefix}chip-border-color);
   border-radius: $ouds-chip-border-radius; // stylelint-disable-line property-disallowed-list
 
-  &::after { // TODO: Set a table to explain what pseudo-elements are used or not ?
+  &::after {
     position: absolute;
     top: 0;
     left: 0;
@@ -178,12 +179,12 @@ input:checked ~ .chip-filter,
     width: 1em;
     height: 1em;
     overflow: hidden;
-    font-size: $ouds-chip-size-icon;
+    font-size: px-to-rem($ouds-chip-size-icon);
     line-height: 1;
     color: var(--#{$prefix}chip-tick-color);
     content: "";
     background-color: currentcolor;
-    mask: escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#000'><path d='m13.292 5.047-6.07 7a.978.978 0 0 1-.74.328.977.977 0 0 1-.74-.329l-3.035-3.5A.83.83 0 0 1 2.5 8a.84.84 0 0 1 .277-.619l.38-.35a.986.986 0 0 1 .67-.256c.236 0 .451.08.617.21l1.849 1.89 5.61-5.013a.989.989 0 0 1 .648-.237c.524 0 .948.392.948.875a.83.83 0 0 1-.207.547Z'/></svg>")) no-repeat 50% / calc($ouds-chip-size-icon); // stylelint-disable-line function-disallowed-list
+    mask: escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#000'><path d='m13.292 5.047-6.07 7a.978.978 0 0 1-.74.328.977.977 0 0 1-.74-.329l-3.035-3.5A.83.83 0 0 1 2.5 8a.84.84 0 0 1 .277-.619l.38-.35a.986.986 0 0 1 .67-.256c.236 0 .451.08.617.21l1.849 1.89 5.61-5.013a.989.989 0 0 1 .648-.237c.524 0 .948.392.948.875a.83.83 0 0 1-.207.547Z'/></svg>")) no-repeat 50% / px-to-rem($ouds-chip-size-icon);
   }
 }
 

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -3,7 +3,8 @@
   display: flex;
   flex-direction: row;
   gap: 0 8px; // TODO: update values once the component is developed
-  margin: 0;
+  padding: 0 5px; // Handle focus for the first and last Chips
+  margin: 0 -5px;
   overflow: auto;
 }
 
@@ -23,8 +24,9 @@
   }
 }
 
-.chip-filter,
-.chip-suggestion {
+// Common styles
+.chip-suggestion,
+.chip-filter {
   --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-enabled};
   --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-enabled};
   --#{$prefix}chip-border-width: #{px-to-rem($ouds-chip-border-width-unselected)};
@@ -86,12 +88,6 @@
     pointer-events: none;
   }
 
-  &:has(svg),
-  &:has(img),
-  &:has(.icon) {
-    --#{$prefix}chip-padding-start: #{$ouds-chip-space-padding-inline-icon};
-  }
-
   svg,
   img,
   .icon {
@@ -103,9 +99,24 @@
   }
 }
 
+// Suggestion chip specific style
+.chip-suggestion {
+  &:has(svg),
+  &:has(img),
+  &:has(.icon) {
+    --#{$prefix}chip-padding-start: #{$ouds-chip-space-padding-inline-icon};
+  }
+}
+
+// Filter chip specific style that handles images, focus-visible and disabled states
 .chip-filter {
+  &:has(svg),
+  &:has(img),
+  &:has(.icon) {
+    --#{$prefix}chip-padding-end: #{$ouds-chip-space-padding-inline-icon};
+  }
+
   input:focus-visible ~ &,
-  &:focus-visible,
   &:has(input:focus-visible) {
     --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-focus};
     --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-focus};
@@ -116,13 +127,50 @@
   }
 
   input:disabled ~ &,
-  &:disabled,
   &:has(input:disabled) {
     --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-disabled};
     --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-disabled};
     --#{$prefix}chip-color: #{$ouds-chip-color-content-unselected-disabled};
 
     pointer-events: none;
+  }
+
+  // Filter chip specific style for selected state
+  input:checked ~ &,
+  &[aria-pressed="true"],
+  &:has(input:checked) {
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-enabled};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-enabled};
+    --#{$prefix}chip-border-width: #{px-to-rem($ouds-chip-border-width-selected)};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-enabled};
+    --#{$prefix}chip-padding-start: #{$ouds-chip-space-padding-inline-icon};
+    --#{$prefix}chip-tick-color: #{$ouds-chip-color-content-selected-tick-enabled};
+
+    &:hover {
+      --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-hover};
+      --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-hover};
+      --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-hover};
+      --#{$prefix}chip-tick-color: currentcolor;
+    }
+
+    &:active {
+      --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-pressed};
+      --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-pressed};
+      --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-pressed};
+      --#{$prefix}chip-tick-color: currentcolor;
+    }
+
+    &::before {
+      width: 1em;
+      height: 1em;
+      overflow: hidden;
+      font-size: px-to-rem($ouds-chip-size-icon);
+      line-height: 1;
+      color: var(--#{$prefix}chip-tick-color);
+      content: "";
+      background-color: currentcolor;
+      mask: escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#000'><path d='m13.292 5.047-6.07 7a.978.978 0 0 1-.74.328.977.977 0 0 1-.74-.329l-3.035-3.5A.83.83 0 0 1 2.5 8a.84.84 0 0 1 .277-.619l.38-.35a.986.986 0 0 1 .67-.256c.236 0 .451.08.617.21l1.849 1.89 5.61-5.013a.989.989 0 0 1 .648-.237c.524 0 .948.392.948.875a.83.83 0 0 1-.207.547Z'/></svg>")) no-repeat 50% / px-to-rem($ouds-chip-size-icon);
+    }
   }
 
   input:checked:focus-visible ~ &,
@@ -142,52 +190,9 @@
     --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-disabled};
     --#{$prefix}chip-tick-color: currentcolor;
   }
-
-  &:has(svg),
-  &:has(img),
-  &:has(.icon) {
-    --#{$prefix}chip-padding-start: #{$ouds-chip-space-padding-inline-icon-none};
-    --#{$prefix}chip-padding-end: #{$ouds-chip-space-padding-inline-icon};
-  }
 }
 
-input:checked ~ .chip-filter,
-.chip-filter[aria-pressed="true"],
-.chip-filter:has(input:checked) {
-  --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-enabled};
-  --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-enabled};
-  --#{$prefix}chip-border-width: #{px-to-rem($ouds-chip-border-width-selected)};
-  --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-enabled};
-  --#{$prefix}chip-padding-start: #{$ouds-chip-space-padding-inline-icon};
-  --#{$prefix}chip-tick-color: #{$ouds-chip-color-content-selected-tick-enabled};
-
-  &:hover {
-    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-hover};
-    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-hover};
-    --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-hover};
-    --#{$prefix}chip-tick-color: currentcolor;
-  }
-
-  &:active {
-    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-pressed};
-    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-pressed};
-    --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-pressed};
-    --#{$prefix}chip-tick-color: currentcolor;
-  }
-
-  &::before {
-    width: 1em;
-    height: 1em;
-    overflow: hidden;
-    font-size: px-to-rem($ouds-chip-size-icon);
-    line-height: 1;
-    color: var(--#{$prefix}chip-tick-color);
-    content: "";
-    background-color: currentcolor;
-    mask: escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#000'><path d='m13.292 5.047-6.07 7a.978.978 0 0 1-.74.328.977.977 0 0 1-.74-.329l-3.035-3.5A.83.83 0 0 1 2.5 8a.84.84 0 0 1 .277-.619l.38-.35a.986.986 0 0 1 .67-.256c.236 0 .451.08.617.21l1.849 1.89 5.61-5.013a.989.989 0 0 1 .648-.237c.524 0 .948.392.948.875a.83.83 0 0 1-.207.547Z'/></svg>")) no-repeat 50% / px-to-rem($ouds-chip-size-icon);
-  }
-}
-
+// Icon chip specific style
 .chip-icon.chip-icon { // Best option since we don't want to duplicate this code.
   --#{$prefix}chip-padding-block: #{$ouds-chip-space-padding-block-icon-only};
   --#{$prefix}chip-padding-end: #{$ouds-chip-space-padding-inline-icon};

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -1,0 +1,59 @@
+.chip-container {
+  @include list-unstyled();
+  display: flex;
+  flex-direction: row;
+  gap: 0 8px;
+}
+
+.chip {
+  position: relative;
+  flex-shrink: 0;
+  padding: 7px 0;
+}
+
+.chip-content {
+  display: inline-flex;
+  padding: 6px 16px;
+  @include get-font-size("label-medium");
+  font-weight: 700;
+  color: var(--bs-color-content-default);
+  background-color: transparent;
+  border: 1px solid var(--bs-color-border-default);
+  border-radius: 9999px; // stylelint-disable-line property-disallowed-list
+
+  &::before {
+    // Check
+    content: "";
+  }
+
+  &::after {
+    // Dropdown
+    content: "";
+  }
+
+  &:hover,
+  &:focus-visible {
+    padding: 5px 15px;
+    color: var(--bs-color-content-muted);
+    border: 2px solid var(--bs-color-border-emphasized);
+  }
+
+  &:active {
+    padding: 5px 15px;
+    color: var(--bs-color-content-brand-primary);
+    border: 2px solid var(--bs-color-border-brand-primary);
+  }
+
+  &:disabled {
+    color: var(--bs-color-content-disabled);
+    border-color: var(--bs-color-content-disabled);
+  }
+
+  &:has(:checked) {
+    border-color: var(--bs-color-border-brand-primary);
+  };
+}
+
+.chip-icon {
+  --bs-padding: 16px;
+}

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -2,58 +2,193 @@
   @include list-unstyled();
   display: flex;
   flex-direction: row;
-  gap: 0 8px;
+  gap: 0 8px; // TODO: update values once the component is developed
+  overflow: auto;
 }
 
 .chip {
   position: relative;
+  display: flex;
   flex-shrink: 0;
-  padding: 7px 0;
+  align-items: center;
+  min-height: $ouds-chip-size-min-height-interactive-area;
+  white-space: nowrap;
+
+  [type="radio"],
+  [type="checkbox"] { // Not `input` because of the incoming editable variant
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    pointer-events: none;
+  }
 }
 
-.chip-content {
-  display: inline-flex;
-  padding: 6px 16px;
+.chip-filter, // Sort what should be inside filter, suggestion, filter-expanded, both or all
+.chip-suggestion {
+  --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-enabled};
+  --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-enabled};
+  --#{$prefix}chip-border-width: #{px-to-rem($ouds-chip-border-width-unselected)};
+  --#{$prefix}chip-color: #{$ouds-chip-color-content-unselected-enabled};
+  --#{$prefix}chip-padding-block: #{$ouds-chip-space-padding-block};
+  --#{$prefix}chip-padding-end: #{$ouds-chip-space-padding-inline-icon-none};
+  --#{$prefix}chip-padding-start: #{$ouds-chip-space-padding-inline-icon-none};
+
+  display: flex;
+  gap: $ouds-chip-space-column-gap-icon;
+  align-items: center;
+  justify-content: center;
+  min-width: $ouds-chip-size-min-width;
+  min-height: $ouds-chip-size-min-height;
+  padding: subtract(var(--#{$prefix}chip-padding-block), var(--#{$prefix}chip-border-width)) subtract(var(--#{$prefix}chip-padding-end), var(--#{$prefix}chip-border-width)) subtract(var(--#{$prefix}chip-padding-block), var(--#{$prefix}chip-border-width)) subtract(var(--#{$prefix}chip-padding-start), var(--#{$prefix}chip-border-width));
   @include get-font-size("label-medium");
   font-weight: 700;
-  color: var(--bs-color-content-default);
-  background-color: transparent;
-  border: 1px solid var(--bs-color-border-default);
-  border-radius: 9999px; // stylelint-disable-line property-disallowed-list
+  color: var(--#{$prefix}chip-color);
+  background-color: var(--#{$prefix}chip-bg);
+  border: var(--#{$prefix}chip-border-width) solid var(--#{$prefix}chip-border-color);
+  border-radius: $ouds-chip-border-radius; // stylelint-disable-line property-disallowed-list
 
-  &::before {
-    // Check
+  &::after { // TODO: Set a table to explain what pseudo-elements are used or not ?
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
     content: "";
   }
 
-  &::after {
-    // Dropdown
-    content: "";
+  &:hover {
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-hover};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-hover};
+    --#{$prefix}chip-border-width: #{px-to-rem($ouds-chip-border-width-unselected-interaction)};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-unselected-hover};
   }
 
-  &:hover,
   &:focus-visible {
-    padding: 5px 15px;
-    color: var(--bs-color-content-muted);
-    border: 2px solid var(--bs-color-border-emphasized);
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-focus};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-focus};
+    --#{$prefix}chip-border-width: #{px-to-rem($ouds-chip-border-width-unselected-interaction)};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-unselected-focus};
   }
 
   &:active {
-    padding: 5px 15px;
-    color: var(--bs-color-content-brand-primary);
-    border: 2px solid var(--bs-color-border-brand-primary);
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-pressed};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-pressed};
+    --#{$prefix}chip-border-width: #{px-to-rem($ouds-chip-border-width-unselected-interaction)};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-unselected-pressed};
   }
 
   &:disabled {
-    color: var(--bs-color-content-disabled);
-    border-color: var(--bs-color-content-disabled);
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-disabled};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-disabled};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-unselected-disabled};
+
+    pointer-events: none;
   }
 
-  &:has(:checked) {
-    border-color: var(--bs-color-border-brand-primary);
-  };
+  &:has(svg),
+  &:has(img),
+  &:has(.icon) {
+    --#{$prefix}chip-padding-start: #{$ouds-chip-space-padding-inline-icon};
+  }
+
+  svg,
+  img,
+  .icon {
+    width: 1em;
+    height: 1em;
+    overflow: hidden;
+    font-size: px-to-rem($ouds-chip-size-icon);
+    line-height: 1;
+  }
 }
 
-.chip-icon {
-  --bs-padding: 16px;
+.chip-filter {
+  input:focus-visible ~ &,
+  &:focus-visible,
+  &:has(input:focus-visible) {
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-focus};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-focus};
+    --#{$prefix}chip-border-width: #{px-to-rem($ouds-chip-border-width-unselected-interaction)};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-unselected-focus};
+
+    @include focus-visible();
+  }
+
+  input:disabled ~ &,
+  &:disabled,
+  &:has(input:disabled) {
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-unselected-disabled};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-unselected-disabled};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-unselected-disabled};
+
+    pointer-events: none;
+  }
+
+  input:checked:focus-visible ~ &,
+  &[aria-pressed="true"]:focus-visible,
+  &:has(input:checked:focus-visible) {
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-focus};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-focus};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-focus};
+    --#{$prefix}chip-tick-color: currentcolor;
+  }
+
+  input:checked:disabled ~ &,
+  &[aria-pressed="true"]:disabled,
+  &:has(input:checked:disabled) {
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-disabled};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-disabled};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-disabled};
+    --#{$prefix}chip-tick-color: currentcolor;
+  }
+
+  &:has(svg),
+  &:has(img),
+  &:has(.icon) {
+    --#{$prefix}chip-padding-start: #{$ouds-chip-space-padding-inline-icon-none};
+    --#{$prefix}chip-padding-end: #{$ouds-chip-space-padding-inline-icon};
+  }
+}
+
+input:checked ~ .chip-filter,
+.chip-filter[aria-pressed="true"],
+.chip-filter:has(input:checked) {
+  --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-enabled};
+  --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-enabled};
+  --#{$prefix}chip-border-width: #{px-to-rem($ouds-chip-border-width-selected)};
+  --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-enabled};
+  --#{$prefix}chip-padding-start: #{$ouds-chip-space-padding-inline-icon};
+  --#{$prefix}chip-tick-color: #{$ouds-chip-color-content-selected-tick-enabled};
+
+  &:hover {
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-hover};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-hover};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-hover};
+    --#{$prefix}chip-tick-color: currentcolor;
+  }
+
+  &:active {
+    --#{$prefix}chip-bg: #{$ouds-chip-color-bg-selected-pressed};
+    --#{$prefix}chip-border-color: #{$ouds-chip-color-border-selected-pressed};
+    --#{$prefix}chip-color: #{$ouds-chip-color-content-selected-pressed};
+    --#{$prefix}chip-tick-color: currentcolor;
+  }
+
+  &::before {
+    width: 1em;
+    height: 1em;
+    overflow: hidden;
+    font-size: $ouds-chip-size-icon;
+    line-height: 1;
+    color: var(--#{$prefix}chip-tick-color);
+    content: "";
+    background-color: currentcolor;
+    mask: escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#000'><path d='m13.292 5.047-6.07 7a.978.978 0 0 1-.74.328.977.977 0 0 1-.74-.329l-3.035-3.5A.83.83 0 0 1 2.5 8a.84.84 0 0 1 .277-.619l.38-.35a.986.986 0 0 1 .67-.256c.236 0 .451.08.617.21l1.849 1.89 5.61-5.013a.989.989 0 0 1 .648-.237c.524 0 .948.392.948.875a.83.83 0 0 1-.207.547Z'/></svg>")) no-repeat 50% / calc($ouds-chip-size-icon); // stylelint-disable-line function-disallowed-list
+  }
+}
+
+.chip-icon.chip-icon { // Best option since we don't want to duplicate this code.
+  --#{$prefix}chip-padding-block: #{$ouds-chip-space-padding-block-icon-only};
+  --#{$prefix}chip-padding-end: #{$ouds-chip-space-padding-inline-icon};
+  --#{$prefix}chip-padding-start: #{$ouds-chip-space-padding-inline-icon};
 }

--- a/scss/ouds-web.scss
+++ b/scss/ouds-web.scss
@@ -29,6 +29,7 @@
 @import "links"; // OUDS mod
 @import "bullet-list"; // OUDS mod
 @import "buttons";
+@import "chip"; // OUDS mod
 @import "transitions";
 @import "dropdown";
 @import "button-group";

--- a/scss/tokens/_component.scss
+++ b/scss/tokens/_component.scss
@@ -183,8 +183,8 @@ $ouds-checkbox-size-min-width: $ouds-size-min-interactive-area !default;
 // Chip
 
 // scss-docs-start ouds-component-chip
-$ouds-chip-badge-color-bg: $ouds-color-surface-status-neutral-emphasized !default;
-$ouds-chip-badge-color-content: $ouds-color-content-on-status-neutral-emphasized !default;
+$ouds-chip-badge-color-bg: $ouds-color-surface-status-neutral-emphasized !default; // Not used for now
+$ouds-chip-badge-color-content: $ouds-color-content-on-status-neutral-emphasized !default; // Not used for now
 $ouds-chip-border-radius: $ouds-border-radius-pill !default;
 $ouds-chip-border-width-selected: $ouds-border-width-medium !default;
 $ouds-chip-border-width-unselected-interaction: $ouds-border-width-medium !default;
@@ -224,12 +224,12 @@ $ouds-chip-size-icon: $ouds-size-icon-with-label-medium-size-sm !default;
 $ouds-chip-size-min-height-interactive-area: $ouds-size-min-interactive-area !default;
 $ouds-chip-size-min-height: $ouds-dimension-xs !default;
 $ouds-chip-size-min-width: $ouds-dimension-2xl !default;
-$ouds-chip-space-column-gap-badge-arrow: $ouds-space-column-gap-2xs !default;
+$ouds-chip-space-column-gap-badge-arrow: $ouds-space-column-gap-2xs !default; // Not used for now
 $ouds-chip-space-column-gap-icon: $ouds-space-column-gap-xs !default;
 $ouds-chip-space-padding-block-icon-only: $ouds-space-padding-block-sm !default;
 $ouds-chip-space-padding-block: $ouds-space-padding-block-xs !default;
-$ouds-chip-space-padding-inline-arrow-end: $ouds-space-padding-inline-xs !default;
-$ouds-chip-space-padding-inline-badge-start: $ouds-space-padding-inline-4xs !default;
+$ouds-chip-space-padding-inline-arrow-end: $ouds-space-padding-inline-xs !default; // Not used for now
+$ouds-chip-space-padding-inline-badge-start: $ouds-space-padding-inline-4xs !default; // Not used for now
 $ouds-chip-space-padding-inline-icon-none: $ouds-space-padding-inline-lg !default;
 $ouds-chip-space-padding-inline-icon: $ouds-space-padding-inline-sm !default;
 // scss-docs-end ouds-component-chip

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -115,6 +115,7 @@
       draft: true
     - title: Carousel
       draft: true
+    - title: Chip
     - title: Close button
       draft: true
     - title: Collapse

--- a/site/src/content/docs/components/chip.mdx
+++ b/site/src/content/docs/components/chip.mdx
@@ -1,0 +1,89 @@
+---
+title: Chip
+description: OUDS Web’s chip provides a compact UI element used either to represent a filter or to recommend an option.
+aliases:
+  - "/docs/components/chip/"
+toc: true
+---
+
+## Standard variant(s)
+
+{/* <Example code={`<ul class="chip-container">
+    <li>
+      <button class="chip">Label</button>
+    </li>
+    <li>
+      <button class="chip">Label</button>
+    </li>
+  </ul>`} /> */}
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <button>Label</button>
+    </li>
+    <li class="chip">
+      <button class="chip-content">
+        Label
+        <span class="chip-util" aria-hidden="true"></span>
+      </button>
+    </li>
+  </ul>`} />
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <input type="checkbox" />
+      <label class="chip-content">
+        Label
+        <span class="chip-util" aria-hidden="true"></span>
+      </label>
+    </li>
+    <li class="chip-break"></li>
+    <li class="chip">
+      <input type="checkbox" checked />
+      <label class="chip-content">
+        Label
+        <span class="chip-util" aria-hidden="true"></span>
+      </label>
+    </li>
+  </ul>`} />
+{/* <Example code={`<ul class="chip-container">
+    <li class="chip">
+      <label>
+        <input type="checkbox" />
+      </label>
+    </li>
+    <li class="chip-break"></li>
+    <li class="chip">
+      <label>
+        <input type="checkbox" checked />
+      </label>
+    </li>
+  </ul>`} /> */}
+{/* <Example code={`<ul class="chip-container">
+    <li>
+      <label class="chip">
+        <input type="checkbox" />
+      </label>
+    </li>
+    <li class="chip-break"></li>
+    <li>
+      <label class="chip">
+        <input type="checkbox" checked />
+      </label>
+    </li>
+  </ul>`} /> */}
+<Example code={`<ul class="chip-container">
+    <li>
+      <input type="radio" />
+      <label></label>
+    </li>
+    <li>
+      <input type="radio" checked />
+      <label></label>
+    </li>
+  </ul>`} />
+
+chip = position relative
+chip container = overflow, wrap automatic or manual, 2.5 lines height,
+
+## Layout
+## Other variants : With icon, with chevron, etc
+## States : disabled, visited, loading, etc

--- a/site/src/content/docs/components/chip.mdx
+++ b/site/src/content/docs/components/chip.mdx
@@ -6,84 +6,295 @@ aliases:
 toc: true
 ---
 
-## Standard variant(s)
+import { getConfig } from '@libs/config'
 
-{/* <Example code={`<ul class="chip-container">
-    <li>
-      <button class="chip">Label</button>
-    </li>
-    <li>
-      <button class="chip">Label</button>
-    </li>
-  </ul>`} /> */}
+Chip is a component that is always grouped with some others. This is why we display all our examples using `<ul class="chip-container"><li></li></ul>` structure. Please adapt this structure to what's needed in your project and the context of use.
+
+`.chip-container` helps managing the Chip list.
+
+`.chip` helps managing the placement inside the container and the click area.
+
+<Callout type="warning">
+`.chip-container` is provided without any design specifications, please make sure to align it with your project requirements. More likely, the list should be horizontally scrollable when overflowing or be wrapped on 2 or 3 lines visible lines either manually or automatically vertically scrollable.
+</Callout>
+
+## Filter chip
+
+Filter chips allow users to filter content by selecting or deselecting specific categories or attributes while keeping the element on the page. It's mainly base on checkbox inputs, but we also have [button based](#using-buttons) or [radio button based](#using-radio-buttons) ones too.
+
+Add `.chip-filter` to the clickable part of the component.
+
 <Example code={`<ul class="chip-container">
     <li class="chip">
-      <button>Label</button>
+      <input type="checkbox" id="appleCheck" checked />
+      <label class="chip-filter" for="appleCheck">
+        Apple
+      </label>
     </li>
     <li class="chip">
-      <button class="chip-content">
+      <input type="checkbox" id="samsungCheck" />
+      <label class="chip-filter" for="samsungCheck">
+        Samsung
+      </label>
+    </li>
+    <li class="chip">
+      <input type="checkbox" id="xiaomiCheck" />
+      <label class="chip-filter" for="xiaomiCheck">
+        Xiaomi
+      </label>
+    </li>
+  </ul>`} />
+
+### Text and icon
+
+To display an icon, please set it up at the end of the component.
+
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <input type="checkbox" id="filterWithIcon" />
+      <label class="chip-filter" for="filterWithIcon">
+        Label with icon
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
+      </label>
+    </li>
+    <li class="chip">
+      <input type="checkbox" id="filterWithIcon2" checked />
+      <label class="chip-filter" for="filterWithIcon2">
+        Antoher label with icon
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
+      </label>
+    </li>
+  </ul>`} />
+
+### Icon only
+
+To display a Chip with only an icon, add `.chip-icon` to the clickable part of the component.
+
+Prefer using an [embedded SVG], but you can also use font icon. Please avoid using `<img />` because the color system won't work on this.
+
+Make sure to provide an accessible text for each Chip.
+
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <input type="checkbox" id="filterIconOnly" />
+      <label class="chip-filter chip-icon" for="filterIconOnly">
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
+        <span class="visually-hidden">Favorites</span>
+      </label>
+    </li>
+    <li class="chip">
+      <input type="checkbox" id="filterIconOnly2" checked />
+      <label class="chip-filter chip-icon" for="filterIconOnly2">
+        <span class="icon si si-settings" aria-hidden="true"></span>
+        <span class="visually-hidden">Technical</span>
+      </label>
+    </li>
+  </ul>`} />
+
+### Using radio buttons
+
+If you want to have only one filter active at a time, you can use the radio button based one. All the rules explained in this page about filter Chips apply on this variant as well.
+
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <input type="radio" id="radioCheck" name="radio" />
+      <label class="chip-filter" for="radioCheck">
+        Filter 1
+      </label>
+    </li>
+    <li class="chip">
+      <input type="radio" id="radioCheck2" name="radio" />
+      <label class="chip-filter" for="radioCheck2">
+        Filter 2
+      </label>
+    </li>
+    <li class="chip">
+      <input type="radio" id="radioCheck3" name="radio" checked />
+      <label class="chip-filter" for="radioCheck3">
+        Filter 3
+      </label>
+    </li>
+  </ul>`} />
+
+### With `<input />` inside label
+
+Inputs can also be held inside labels to allow a different HTML structure but should avoided since it's not the maintained one.
+
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <label class="chip-filter">
+        <input type="checkbox" id="inputInside" checked />
+        Filter 1
+      </label>
+    </li>
+    <li class="chip">
+      <label class="chip-filter">
+        Filter 2
+        <input type="checkbox" id="inputInside2" />
+      </label>
+    </li>
+  </ul>`} />
+
+### Using buttons
+
+To have dynamic updates, please prefer using buttons. All the rules explained in this page about filter Chips apply on this variant as well.
+
+The style is applied on `[aria-pressed="true"]` to make sure that accessibility is good.
+
+Make use of our [Button JS plugin]([[docsref:/components/buttons#plugin]]) or make a custom one on your side, but at least provide the `aria-pressed`.
+
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
         Label
-        <span class="chip-util" aria-hidden="true"></span>
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Label
+      </button>
+    </li>
+  </ul>`} />
+
+### Disabled state
+
+Here are the different rendering under disabled state. Add `disabled` attribute either on the input or on the button element.
+
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <input type="checkbox" id="disabledFilter" checked disabled />
+      <label class="chip-filter" for="disabledFilter">
+        Disabled checked filter
+      </label>
+    </li>
+    <li class="chip">
+      <label class="chip-filter">
+        <input type="checkbox" id="disabledFilter2" disabled />
+        Disabled filter with icon
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
+      </label>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button" disabled>
+        Disabled button filter
+      </button>
+    </li>
+  </ul>`} />
+
+## Suggestion chip
+
+No Selected state
+
+### Text and icon
+
+### Icon only
+
+### Disabled state
+
+{/* TODO: Probably a Layout section explaining How it behaves with long labels, maybe examples with utilities on wrapping li[aria-hidden].w-100 */}
+
+## Standard variant(s)
+
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <button class="chip-suggestion">
+        Label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-suggestion">
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
+        Label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-suggestion chip-icon">
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
       </button>
     </li>
   </ul>`} />
 <Example code={`<ul class="chip-container">
     <li class="chip">
-      <input type="checkbox" />
-      <label class="chip-content">
+      <input type="checkbox" id="check1" />
+      <label class="chip-filter" for="check1">
         Label
-        <span class="chip-util" aria-hidden="true"></span>
       </label>
     </li>
-    <li class="chip-break"></li>
     <li class="chip">
-      <input type="checkbox" checked />
-      <label class="chip-content">
+      <input type="checkbox" id="check3" checked />
+      <label class="chip-filter" for="check3">
         Label
-        <span class="chip-util" aria-hidden="true"></span>
       </label>
+    </li>
+    <li class="chip">
+      <input type="checkbox" id="check4" checked />
+      <label class="chip-filter" for="check4">
+        Label
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
+      </label>
+    </li>
+    <li class="chip">
+      <input type="checkbox" id="check5" checked />
+      <label class="chip-filter chip-icon" for="check5">
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
+      </label>
+    </li>
+    <li class="chip">
+      <button class="chip-filter">
+        Label
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true">
+        Label
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
+      </button>
     </li>
   </ul>`} />
-{/* <Example code={`<ul class="chip-container">
-    <li class="chip">
-      <label>
-        <input type="checkbox" />
-      </label>
-    </li>
-    <li class="chip-break"></li>
-    <li class="chip">
-      <label>
-        <input type="checkbox" checked />
-      </label>
-    </li>
-  </ul>`} /> */}
-{/* <Example code={`<ul class="chip-container">
-    <li>
-      <label class="chip">
-        <input type="checkbox" />
-      </label>
-    </li>
-    <li class="chip-break"></li>
-    <li>
-      <label class="chip">
-        <input type="checkbox" checked />
-      </label>
-    </li>
-  </ul>`} /> */}
 <Example code={`<ul class="chip-container">
-    <li>
-      <input type="radio" />
-      <label></label>
+    <li class="chip">
+      <label class="chip-filter">
+        <input type="checkbox" />
+        Label
+      </label>
     </li>
-    <li>
-      <input type="radio" checked />
-      <label></label>
+    <li class="chip">
+      <label class="chip-filter">
+        <input type="checkbox" checked />
+        Label
+      </label>
     </li>
   </ul>`} />
-
-chip = position relative
-chip container = overflow, wrap automatic or manual, 2.5 lines height,
-
-## Layout
-## Other variants : With icon, with chevron, etc
-## States : disabled, visited, loading, etc
+{/* <Example code={`<ul class="chip-container">
+    <li>
+      <label class="chip">
+        <input type="checkbox" />
+      </label>
+    </li>
+    <li>
+      <label class="chip">
+        <input type="checkbox" checked />
+      </label>
+    </li>
+  </ul>`} /> */}

--- a/site/src/content/docs/components/chip.mdx
+++ b/site/src/content/docs/components/chip.mdx
@@ -8,7 +8,7 @@ toc: true
 
 import { getConfig } from '@libs/config'
 
-Chip is a component that is always grouped with some others. This is why we display all our examples using `<ul class="chip-container"><li></li></ul>` structure. Please adapt this structure to what's needed in your project and the context of use.
+Chip is a component that is always grouped with some others. This is why we display all our examples using `<ul class="chip-container"><li></li></ul>` structure. Please adapt this structure to what’s needed in your project and the context of use.
 
 `.chip-container` helps managing the Chip list.
 
@@ -20,7 +20,7 @@ Chip is a component that is always grouped with some others. This is why we disp
 
 ## Filter chip
 
-Filter chips allow users to filter content by selecting or deselecting specific categories or attributes while keeping the element on the page. It's mainly base on checkbox inputs, but we also have [button based](#using-buttons) or [radio button based](#using-radio-buttons) ones too.
+Filter chips allow users to filter content by selecting or deselecting specific categories or attributes while keeping the element on the page. It’s mainly base on checkbox inputs, but we also have [button based](#using-buttons) or [radio button based](#using-radio-buttons) ones too. Thus, there is a selected state on this variant of the component.
 
 Add `.chip-filter` to the clickable part of the component.
 
@@ -53,7 +53,7 @@ To display an icon, please set it up at the end of the component.
     <li class="chip">
       <input type="checkbox" id="filterWithIcon" />
       <label class="chip-filter" for="filterWithIcon">
-        Label with icon
+        Filter with icon
         <svg aria-hidden="true">
           <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
         </svg>
@@ -62,7 +62,7 @@ To display an icon, please set it up at the end of the component.
     <li class="chip">
       <input type="checkbox" id="filterWithIcon2" checked />
       <label class="chip-filter" for="filterWithIcon2">
-        Antoher label with icon
+        Antoher filter with icon
         <svg aria-hidden="true">
           <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
         </svg>
@@ -74,7 +74,7 @@ To display an icon, please set it up at the end of the component.
 
 To display a Chip with only an icon, add `.chip-icon` to the clickable part of the component.
 
-Prefer using an [embedded SVG], but you can also use font icon. Please avoid using `<img />` because the color system won't work on this.
+Prefer using an [embedded SVG]([[docsref:/extend/icons]]), but you can also use font icon. Please avoid using `<img />` since the color system won’t work on it.
 
 Make sure to provide an accessible text for each Chip.
 
@@ -85,14 +85,14 @@ Make sure to provide an accessible text for each Chip.
         <svg aria-hidden="true">
           <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
         </svg>
-        <span class="visually-hidden">Favorites</span>
+        <span class="visually-hidden">Favorites filter</span>
       </label>
     </li>
     <li class="chip">
       <input type="checkbox" id="filterIconOnly2" checked />
       <label class="chip-filter chip-icon" for="filterIconOnly2">
         <span class="icon si si-settings" aria-hidden="true"></span>
-        <span class="visually-hidden">Technical</span>
+        <span class="visually-hidden">Technical filter</span>
       </label>
     </li>
   </ul>`} />
@@ -105,37 +105,37 @@ If you want to have only one filter active at a time, you can use the radio butt
     <li class="chip">
       <input type="radio" id="radioCheck" name="radio" />
       <label class="chip-filter" for="radioCheck">
-        Filter 1
+        Filter with radio 1
       </label>
     </li>
     <li class="chip">
       <input type="radio" id="radioCheck2" name="radio" />
       <label class="chip-filter" for="radioCheck2">
-        Filter 2
+        Filter with radio 2
       </label>
     </li>
     <li class="chip">
       <input type="radio" id="radioCheck3" name="radio" checked />
       <label class="chip-filter" for="radioCheck3">
-        Filter 3
+        Filter with radio 3
       </label>
     </li>
   </ul>`} />
 
 ### With `<input />` inside label
 
-Inputs can also be held inside labels to allow a different HTML structure but should avoided since it's not the maintained one.
+Inputs can also be held inside labels to allow a different HTML structure but should avoided since it’s not the maintained one.
 
 <Example code={`<ul class="chip-container">
     <li class="chip">
       <label class="chip-filter">
         <input type="checkbox" id="inputInside" checked />
-        Filter 1
+        Filter with input inside 1
       </label>
     </li>
     <li class="chip">
       <label class="chip-filter">
-        Filter 2
+        Filter with input inside 2
         <input type="checkbox" id="inputInside2" />
       </label>
     </li>
@@ -152,12 +152,12 @@ Make use of our [Button JS plugin]([[docsref:/components/buttons#plugin]]) or ma
 <Example code={`<ul class="chip-container">
     <li class="chip">
       <button class="chip-filter" data-bs-toggle="button">
-        Label
+        Filter label using button 1
       </button>
     </li>
     <li class="chip">
       <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
-        Label
+        Filter label using button 2
       </button>
     </li>
   </ul>`} />
@@ -187,26 +187,50 @@ Here are the different rendering under disabled state. Add `disabled` attribute 
         Disabled button filter
       </button>
     </li>
+    <li class="chip">
+      <input type="checkbox" id="filterIconOnly2" checked disabled />
+      <label class="chip-filter chip-icon" for="filterIconOnly2">
+        <span class="icon si si-settings" aria-hidden="true"></span>
+        <span class="visually-hidden">Technical filter</span>
+      </label>
+    </li>
   </ul>`} />
 
 ## Suggestion chip
 
-No Selected state
+Suggestion chips show relevant options based on user input or context. They help users quickly choose from dynamic or recommended items. Since this implies a dynamic behavior, these should be implemented using buttons.
 
-### Text and icon
-
-### Icon only
-
-### Disabled state
-
-{/* TODO: Probably a Layout section explaining How it behaves with long labels, maybe examples with utilities on wrapping li[aria-hidden].w-100 */}
-
-## Standard variant(s)
+Add `.chip-suggestion` to the clickable part of the component.
 
 <Example code={`<ul class="chip-container">
     <li class="chip">
       <button class="chip-suggestion">
-        Label
+        Thanks.
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-suggestion">
+        Looks good to me.
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-suggestion">
+        Can we talk about it later ?
+      </button>
+    </li>
+  </ul>`} />
+
+### Text and icon
+
+To display an icon, please set it up at the start of the component.
+
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <button class="chip-suggestion">
+        <svg aria-hidden="true">
+          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
+        </svg>
+        Suggestion with icon 1
       </button>
     </li>
     <li class="chip">
@@ -214,87 +238,381 @@ No Selected state
         <svg aria-hidden="true">
           <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
         </svg>
-        Label
+        Suggestion with icon 2
       </button>
     </li>
+  </ul>`} />
+
+### Icon only
+
+To display a Chip with only an icon, add `.chip-icon` to the clickable part of the component.
+
+Prefer using an [embedded SVG]([[docsref:/extend/icons]]), but you can also use font icon. Please avoid using `<img />` since the color system won’t work on it.
+
+Make sure to provide an accessible text for each Chip.
+
+<Example code={`<ul class="chip-container">
     <li class="chip">
       <button class="chip-suggestion chip-icon">
         <svg aria-hidden="true">
           <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
         </svg>
+        <span class="visually-hidden">Send: "I love it."</span>
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-suggestion chip-icon">
+        <span class="icon si si-settings" aria-hidden="true"></span>
+        <span class="visually-hidden">Send: "Go to parameters."</span>
       </button>
     </li>
   </ul>`} />
+
+### Disabled state
+
+Here are the different rendering under disabled state. Add `disabled` attribute either on the input or on the button element.
+
 <Example code={`<ul class="chip-container">
     <li class="chip">
-      <input type="checkbox" id="check1" />
-      <label class="chip-filter" for="check1">
-        Label
-      </label>
-    </li>
-    <li class="chip">
-      <input type="checkbox" id="check3" checked />
-      <label class="chip-filter" for="check3">
-        Label
-      </label>
-    </li>
-    <li class="chip">
-      <input type="checkbox" id="check4" checked />
-      <label class="chip-filter" for="check4">
-        Label
-        <svg aria-hidden="true">
-          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
-        </svg>
-      </label>
-    </li>
-    <li class="chip">
-      <input type="checkbox" id="check5" checked />
-      <label class="chip-filter chip-icon" for="check5">
-        <svg aria-hidden="true">
-          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
-        </svg>
-      </label>
-    </li>
-    <li class="chip">
-      <button class="chip-filter">
-        Label
-        <svg aria-hidden="true">
-          <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
-        </svg>
+      <button class="chip-suggestion" disabled>
+        Thanks.
       </button>
     </li>
     <li class="chip">
-      <button class="chip-filter active" aria-pressed="true">
-        Label
+      <button class="chip-suggestion" disabled>
         <svg aria-hidden="true">
           <use xlink:href="/docs/${getConfig().docs_version}/assets/img/ouds-web-sprite.svg#heart-recommend"/>
         </svg>
+        Suggestion with icon 1
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-suggestion chip-icon" disabled>
+        <span class="icon si si-settings" aria-hidden="true"></span>
+        <span class="visually-hidden">Send: "Go to parameters."</span>
       </button>
     </li>
   </ul>`} />
+
+## Layout
+
+This part explains global truth among all the Chip variants.
+
+### With long label
+
+Prefer short labels over long ones, but here is the expected rendering when the labels are too long. Long labels shouldn’t wrap and stay on one line.
+
 <Example code={`<ul class="chip-container">
     <li class="chip">
-      <label class="chip-filter">
-        <input type="checkbox" />
-        Label
-      </label>
+      <button class="chip-suggestion">
+        Thanks for this message, I’ll answer it later.
+      </button>
     </li>
     <li class="chip">
-      <label class="chip-filter">
-        <input type="checkbox" checked />
-        Label
-      </label>
+      <button class="chip-suggestion">
+        Maybe we can we talk about it later ? I have a meeting right now.
+      </button>
     </li>
   </ul>`} />
-{/* <Example code={`<ul class="chip-container">
-    <li>
-      <label class="chip">
-        <input type="checkbox" />
-      </label>
+
+### Overflowing
+
+Easily handle many chips since it is the default behavior implemented in our Chip component.
+
+<Example code={`<ul class="chip-container">
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
     </li>
-    <li>
-      <label class="chip">
-        <input type="checkbox" checked />
-      </label>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
     </li>
-  </ul>`} /> */}
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+  </ul>`} />
+
+### Wrapping
+
+Easily handle many chips by adding `.flex-wrap` on the `.chip-container` element. Be careful using this technique because on mobile wiewports, it can take many space. It shouldn’t take more than 2 or 3 lines.
+
+<Example code={`<ul class="chip-container flex-wrap">
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+  </ul>`} />
+
+### Mix of two worlds
+
+Here is a rendering mixing wrapping and overflowing to a better UX.
+
+#### Vertical overflow
+
+Please note that a `style="max-height: 115px;"` is added since we don’t want to display more than 2 or 3 lines at the same time, and in the same time the scrollbar isn’t displayed on all device and people still want to know that there is some more Chips below.
+
+<Callout type="warning">
+This part is experimental and should be changed at some point.
+</Callout>
+
+<Example code={`<ul class="chip-container flex-wrap" style="max-height: 115px;">
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+    <li class="chip">
+      <button class="chip-filter" data-bs-toggle="button">
+        Quite long label
+      </button>
+    </li>
+  </ul>`} />
+
+#### Horizontal overflow
+
+Add a parent element to multiple `.chip-container`s with `.d-flex.flex-column.overflow-auto` and add `.overflow-visible` to each `.chip-container` in order to have a good overflow.
+
+<Callout type="warning">
+This part is experimental and should be changed at some point.
+</Callout>
+
+<Example code={`<div class="d-flex flex-column overflow-auto">
+    <ul class="chip-container overflow-visible">
+      <li class="chip">
+        <button class="chip-filter" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+    </ul>
+    <ul class="chip-container overflow-visible">
+      <li class="chip">
+        <button class="chip-filter" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+      <li class="chip">
+        <button class="chip-filter active" aria-pressed="true" data-bs-toggle="button">
+          Quite long label
+        </button>
+      </li>
+    </ul>
+  </div>`} />
+
+### Pseudo elements
+
+Here is a table resuming the pseudo elements that are used by the different variants of the Chip.
+
+<BsTable>
+| Chip variant    | `::before` | `::after` |
+| ---| --- | --- |
+| Filter chip     | Used       | Used      |
+| Suggestion chip | –          | Used      |
+</BsTable>
+
+{/* | Filter expand chip | Used       | Used      | */}

--- a/site/src/content/docs/migrations/migration-from-boosted.mdx
+++ b/site/src/content/docs/migrations/migration-from-boosted.mdx
@@ -142,6 +142,10 @@ You will have to make some extra Javascript to change the styles and update the 
 
 - <span class="badge text-bg-status-negative-emphasized">Breaking</span> Button plugin (button with a toggle behavior) has been removed.
 
+### Chip
+
+- <span class="badge text-bg-status-positive-emphasized">New</span> Chip component has been implemented. See more in our [Chip page]([[docsref:/components/chip]]).
+
 ### Links
 
 - <span class="badge text-bg-status-positive-emphasized">New</span> New standalone link component has been added. Use `.link` class to get it.

--- a/site/src/content/docs/migrations/migration.mdx
+++ b/site/src/content/docs/migrations/migration.mdx
@@ -8,6 +8,14 @@ aliases:
 toc: true
 ---
 
+## v0.6.0
+
+### Components
+
+#### Chip
+
+- <span class="badge text-bg-status-positive-emphasized">New</span> Chip component has been implemented. See more in our [Chip page]([[docsref:/components/chip]]).
+
 ## v0.5.0
 
 <hr />


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Closes #2844 

### Description

Add the chip component.

### Motivation & Context

NA

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/docs/components/chip>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices; I have at least run axe

#### Design

- [x] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [x] My change is compatible with a responsive display

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] I have added JavaScript unit tests to cover my changes
- [x] I have added SCSS unit tests to cover my changes

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] My change introduces changes to the migration guide
- [x] My new component is well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook)
- [x] My new component is compatible with RTL
- [x] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [x] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)

<!------------------------>
<!-- /!\ Core Team Only -->
<!------------------------>

<!-- Uncomment the following for a release DoD -->

<!--
- [ ] Run linters;
- [ ] Run compilers;
- [ ] Run tests;
- [ ] Check documentation site: examples and contents;
- [ ] Test cross-browser compatibility locally and with [BrowserStack](https://www.browserstack.com/):
  - Firefox ESR
  - IE11 (v4 only)
  - Latest Edge, Chrome, Firefox, Safari
  - iOS Safari
  - Chrome & Firefox on Android
- [ ] Including RTL mode;
- [ ] Ask for reviews and accessibility testing;
- [ ] [sync with Bootstrap](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Syncing-with-Bootstrap)'s release and probably wait for it;
- [ ] `npm run release-version $current_version $next_version` to bump version number
  - then, if bumping a minor or major version:
    - [ ] Manually change `version_short` in `package.json`
    - [ ] Add docs version to `site/data/docs-versions.yml`
    - [ ] Manually change `docs_version` in `hugo.yml` and other references to the previous version
    - [ ] Update redirects in docs frontmatter (`site/src/content/docs/_index.html`?)
    - [ ] Move `site/src/content/docs/5.x` to `site/src/content/docs/5.x+1`
    - [ ] Increment `site/static/docs/{version}` version
    - [ ] Increment version in `nuget/boosted.nuspec`
    - [ ] (Major version) Manually update the version in `nuget/boosted.nuspec` and `nuget/boosted.sass.nuspec`
  - check wrong matches in `CHANGELOG.md`, and maybe `site/src/content/docs/<version>/migration.md`
  - :warning: check the `package-lock.json` and `package.json` content, only "boosted" should have its version changed!
  - :warning: `site/src/content/docs/5.1/**/*.md` should not always be modified
- [ ] if the year changed recently, happy new year :tada: but please change © year in `.scss` main files (reboot, grid, utilities, and main file) as well as in `NOTICE.txt`.
- [ ] `npm run release` to compile dist, build Storybook, update SRI hashes in doc, and package the release
- [ ] Prepare changelog:
  - install [Conventionnal Changelog](https://github.com/conventional-changelog/conventional-changelog) and `conventional-changelog-cli` globally
  - run `conventional-changelog -p angular -i CHANGELOG.md -s`
  - and probably maintain [a ship list (e.g. for v4.4.0)](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/226)
- [ ] Commit and push `dist` with a `chore(release)` commit message
- [ ] Manually run BrowserStack test
- [ ] Manually run Percy test
- [ ] Merge (on `v4-dev` or `main`)
- [ ] Tag your version, and push your tag
- [ ] Pack and publish
  - `npm pack`
  - if you are already logged in to NPM (with a personal account, for example), [you’d better use a repository scoped `.npmrc` file](https://stackoverflow.com/questions/30114166/how-to-have-multiple-npm-users-set-up-locally)
  - Publish:
    - if you’re releasing a pre-release, use `--tag`, e.g. for v5-alpha1 `npm publish boosted-5.0.0-alpha1.tgz --tag next`
    - (v4 only) `npm publish --tag v4.x.y` (if you forgot and v4 becomes the latest version on NPM, you can run `npm dist-tag add boosted@5.x.y latest to fix it)
    - (v5 only) `npm publish`
- [ ] check release on [NPM](https://www.npmjs.com/package/boosted), [Nuget](https://www.nuget.org/packages/boosted/), [Packagist](https://packagist.org/packages/orange-opensource/orange-boosted-bootstrap)…
- [ ] publish documentation on `gh-pages`:
  - [ ] copy `../_site` to the `gh-pages` branch (don’t forget to update Storybook as well)
  - [ ] check every `index.html` used as redirections to redirect to the new release
  - [ ] when bumping minor version: ensure `dist` URLs in examples’ HTML has changed
  - [ ] double-check everything before pushing, starting by searching for forgotten old version number occurrences
- [ ] make an announcement in [GitHub Discussions](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/discussions/categories/announcements) (+ pin the new GH Discussion)
- [ ] [create a GitHub release](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/new):
  - attach the zip file
  - paste the CHANGELOG / Ship list in the release’s description
- [ ] make an announcement on internal communication channels :tada:
- [ ] [publish on Nuget](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Generate-NuGet-packages)
-->
