### PR TITLE
Add some labels on example buttons

### DIFF
--- a/site/src/components/shortcodes/Code.astro
+++ b/site/src/components/shortcodes/Code.astro
@@ -39,9 +39,16 @@ interface Props {
    * @default false
    */
   nestedInExample?: boolean
+  /**
+   * Defines label to complete 'Edit on Stackblitz' and 'Copy to clipboard' buttons' labels.
+   * @default null
+   */
+  buttonLabel?: string
 }
 
-const { class: className, code, containerClass, fileMatch, filePath, lang, nestedInExample = false } = Astro.props
+const { class: className, code, containerClass, fileMatch, filePath, lang, nestedInExample = false, buttonLabel = null } = Astro.props
+
+const clipboardLabel = buttonLabel ? `Copy ${buttonLabel} code to clipboard4` : 'Copy code to clipboard5'
 
 let codeToDisplay = filePath
   ? fs.readFileSync(path.join(process.cwd(), filePath), 'utf8')
@@ -63,8 +70,14 @@ if (filePath && fileMatch && codeToDisplay) {
 <script>
   import ClipboardJS from 'clipboard'
 
-  const btnTitle = 'Copy to clipboard'
-  const btnEdit = 'Edit on StackBlitz'
+  let  stackblitzLabel = 'Edit code on StackBlitz'
+  if (document.querySelector('.btn-edit') !== null && document.querySelector('.btn-edit').getAttribute('title') !== null) {
+    stackblitzLabel = document.querySelector('.btn-edit').getAttribute('title')
+  }
+  let  clipboardLabel = 'Copy code to clipboard'
+  if (document.querySelector('.btn-clipboard') !== null && document.querySelector('.btn-clipboard').getAttribute('title') !== null) {
+    clipboardLabel = document.querySelector('.btn-clipboard').getAttribute('title')
+  }
 
   function snippetButtonTooltip(selector: string, title: string) {
     document.querySelectorAll(selector).forEach((btn) => {
@@ -72,8 +85,8 @@ if (filePath && fileMatch && codeToDisplay) {
     })
   }
 
-  snippetButtonTooltip('.btn-clipboard', btnTitle)
-  snippetButtonTooltip('.btn-edit', btnEdit)
+  snippetButtonTooltip('.btn-clipboard', clipboardLabel)
+  snippetButtonTooltip('.btn-edit', stackblitzLabel)
 
   const clipboard = new ClipboardJS('.btn-clipboard', {
     target: (trigger) => trigger.closest('.bd-code-snippet')?.querySelector('.highlight')!,
@@ -101,7 +114,7 @@ if (filePath && fileMatch && codeToDisplay) {
     event.trigger.addEventListener(
       'hidden.bs.tooltip',
       () => {
-        tooltipBtn?.setContent({ '.tooltip-inner': btnTitle })
+        tooltipBtn?.setContent({ '.tooltip-inner': clipboardLabel })
       },
       { once: true }
     )
@@ -129,7 +142,7 @@ if (filePath && fileMatch && codeToDisplay) {
     event.trigger.addEventListener(
       'hidden.bs.tooltip',
       () => {
-        tooltipBtn?.setContent({ '.tooltip-inner': btnTitle })
+        tooltipBtn?.setContent({ '.tooltip-inner': clipboardLabel })
       },
       { once: true }
     )
@@ -156,8 +169,8 @@ if (filePath && fileMatch && codeToDisplay) {
         )
         : (
           <div class="bd-clipboard">
-            <button type="button" class="btn btn-minimal btn-icon btn-clipboard m-2xs" title="Copy to clipboard">
-              <svg class="bi" role="img" aria-label="Copy">
+            <button type="button" class="btn btn-minimal btn-icon btn-clipboard m-2xs" title={clipboardLabel}>
+              <svg class="bi" aria-hidden="true">
                 <use xlink:href={getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#copy')} />
               </svg>
             </button>

--- a/site/src/components/shortcodes/Example.astro
+++ b/site/src/components/shortcodes/Example.astro
@@ -42,6 +42,11 @@ interface Props {
    * @default true
    */
   showToolbar?: boolean
+  /**
+   * Defines label to complete 'Edit on Stackblitz' and 'Copy to clipboard' buttons' labels.
+   * @default true
+   */
+  buttonLabel?: string
 }
 
 const {
@@ -52,11 +57,15 @@ const {
   lang = 'html',
   showMarkup = true,
   showPreview = true,
-  showToolbar = true
+  showToolbar = true,
+  buttonLabel = null
 } = Astro.props
 
 let markup = Array.isArray(code) ? code.join('\n') : code
 markup = replacePlaceholdersInHtml(markup)
+
+const stackblitzLabel = buttonLabel ? `Edit ${buttonLabel} code on StackBlitz` : 'Edit code on StackBlitz'
+const clipboardLabel = buttonLabel ? `Copy ${buttonLabel} code to clipboard` : 'Copy code to clipboard'
 
 const simplifiedMarkup = markup
   .replace(
@@ -81,23 +90,21 @@ const simplifiedMarkup = markup
   {
     showMarkup && (
       <>
-        <Code code={simplifiedMarkup} lang={lang} nestedInExample={true} />
+        <Code code={simplifiedMarkup} lang={lang} nestedInExample={true} buttonLabel={buttonLabel} />
         {showPreview && showToolbar && (
           <div class="d-flex order-first align-items-center highlight-toolbar ps-lg border-top border-bottom border-thin border-default">
             <small class="font-monospace text-muted text-uppercase my-sm">{lang}</small>
             <!-- OUDS mod: buttons are not displayed on small screens -->
             <div class="d-none d-md-flex ms-auto">
-              <button
-                type="button"
-                class="btn btn-minimal btn-icon btn-edit m-2xs me-xs"
-                title="Try it on StackBlitz"
-                data-sb-js-snippet={addStackblitzJs ? true : undefined}
-              >
+              <button type="button" class="btn btn-minimal btn-icon btn-edit m-2xs me-xs"
+                title={stackblitzLabel}
+                data-sb-js-snippet={addStackblitzJs ? true : undefined}>
                 <svg aria-hidden="true">
                   <use xlink:href={getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#lightning-charge-fill')} />
                 </svg>
               </button>
-              <button type="button" class="btn btn-minimal btn-icon btn-clipboard m-2xs" title="Copy code to clipboard">
+              <button type="button" class="btn btn-minimal btn-icon btn-clipboard m-2xs"
+                title={clipboardLabel}>
                 <svg aria-hidden="true">
                   <use xlink:href={getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#copy')} />
                 </svg>

--- a/site/src/content/docs/components/tags.mdx
+++ b/site/src/content/docs/components/tags.mdx
@@ -74,7 +74,7 @@ Several examples are provided below but they will need to be adapted for actual 
 Tags lists must be wrapped in a semantic container (usually a `<ul>` or `<ol>`). *If possible, display a semantically informative text to describe the tags' list purpose*, otherwise an `aria-label` must be added to the container to explain the function of the tags, [more information here](#accessibility).
 </Callout>
 
-<Example code={`<ul class="list-unstyled d-flex column-gap-xs" aria-label="Mobile coverage">
+<Example buttonLabel="default tags" code={`<ul class="list-unstyled d-flex column-gap-xs" aria-label="Mobile coverage">
     <li class="tag">Roaming</li>
     <li class="tag">5G Ready</li>
     <li class="tag">4G</li>
@@ -87,7 +87,7 @@ OUDS Web [color and background utilities]([[docsref:/helpers/color-background]])
 Keep in mind that color should not be the only way to convey information. If the color has strong meaning, reflect it in the tag's text and if necessary add additional text with the class `.visually-hidden`.
 </Callout>
 
-<Example code={`<ul class="list-unstyled d-flex flex-wrap column-gap-xs row-gap-md" aria-label="Muted colors">
+<Example buttonLabel="colored tags" code={`<ul class="list-unstyled d-flex flex-wrap column-gap-xs row-gap-md" aria-label="Muted colors">
     <li class="tag text-bg-status-neutral-muted">Neutral</li>
     <li class="tag text-bg-status-accent-muted">Accent</li>
     <li class="tag text-bg-status-positive-muted">Positive</li>

--- a/site/src/content/docs/layout/containers.mdx
+++ b/site/src/content/docs/layout/containers.mdx
@@ -94,11 +94,9 @@ Responsive containers allow you to specify a class that follows the `.container-
 
 Use `.container-fluid` for a full width container with minimum margins, spanning almost the entire width of the viewport.
 
-```html
-<div class="container-fluid">
-  ...
-</div>
-```
+<Code lang="html" buttonLabel="fluid container" code={`<div class="container-fluid">
+    ...
+  </div>`} />
 
 ### Default max width
 


### PR DESCRIPTION
### Related issues

Closes #

### Description

<!-- Describe your changes in detail -->

### Checklists

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>
