### PR TITLE
feat(component): Add Text-input component

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -960,12 +960,12 @@ $btn-icon-padding-x:          subtract($ouds-button-space-padding-inline-icon-st
 // Forms
 
 // scss-docs-start form-text-variables
-$form-text-margin-top:                  .4375rem !default; // OUDS mod
-$form-text-font-size:                   null !default; // OUDS mod: instead of `$small-font-size`
-$form-text-font-style:                  null !default;
-$form-text-font-weight:                 $font-weight-bold !default; // OUDS mod: instead of `null`
-$form-text-line-height:                 $line-height-sm !default; // OUDS mod
-$form-text-color:                       var(--#{$prefix}secondary-color) !default;
+$form-text-margin-top:                  $ouds-text-input-space-padding-block-top-helper-text !default; // OUDS mod
+// OUDS mod: no $form-text-font-size
+// OUDS mod: no $form-text-font-style
+// OUDS mod: no $form-text-font-weight
+// OUDS mod: no $form-text-line-height
+$form-text-color:                       var(--#{$prefix}color-content-muted) !default; // OUDS mod
 // scss-docs-end form-text-variables
 
 // scss-docs-start form-label-variables
@@ -988,8 +988,8 @@ $form-helper-label-margin-bottom:       $form-label-margin-bottom - divide(($for
 // scss-docs-end form-helper-variables
 
 // scss-docs-start form-input-variables
-$input-padding-y:                       .5rem !default; // OUDS mod: instead of $input-btn-padding-y (temporary value waiting for input component)
-$input-padding-x:                       $spacer * .5 !default;
+$input-padding-y:                       $ouds-text-input-space-padding-block-default !default; // OUDS mod
+$input-padding-x:                       $ouds-text-input-space-padding-inline-default !default; // OUDS mod
 $input-font-family:                     $input-btn-font-family !default;
 $input-font-size:                       $input-btn-font-size !default;
 $input-font-weight:                     $font-weight-bold !default;
@@ -1003,27 +1003,27 @@ $input-padding-y-lg:                    $input-btn-padding-y-lg !default;
 $input-padding-x-lg:                    $input-btn-padding-x-lg !default;
 $input-font-size-lg:                    $input-btn-font-size-lg !default;
 
-$input-bg:                              var(--#{$prefix}body-bg) !default;
-$input-disabled-color:                  var(--#{$prefix}secondary-color) !default; // OUDS mod
-$input-disabled-bg:                     var(--#{$prefix}secondary-bg) !default;
-$input-disabled-border-color:           null !default;
+$input-bg:                              var(--#{$prefix}color-action-support-enabled) !default; // OUDS mod
+$input-disabled-color:                  var(--#{$prefix}color-action-disabled) !default; // OUDS mod
+$input-disabled-bg:                     var(--#{$prefix}color-action-support-disabled) !default; // OUDS mod
+$input-disabled-border-color:           var(--#{$prefix}color-action-disabled) !default; // OUDS mod
 
-$input-color:                           var(--#{$prefix}body-color) !default;
-$input-border-color:                    var(--#{$prefix}color-border-default) !default; // OUDS mod: instead of var(--#{$prefix}border-color)
-$input-border-width:                    0 !default; // OUDS mod TODO to be modified for inputs
+$input-color:                           var(--#{$prefix}color-content-default) !default; // OUDS mod
+$input-border-color:                    $ouds-text-input-color-border-enabled !default; // OUDS mod
+$input-border-width:                    $ouds-text-input-border-width-default !default; // OUDS mod
 $input-box-shadow:                      none !default; // OUDS mod
 
-$input-border-radius:                   var(--#{$prefix}border-radius) !default;
+$input-border-radius:                   $ouds-text-input-border-radius-default !default; // OUDS mod
 $input-border-radius-sm:                var(--#{$prefix}border-radius-sm) !default;
 $input-border-radius-lg:                var(--#{$prefix}border-radius-lg) !default;
 
-$input-focus-bg:                        $input-bg !default;
-$input-focus-border-color:              currentcolor !default;
-$input-focus-color:                     $input-color !default;
+// OUDS mod: no $input-focus-bg
+// OUDS mod: no $input-focus-border-color
+// OUDS mod: no $input-focus-color
 $input-focus-width:                     $input-btn-focus-width !default;
 $input-focus-box-shadow:                none !default; // OUDS mod
 
-$input-placeholder-color:               var(--#{$prefix}secondary-color) !default;
+// OUDS mod: no $input-placeholder-color
 $input-plaintext-color:                 null !default; // OUDS mod: instead of `var(--#{$prefix}body-color)`
 
 // OUDS mod: no $input-height-border
@@ -1037,7 +1037,7 @@ $input-height-sm:                       1.875rem !default;
 $input-height-lg:                       3.125rem !default;
 $input-line-height-lg:                  var(--#{$prefix}font-line-height-body-large) !default; // OUDS mod
 
-$input-transition:                      border-color $transition-duration $transition-timing, $transition-focus !default;
+$input-transition:                      none !default; // OUDS mod
 
 $form-color-width:                      2.5rem !default; // OUDS mod: instead of `3rem`
 $form-color-border-color:               var(--#{$prefix}emphasis-color) !default; // OUDS mod

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -2,25 +2,142 @@
 // General form controls (plus a few specific high-level interventions)
 //
 
+%form-item {
+  // scss-docs-start form-control-css-vars
+  --#{$prefix}form-control-color: var(--#{$prefix}color-content-default);
+  --#{$prefix}form-control-background-color: var(--#{$prefix}color-action-support-enabled);
+  --#{$prefix}form-control-border-color: #{$ouds-text-input-color-border-enabled};
+  --#{$prefix}form-control-border-width-top: 0px;
+  --#{$prefix}form-control-border-width-right: 0px;
+  --#{$prefix}form-control-border-width-bottom: #{$ouds-text-input-border-width-default};
+  --#{$prefix}form-control-border-width-left: 0px;
+  --#{$prefix}form-control-border-width-focus: 0px;
+  --#{$prefix}form-control-border-radius: #{$ouds-text-input-border-radius-default};
+  --#{$prefix}form-control-padding-x: #{$ouds-text-input-space-padding-inline-default};
+  --#{$prefix}form-control-padding-y: #{$ouds-text-input-space-padding-block-default};
+  --#{$prefix}form-control-max-width: #{$ouds-text-input-size-max-width};
+  --#{$prefix}form-control-min-height: #{$ouds-text-input-size-min-height};
+  --#{$prefix}form-control-min-width: #{$ouds-text-input-size-min-width};
+  // scss-docs-end form-control-css-vars
+
+  // scss-docs-start form-label-css-vars
+  --#{$prefix}form-label-color: var(--#{$prefix}color-content-muted);
+  // scss-docs-end form-label-css-vars
+}
+
+.form-control-item {
+  @extend %form-item;
+  position: relative;
+
+
+  > .form-control {
+    min-width: var(--#{$prefix}form-control-min-width);
+    max-width: var(--#{$prefix}form-control-max-width);
+    min-height: var(--#{$prefix}form-control-min-height);
+
+
+    /* stylelint-disable-next-line declaration-no-important */
+    padding-top: calc(var(--#{$prefix}form-control-padding-y) * 4) !important; // stylelint-disable-line function-disallowed-list
+
+
+    &::placeholder {
+      color: transparent;
+    }
+  }
+
+  > label {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    max-width: var(--#{$prefix}form-control-max-width);
+    height: 100%;
+    padding-top: subtract(var(--#{$prefix}form-control-padding-y), var(--#{$prefix}form-control-border-width-top));
+    padding-right: subtract(var(--#{$prefix}form-control-padding-x), var(--#{$prefix}form-control-border-width-right));
+    padding-bottom: subtract(var(--#{$prefix}form-control-padding-y), var(--#{$prefix}form-control-border-width-bottom));
+    padding-left: subtract(var(--#{$prefix}form-control-padding-x), var(--#{$prefix}form-control-border-width-left));
+    overflow: hidden;
+    color: var(--#{$prefix}form-label-color);
+    text-align: start;
+
+    pointer-events: none;
+    transform-origin: 0 0;
+    @include get-font-size("label-large");
+    @include transition(all .1s ease-out);
+  }
+
+  > .form-control:focus,
+  > .form-control:not(:placeholder-shown) {
+    padding-top: 12px;
+    ~ label {
+      top: calc(var(--#{$prefix}form-control-padding-y) / 2); // stylelint-disable-line function-disallowed-list
+      display: block;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      @include get-font-size("label-small");
+    }
+  }
+
+  // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
+  > .form-control:-webkit-autofill {
+    padding-top: 12px;
+    ~ label {
+      top: calc(var(--#{$prefix}form-control-padding-y) / 2); // stylelint-disable-line function-disallowed-list
+      display: block;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      @include get-font-size("label-small");
+    }
+  }
+
+  > :disabled ~ label,
+  > .form-control:disabled ~ label {
+    --#{$prefix}form-label-color: var(--#{$prefix}color-action-disabled);
+  }
+}
+
 .form-control {
+  @extend %form-item;
+
   display: block;
   width: 100%;
-  padding: subtract($input-padding-y, 1px) $input-padding-x add($input-padding-y, 1px); // OUDS mod
-  font-family: $input-font-family;
-  @include font-size($input-font-size);
-  font-weight: $input-font-weight;
-  line-height: $input-line-height;
-  color: $input-color;
+  // padding-top: subtract(var(--#{$prefix}form-control-padding-y), var(--#{$prefix}form-control-border-width-top));
+  padding-right: subtract(var(--#{$prefix}form-control-padding-x), var(--#{$prefix}form-control-border-width-right));
+  padding-bottom: subtract(var(--#{$prefix}form-control-padding-y), var(--#{$prefix}form-control-border-width-bottom));
+  padding-left: subtract(var(--#{$prefix}form-control-padding-x), var(--#{$prefix}form-control-border-width-left));
+  // OUDS mod: no font-family
+  @include get-font-size("label-large"); // OUDS mod: instead of @include font-size($input-font-size);
+  // OUDS mod: no font-weight
+  // OUDS mod: no line-height
+  color: var(--#{$prefix}form-control-color); // OUDS mod
   appearance: none; // Fix appearance for date inputs in Safari
-  background-color: $input-bg;
+  background-color: var(--#{$prefix}form-control-background-color); // OUDS mod
   background-clip: padding-box;
-  border: $input-border-width solid $input-border-color;
+  border-color: var(--#{$prefix}form-control-border-color); // OUDS mod
+  border-style: solid; // OUDS mod
+  border-width: var(--#{$prefix}form-control-border-width-top) var(--#{$prefix}form-control-border-width-right) var(--#{$prefix}form-control-border-width-bottom) var(--#{$prefix}form-control-border-width-left); // OUDS mod
+  @include get-font-size("label-large"); // OUDS mod
 
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
-  @include border-radius($input-border-radius, 0);
+  @include border-radius(var(--#{$prefix}form-control-border-radius), 0); // OUDS mod
 
   @include box-shadow($input-box-shadow);
   @include transition($input-transition);
+
+  // OUDS mod
+  &.form-control-alternative {
+    --#{$prefix}form-control-background-color: transparent;
+    --#{$prefix}form-control-border-width-top: #{$ouds-text-input-border-width-default};
+    --#{$prefix}form-control-border-width-right: #{$ouds-text-input-border-width-default};
+    --#{$prefix}form-control-border-width-left: #{$ouds-text-input-border-width-default};
+  }
+
+  &.form-control-rounded {
+    --#{$prefix}form-control-border-radius: #{$ouds-text-input-border-radius-rounded};
+  }
+  // End mod
 
   &[type="file"] {
     overflow: hidden; // prevent pseudo element button overlap
@@ -30,11 +147,27 @@
     }
   }
 
+  // OUDS mod
+  &:not(.form-control-color):hover:not(:focus):not(:disabled):not(:read-only) {
+    --#{$prefix}form-control-border-color: #{$ouds-text-input-color-border-hover};
+    &:not(.form-control-alternative) {
+      --#{$prefix}form-control-background-color: #{$ouds-color-action-support-hover};
+    }
+  }
+  // End mod
+
   // Customize the `:focus` state to imitate native WebKit styles.
-  &:not(.form-control-color):focus { // OUDS mod: instead of `&:focus`
-    color: $input-focus-color;
-    background-color: $input-focus-bg;
-    border-color: $input-focus-border-color !important; // stylelint-disable-line declaration-no-important
+  &:not(.form-control-color):focus:not(:disabled):not(:read-only) { // OUDS mod: instead of `&:focus`
+    --#{$prefix}form-control-background-color: var(--#{$prefix}color-action-support-pressed);
+    --#{$prefix}form-control-border-color: #{$ouds-text-input-color-border-focus};
+    --#{$prefix}form-control-border-width-bottom: #{$ouds-text-input-border-width-focus};
+    &.form-control-alternative {
+      --#{$prefix}form-control-background-color: transparent;
+      --#{$prefix}form-control-border-width-top: #{$ouds-text-input-border-width-focus};
+      --#{$prefix}form-control-border-width-right: #{$ouds-text-input-border-width-focus};
+      --#{$prefix}form-control-border-width-left: #{$ouds-text-input-border-width-focus};
+    }
+
     outline: 0;
     @if $enable-shadows {
       @include box-shadow($input-box-shadow, $input-focus-box-shadow);
@@ -43,6 +176,28 @@
       box-shadow: $input-focus-box-shadow;
     }
   }
+
+  // Read only inputs
+  &:not(.form-control-color):not(.form-control-alternative):read-only:not(:disabled) {
+    --#{$prefix}form-control-background-color: transparent;
+    --#{$prefix}form-control-border-color: #{$ouds-color-border-muted};
+    --#{$prefix}form-control-border-width-top: #{$ouds-text-input-border-width-default};
+    --#{$prefix}form-control-border-width-right: #{$ouds-text-input-border-width-default};
+    --#{$prefix}form-control-border-width-left: #{$ouds-text-input-border-width-default};
+
+    outline: 0;
+  }
+
+  &.form-control-alternative:read-only:not(:disabled) {
+    --#{$prefix}form-control-background-color: var(--#{$prefix}color-action-support-disabled);
+    --#{$prefix}form-control-border-width-top: 0px;
+    --#{$prefix}form-control-border-width-right: 0px;
+    --#{$prefix}form-control-border-width-bottom: 0px;
+    --#{$prefix}form-control-border-width-left: 0px;
+
+    outline: 0;
+  }
+  // End mod
 
   &::-webkit-date-and-time-value {
     // On Android Chrome, form-control's "width: 100%" makes the input width too small
@@ -74,7 +229,7 @@
 
   // Placeholder
   &::placeholder {
-    color: $input-placeholder-color;
+    --#{$prefix}form-control-color: var(--#{$prefix}color-content-muted);
     // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
     opacity: 1;
   }
@@ -85,9 +240,12 @@
   // disabled if the fieldset is disabled. Due to implementation difficulty, we
   // don't honor that edge case; we style them as disabled anyway.
   &:disabled {
-    color: $input-disabled-color; // OUDS mod
-    background-color: $input-disabled-bg;
-    border-color: $input-disabled-border-color;
+    --#{$prefix}form-control-color: var(--#{$prefix}color-action-disabled);
+    --#{$prefix}form-control-border-color: var(--#{$prefix}color-action-disabled);
+    &:not(.form-control-alternative) { // OUDS mod
+      --#{$prefix}form-control-background-color: var(--#{$prefix}color-action-support-disabled);
+    }
+
     // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655.
     opacity: 1;
   }

--- a/scss/forms/_form-text.scss
+++ b/scss/forms/_form-text.scss
@@ -4,9 +4,9 @@
 
 .form-text {
   margin-top: $form-text-margin-top;
-  @include font-size($form-text-font-size);
-  font-style: $form-text-font-style;
-  font-weight: $form-text-font-weight;
-  line-height: $form-text-line-height; // OUDS mod
+  @include get-font-size("label-medium"); // OUDS mod: instead of @include font-size($form-text-font-size);
+  // OUDS mod: no font-style
+  // OUDS mod: no font-weight
+  // OUDS mod: no line-height
   color: $form-text-color;
 }

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -77,7 +77,7 @@
   pages:
     - title: Overview
     - title: Form control
-      draft: true
+    - title: Text input
     - title: Select
       draft: true
     - title: Checkbox

--- a/site/src/content/docs/forms/form-control.mdx
+++ b/site/src/content/docs/forms/form-control.mdx
@@ -1,9 +1,166 @@
 ---
 title: Form controls
-description: Give textual form controls like `<input />`s and `<textarea>`s an upgrade with custom styles, sizing, focus states, and more.
-aliases:
-  - "/docs/forms/form-control/"
+description: Give textual form controls like `<input>`s and `<textarea>`s an upgrade with custom styles, sizing, focus states, and more.
 toc: true
 ---
 
-<CalloutSoon type="component" />
+## Example
+
+Form controls are styled with a mix of Sass and CSS variables, allowing them to adapt to color modes and support any customization method.
+
+<Example code={`<div class="mb-3">
+    <label for="exampleFormControlInput1" class="form-label">Email address</label>
+    <input type="email" class="form-control" id="exampleFormControlInput1" placeholder="name@example.com">
+  </div>
+  <div class="mb-3">
+    <label for="exampleFormControlTextarea1" class="form-label">Example textarea</label>
+    <textarea class="form-control" id="exampleFormControlTextarea1" rows="3"></textarea>
+  </div>`} />
+
+## Sizing
+
+Set heights using classes like `.form-control-lg` and `.form-control-sm`.
+
+<Example code={`<input class="form-control form-control-lg" type="text" placeholder=".form-control-lg" aria-label=".form-control-lg example">
+<input class="form-control" type="text" placeholder="Default input" aria-label="default input example">
+<input class="form-control form-control-sm" type="text" placeholder=".form-control-sm" aria-label=".form-control-sm example">`} />
+
+## Form text
+
+Block-level or inline-level form text can be created using `.form-text`.
+
+<Callout type="warning">
+Form text should be explicitly associated with the form control it relates to using the `aria-describedby` attribute. This will ensure that assistive technologies—such as screen readers—will announce this form text when the user focuses or enters the control.
+</Callout>
+
+Form text below inputs can be styled with `.form-text`. If a block-level element will be used, a top margin is added for easy spacing from the inputs above.
+
+<Example code={`<label for="inputPassword5" class="form-label">Password</label>
+  <input type="password" id="inputPassword5" class="form-control" aria-describedby="passwordHelpBlock">
+  <div id="passwordHelpBlock" class="form-text">
+    Your password must be 8-20 characters long, contain letters and numbers, and must not contain spaces, special characters, or emoji.
+  </div>`} />
+
+Inline text can use any typical inline HTML element (be it a `<span>`, `<small>`, or something else) with nothing more than the `.form-text` class.
+
+<Example code={`<div class="row g-3 align-items-center">
+    <div class="col-auto">
+      <label for="inputPassword6" class="col-form-label">Password</label>
+    </div>
+    <div class="col-auto">
+      <input type="password" id="inputPassword6" class="form-control" aria-describedby="passwordHelpInline">
+    </div>
+    <div class="col-auto">
+      <span id="passwordHelpInline" class="form-text">
+        Must be 8-20 characters long.
+      </span>
+    </div>
+  </div>`} />
+
+## Disabled
+
+Add the `disabled` boolean attribute on an input to give it a grayed out appearance, remove pointer events, and prevent focusing.
+
+<Example code={`<input class="form-control" type="text" placeholder="Disabled input" aria-label="Disabled input example" disabled>
+<input class="form-control" type="text" value="Disabled readonly input" aria-label="Disabled input example" disabled readonly>`} />
+
+## Readonly
+
+Add the `readonly` boolean attribute on an input to prevent modification of the input’s value. `readonly` inputs can still be focused and selected, while `disabled` inputs cannot.
+
+<Example code={`<input class="form-control" type="text" value="Readonly input here..." aria-label="readonly input example" readonly>`} />
+
+## Readonly plain text
+
+If you want to have `<input readonly>` elements in your form styled as plain text, replace `.form-control` with `.form-control-plaintext` to remove the default form field styling and preserve the correct `margin` and `padding`.
+
+<Example code={`<div class="mb-3 row">
+    <label for="staticEmail" class="col-sm-2 col-form-label">Email</label>
+    <div class="col-sm-10">
+      <input type="text" readonly class="form-control-plaintext" id="staticEmail" value="email@example.com">
+    </div>
+  </div>
+  <div class="mb-3 row">
+    <label for="inputPassword" class="col-sm-2 col-form-label">Password</label>
+    <div class="col-sm-10">
+      <input type="password" class="form-control" id="inputPassword">
+    </div>
+  </div>`} />
+
+<Example code={`<form class="row g-3">
+    <div class="col-auto">
+      <label for="staticEmail2" class="visually-hidden">Email</label>
+      <input type="text" readonly class="form-control-plaintext" id="staticEmail2" value="email@example.com">
+    </div>
+    <div class="col-auto">
+      <label for="inputPassword2" class="visually-hidden">Password</label>
+      <input type="password" class="form-control" id="inputPassword2" placeholder="Password">
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-primary mb-3">Confirm identity</button>
+    </div>
+  </form>`} />
+
+## File input
+
+<Example code={`<div class="mb-3">
+    <label for="formFile" class="form-label">Default file input example</label>
+    <input class="form-control" type="file" id="formFile">
+  </div>
+  <div class="mb-3">
+    <label for="formFileMultiple" class="form-label">Multiple files input example</label>
+    <input class="form-control" type="file" id="formFileMultiple" multiple>
+  </div>
+  <div class="mb-3">
+    <label for="formFileDisabled" class="form-label">Disabled file input example</label>
+    <input class="form-control" type="file" id="formFileDisabled" disabled>
+  </div>
+  <div class="mb-3">
+    <label for="formFileSm" class="form-label">Small file input example</label>
+    <input class="form-control form-control-sm" id="formFileSm" type="file">
+  </div>
+  <div>
+    <label for="formFileLg" class="form-label">Large file input example</label>
+    <input class="form-control form-control-lg" id="formFileLg" type="file">
+  </div>`} />
+
+## Color
+
+Set the `type="color"` and add `.form-control-color` to the `<input>`. We use the modifier class to set fixed `height`s and override some inconsistencies between browsers.
+
+<Example code={`<label for="exampleColorInput" class="form-label">Color picker</label>
+<input type="color" class="form-control form-control-color" id="exampleColorInput" value="#563d7c" title="Choose your color">`} />
+
+## Datalists
+
+Datalists allow you to create a group of `<option>`s that can be accessed (and autocompleted) from within an `<input>`. These are similar to `<select>` elements, but come with more menu styling limitations and differences. While most browsers and operating systems include some support for `<datalist>` elements, their styling is inconsistent at best.
+
+Learn more about [support for datalist elements](https://caniuse.com/datalist).
+
+<Example code={`<label for="exampleDataList" class="form-label">Datalist example</label>
+  <input class="form-control" list="datalistOptions" id="exampleDataList" placeholder="Type to search...">
+  <datalist id="datalistOptions">
+    <option value="San Francisco">
+    <option value="New York">
+    <option value="Seattle">
+    <option value="Los Angeles">
+    <option value="Chicago">
+  </datalist>`} />
+
+## CSS
+
+### Sass variables
+
+`$input-*` are shared across most of our form controls (and not buttons).
+
+<ScssDocs name="form-input-variables" file="scss/_variables.scss" />
+
+`$form-label-*` and `$form-text-*` are for our `<label>`s and `.form-text` component.
+
+<ScssDocs name="form-label-variables" file="scss/_variables.scss" />
+
+<ScssDocs name="form-text-variables" file="scss/_variables.scss" />
+
+`$form-file-*` are for file input.
+
+<ScssDocs name="form-file-variables" file="scss/_variables.scss" />

--- a/site/src/content/docs/forms/text-input.mdx
+++ b/site/src/content/docs/forms/text-input.mdx
@@ -1,0 +1,141 @@
+---
+title: Text input
+description: A text input is a user interface component that allows users to enter, edit, or select single-line textual data. It provides a visual and interactive affordance for text entry while supporting labels, placeholders, icons, helper messages, and validation feedback.
+toc: true
+---
+
+<Callout type="info">
+{/* TODO: set the right url for design documentation */}
+You can find here the [OUDS Checkbox design guidelines](https://unified-design-system.orange.com/).
+</Callout>
+
+## Basic example
+
+<Example code={`<div class="form-control-item mb-3">
+    <input type="text" class="form-control" id="exampleFormControlInput1" placeholder="">
+    <label for="exampleFormControlInput1">Firstname</label>
+  </div>
+  <div class="form-control-item mb-3">
+    <input type="text" class="form-control" id="exampleFormControlInput0" placeholder="Firstname">
+    <label for="exampleFormControlInput0">Firstname</label>
+  </div>
+  <div class="form-control-item mb-3">
+    <input type="email" class="form-control" id="exampleFormControlInput2" placeholder="name@example.com">
+    <label for="exampleFormControlInput2">Email address</label>
+  </div>`} />
+
+## Variants
+
+### Alternative
+
+A minimalist input with a transparent background and a visible stroke outlining the field. This style may be interesting for contexts other than form pages:
+* When inputs need to feel lightweight and unobtrusive
+* In a header (search field)
+* In a selection/filtering feature in a product catalog
+
+<Example code={`<div class="form-control-item mb-3">
+    <input type="text" class="form-control form-control-alternative" id="exampleFormControlInputAlternative" placeholder="">
+    <label for="exampleFormControlInputAlternative">Firstname</label>
+  </div>`} />
+
+### Rounded
+
+For a finish with rounded corners.
+
+<Example code={`<div class="form-control-item mb-3">
+    <input type="text" class="form-control form-control-rounded" id="exampleFormControlInputRounded" placeholder="">
+    <label for="exampleFormControlInputRounded">Firstname</label>
+  </div>
+  <div class="form-control-item mb-3">
+    <input type="text" class="form-control form-control-alternative form-control-rounded" id="exampleFormControlInputRoundedAlt" placeholder="">
+    <label for="exampleFormControlInputRoundedAlt">Firstname</label>
+  </div>`} />
+
+### Icon
+
+<Callout type="info" name="info-icons-svg-sprite" />
+
+// TODO
+
+### Helper text
+
+To display a helper text below inputs, add a `.form-text` as a sibling of a `.form-control`.
+
+<Callout type="warning">
+Form text should be explicitly associated with the form control it relates to using the `aria-describedby` attribute. This will ensure that assistive technologies—such as screen readers—will announce this form text when the user focuses or enters the control.
+</Callout>
+
+<Example code={`<div class="form-control-item">
+    <input type="password" id="inputPassword5" class="form-control" aria-describedby="passwordHelpBlock" placeholder="">
+    <label for="inputPassword5">Password</label>
+  </div>
+  <div id="passwordHelpBlock" class="form-text">
+    Your password must be 8-20 characters long, contain letters and numbers, and must not contain spaces, special characters, or emoji.
+  </div>`} />
+
+## States
+
+### Disabled
+
+Add the `disabled` boolean attribute on an input to give it a grayed out appearance, remove pointer events, and prevent focusing.
+
+<Example code={`<div class="form-control-item mb-3">
+    <input type="text" class="form-control" id="exampleFormControlInputDisabledEmpty" placeholder="" disabled>
+    <label for="exampleFormControlInputDisabledEmpty">Firstname</label>
+  </div>
+  <div class="form-control-item mb-3">
+    <input type="text" class="form-control" id="exampleFormControlInputDisabled" value="Doe" disabled>
+    <label for="exampleFormControlInputDisabled">Lastname</label>
+  </div>
+  <div class="form-control-item mb-3">
+    <input type="text" class="form-control form-control-alternative" id="exampleFormControlInputAlternativeDisabledEmpty" placeholder="" disabled>
+    <label for="exampleFormControlInputAlternativeDisabledEmpty">Firstname</label>
+  </div>
+  <div class="form-control-item mb-3">
+    <input type="text" class="form-control form-control-alternative" id="exampleFormControlInputAlternativeDisabled" value="Doe" placeholder="" disabled>
+    <label for="exampleFormControlInputAlternativeDisabled">Lastname</label>
+  </div>`} />
+
+### Readonly
+
+Add the `readonly` boolean attribute on an input to prevent modification of the input’s value. `readonly` inputs can still be focused and selected, while `disabled` inputs cannot.
+
+<Example code={`<div class="form-control-item mb-3">
+    <input type="text" class="form-control" id="exampleFormControlInputReadonlyEmpty" placeholder="" readonly>
+    <label for="exampleFormControlInputReadonlyEmpty">Firstname</label>
+  </div>
+  <div class="form-control-item mb-3">
+    <input type="text" class="form-control" id="exampleFormControlInputReadonly" placeholder="" value="Doe" readonly>
+    <label for="exampleFormControlInputReadonly">Lastname</label>
+  </div>
+  <div class="form-control-item mb-3">
+    <input type="text" class="form-control form-control-alternative" id="exampleFormControlInputAlternativeReadonlyEmpty" placeholder="" readonly>
+    <label for="exampleFormControlInputAlternativeReadonlyEmpty">Firstname</label>
+  </div>
+  <div class="form-control-item mb-3">
+    <input type="text" class="form-control form-control-alternative" id="exampleFormControlInputAlternativeReadonly" placeholder="" value="Doe" readonly>
+    <label for="exampleFormControlInputAlternativeReadonly" class="form-label">Lastname</label>
+  </div>`} />
+
+### Invalid
+
+<Callout type="info" name="input-invalid" />
+
+To display an invalid input, add `.is-invalid` to a `.form-control`. Please take a look at our [Validation page to learn more]([[docsref:/forms/validation]]).
+
+{/* <Example code={`<div class="form-control-item mb-3">
+    <label for="exampleFormControlInputInvalidEmpty">Firstname</label>
+    <input type="text" class="form-control is-invalid" id="exampleFormControlInputInvalidEmpty" placeholder="" readonly>
+  </div>
+  <div class="form-control-item mb-3">
+    <label for="exampleFormControlInputInvalid">Lastname</label>
+    <input type="text" class="form-control is-invalid" id="exampleFormControlInputInvalid" value="Doe" placeholder="" readonly>
+  </div>
+  <div class="form-control-item mb-3">
+    <label for="exampleFormControlInputAlternativeInvalidEmpty">Firstname</label>
+    <input type="text" class="form-control form-control-alternative is-invalid" id="exampleFormControlInputAlternativeInvalidEmpty" placeholder="" readonly>
+  </div>
+  <div class="form-control-item mb-3">
+    <label for="exampleFormControlInputAlternativeInvalid" class="form-label">Lastname</label>
+    <input type="text" class="form-control form-control-alternative is-invalid" id="exampleFormControlInputAlternativeInvalid" value="Doe" placeholder="" readonly>
+  </div>`} /> */}


### PR DESCRIPTION
### Related issues

Closes #

### Context & Motivation

Add the Text-input component

### Description

New feature (non-breaking change which adds functionality)

### Checklists

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change pass all tests
- [ ] My change is compatible with a responsive display
- [ ] I have added tests (Javascript unit test or visual) to cover my changes
- [ ] My change introduces changes to the documentation that I have updated accordingly
  - [ ] Title and DOM structure is correct
  - [ ] Links have been updated (title changes impact links)
  - [ ] CSS for the documentation
- [ ] I have checked all states and combinations of the component with my change
- [ ] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [ ] The changes need to be in the migration guide
- [ ] The changes are well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [ ] The changes are compatible with RTL
- [ ] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>
