### PR TITLE
fix(lib): Lesser the specificity of links

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -337,7 +337,7 @@ sup { top: -.5em; }
     color: var(--#{$prefix}link-visited-color);
   }
 
-  &:focus-visible:not([aria-disabled="true"]) {
+  &:focus-visible:where(:not([aria-disabled="true"])) {
     color: var(--#{$prefix}link-focus-color);
     text-decoration: $link-hover-decoration;
   }


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

NA

### Context & Motivation

The focus visible of a button over a link in a colored bg context was broken.

### Description

Lesser the specificity of the link selector. There are probably other places that would need this kind of thing.

### Checklists

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change pass all tests
- [x] My change is compatible with a responsive display
- [x] I have added tests (Javascript unit test or visual) to cover my changes
- [x] My change introduces changes to the documentation that I have updated accordingly
  - [x] Title and DOM structure is correct
  - [x] Links have been updated (title changes impact links)
  - [x] CSS for the documentation
- [x] I have checked all states and combinations of the component with my change
- [x] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [x] The changes need to be in the migration guide
- [x] The changes are well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [x] The changes are compatible with RTL
- [x] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>
