### PR TITLE
[Fix] Label for non required field in form example

### DIFF
--- a/site/src/assets/examples/form/index.astro
+++ b/site/src/assets/examples/form/index.astro
@@ -218,7 +218,7 @@ export const aliases = [
                 </div>
               </div>
               <div class="mb-3">
-                <label for="website" id="websiteLabel" class="form-label">Website<span class="visually-hidden"> (required)</span></label>
+                <label for="website" id="websiteLabel" class="form-label">Website</label>
                 <input type="text" class="form-control" id="website" aria-labelledby="websiteLabel websiteFeedback">
                 <div class="valid-feedback">
                   Looks good!


### PR DESCRIPTION
### Description

In form example (), 'Website' is not a required input. Therefore, the required information in the part of the label designed for screen reader users must be removed.

### Motivation & Context

Avoid potential confusion for blind people to have a non-mandatory field labelled as mandatory.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices; I have at least run axe

#### Design

- [ ] My change respects the design guidelines defined in [Orange Design System](https://oran.ge/dsweb)
- [ ] My change is compatible with a responsive display

#### Development

- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] I have added JavaScript unit tests to cover my changes
- [ ] I have added SCSS unit tests to cover my changes

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] My change introduces changes to the migration guide
- [ ] My new component is well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook)
- [ ] My new component is compatible with RTL
- [ ] Manually run [BrowserStack tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/browserstack.yml)
- [ ] Manually test browser compatibility with BrowserStack (Chrome >= 60, Firefox >= 60 (+ ESR), Edge, Safari >= 12, iOS Safari, Chrome & Firefox on Android)
- [ ] Code review
- [ ] Design review
- [ ] A11y review

#### After the merge

- [ ] Manually launch [Percy tests](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/actions/workflows/percy.yml)
