### PR TITLE
fix(doc): set badge URL documentation

### DIFF
--- a/site/src/content/docs/components/badge.mdx
+++ b/site/src/content/docs/components/badge.mdx
@@ -10,8 +10,7 @@ import { getData } from '@libs/data'
 import { getConfig } from '@libs/config'
 
 <Callout type="info">
-{/* TODO: set the right url for design documentation */}
-You can find here the [OUDS Badge design guidelines](https://unified-design-system.orange.com/).
+You can find here the [OUDS Badge design guidelines](https://unified-design-system.orange.com/472794e18/p/698ea8-badge).
 </Callout>
 
 ## Base class
@@ -27,8 +26,7 @@ For accessibility and semantics reasons, badges, like any other informative elem
 
 ## Standard variants 
 
-{/*  TODO: set the right url for design documentation */}
-OUDS Web [color and background helpers]([[docsref:/helpers/color-background]]) can be applied to display badge variants, each serving its own semantic purpose. Please follow the [Badge design specifications](https://unified-design-system.orange.com/) to choose the right badge for the right action.
+OUDS Web [color and background helpers]([[docsref:/helpers/color-background]]) can be applied to display badge variants, each serving its own semantic purpose. Please follow the [Badge design specifications](https://unified-design-system.orange.com/472794e18/p/698ea8-badge) to choose the right badge for the right action.
 
 <Example class="d-flex gap-3" code={`<p class="badge"><span class="visually-hidden">Badge alt text</span></p>
   <p class="badge text-bg-status-accent-emphasized"><span class="visually-hidden">Badge alt text</span></p>


### PR DESCRIPTION
### Description

Set the correct link to badge documentation URL

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>
