### PR TITLE
Fix doc avoiding repetition and moving some text at the right place

### DIFF
--- a/site/src/content/docs/components/buttons.mdx
+++ b/site/src/content/docs/components/buttons.mdx
@@ -92,15 +92,13 @@ The recommended way of using an icon in a button is through an [SVG sprite file]
 When icons are purely decorative, they should be hidden from assistive technologies using `aria-hidden="true"`, as we’ve done in our text and icon examples. For icon only, we chose to keep the icon hidden from assistive technologies and add a visually hidden label. See [icons accessibility]([[docsref:/extend/icons#icons-accessibility]]) for more info.
 </Callout>
 
-### Text and icon
+If really needed, you can use a font icon associated to the `.icon` class to set correct parameters for the `font-size` and `line-height`.
 
-The recommended way of using an icon in a button is an [embedded SVG]([[docsref:/extend/icons]]). You need to fill it using `currentColor` to respect button color scheme (which can be done inside the SVG sprite file).
+### Text and icon
 
 You don’t need to apply any spacing utility on the icon to get consistent spacing, as the margin is already handled by OUDS Web.
 
 Please note that if you experience a problem with a cropped SVG, we recommend using the `.overflow-visible` utility on the SVG to fix its rendering.
-
-If really needed, you can use a font icon associated to the `.icon` class to set correct parameters for the `font-size` and `line-height`.
 
 We strongly advise not using an `<img />`, in particular because the icon will not benefit from dynamic color changes on states (hover, focus, active) and the color mode system won’t work.
 


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

Split from #3062 

### Context & Motivation

<!-- Describe the actual behavior (and how to reproduce it). -->
Fix doc avoiding repetition and moving some text at the right place

### Description

<!-- Describe your changes in detail -->

### Checklists

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change pass all tests
- [x] My change is compatible with a responsive display
- [ ] I have added tests (Javascript unit test or visual) to cover my changes
- [x] My change introduces changes to the documentation that I have updated accordingly
  - [x] Title and DOM structure is correct
  - [x] Links have been updated (title changes impact links)
  - [x] CSS for the documentation
- [x] I have checked all states and combinations of the component with my change
- [x] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [ ] The changes need to be in the migration guide
- [x] The changes are well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [x] The changes are compatible with RTL
- [ ] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/docs/components/buttons#with-icon>
