### PR TITLE
fix(doc): set chip documentation URL and fix internal link

### DIFF
--- a/site/src/content/docs/components/chip.mdx
+++ b/site/src/content/docs/components/chip.mdx
@@ -25,7 +25,7 @@ You can find here the [OUDS chip design guidelines](https://unified-design-syste
           </p>
         </div>
       </div>
-      <div class="card-body border-default border-thin border-top"><a class="stretched-link" href="#chip-filter">Chip filter</a> is a filter option that can be selected or deselected by the user.</div>
+      <div class="card-body border-default border-thin border-top"><a class="stretched-link" href="#filter-chip">Filter chip</a> is a filter option that can be selected or deselected by the user.</div>
     </div>
   </li>
   <li class="col">


### PR DESCRIPTION
### Description

Set the right URL to chip documentation

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3123--boosted.netlify.app/>

related to #2844