### PR TITLE
fix(doc): remove bottom margin on code examples

### DIFF
--- a/site/src/scss/_component-examples.scss
+++ b/site/src/scss/_component-examples.scss
@@ -408,7 +408,8 @@
 
   pre {
     padding: 0 0 .75rem; // OUDS mod: instead of `padding: .25rem 0 .875rem`
-    margin: .5rem 0; // OUDS mod: instead of `margin-top: .8125rem` and `margin-bottom: 0`
+    margin-top: .5rem; // OUDS mod: instead of `margin-top: .8125rem`
+    margin-bottom: 0;
     overflow: overlay;
     white-space: pre;
     background-color: transparent;


### PR DESCRIPTION
### Description

Removes small margin at the bottom of code examples

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3119--boosted.netlify.app/>