### PR TITLE
fix: minimal icons button disapear on mobile in documentation

### DIFF
--- a/site/src/components/shortcodes/Example.astro
+++ b/site/src/components/shortcodes/Example.astro
@@ -78,7 +78,8 @@ const simplifiedMarkup = markup
         {showPreview && (
           <div class="d-flex order-first align-items-center highlight-toolbar ps-lg border-top border-bottom border-thin border-default">
             <small class="font-monospace text-muted text-uppercase my-sm">{lang}</small>
-            <div class="d-flex ms-auto">
+            <!-- OUDS mod: buttons are not displayed on small screens -->
+            <div class="d-none d-md-flex ms-auto">
               <button
                 type="button"
                 class="btn btn-minimal btn-icon btn-edit m-2xs me-xs"

--- a/site/src/scss/_component-examples.scss
+++ b/site/src/scss/_component-examples.scss
@@ -13,16 +13,6 @@
     // OUDS mod: no margin-right, margin-left, border-width
     @include border-radius(var(--bs-border-radius));
   }
-
-  // OUDS mod
-  .btn-minimal.btn-icon {
-    display: none;
-
-    @include media-breakpoint-up(md) {
-      display: inline-flex;
-    }
-  }
-  // End mod
 }
 
 .bd-example {


### PR DESCRIPTION
### Types of change

- [ ] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

Closes #3118 

### Description

Fix minimal icons button disapear on mobile in documentation

### Checklists

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change pass all tests
- [ ] My change is compatible with a responsive display

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>
