### PR TITLE
feat(github): add a doc-only PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,5 @@ Click the `Preview` tab and select a PR template:
   - [Release Boosted](?expand=1&template=boosted-release-template.md) (Core team only)
 - **OUDS Web**:
   - [Contribute to OUDS Web](?expand=1&template=ouds-contribution-template.md)
+  - [Docs only to OUDS Web](?expand=1&template=ouds-doc-template.md)
   - [Release OUDS Web](?expand=1&template=ouds-release-template.md) (Core team only)

--- a/.github/PULL_REQUEST_TEMPLATE/ouds-doc-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ouds-doc-template.md
@@ -1,0 +1,26 @@
+### Related issues
+
+Closes #
+
+### Description
+
+<!-- Describe your changes in detail -->
+
+### Checklists
+
+- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
+- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
+- [ ] My change follows the page structure defined in #3045
+- [ ] Title and DOM structure is correct
+- [ ] Links have been updated (title change impacts links for example)
+
+### Progression (for Core Team only)
+
+- [ ] Code review
+- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
+
+### Live previews
+
+<!-- Please add direct links where your modifications can be seen in the documentation -->
+
+- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

NA

### Context & Motivation

It was painful to add small modification to our docs with all the checkboxes to check before submitting a PR

### Description

Add a simpler PR template for docs only

### Checklists

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change pass all tests
- [x] My change is compatible with a responsive display
- [x] I have added tests (Javascript unit test or visual) to cover my changes
- [x] My change introduces changes to the documentation that I have updated accordingly
  - [x] Title and DOM structure is correct
  - [x] Links have been updated (title changes impact links)
  - [x] CSS for the documentation
- [x] I have checked all states and combinations of the component with my change
- [x] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [x] The changes need to be in the migration guide
- [x] The changes are well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [x] The changes are compatible with RTL
- [x] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>
