### PR TITLE
fix(component): make buttons informative icons grow with font size

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -49,7 +49,7 @@
   --#{$prefix}btn-icon-size: #{$ouds-button-size-icon};
   --#{$prefix}btn-icon-gap: #{$ouds-button-space-column-gap-icon};
   --#{$prefix}btn-focus-border-color: var(--#{$prefix}btn-hover-border-color);
-  --#{$prefix}btn-loading-size: #{$ouds-button-size-loader};
+  --#{$prefix}btn-loading-size: #{px-to-rem($ouds-button-size-loader)};
   --#{$prefix}btn-loading-dasharray: 96;
   --#{$prefix}btn-loading-animation: 2.1875s infinite linear rotate1-indeterminate, 1.25s linear infinite rotate2-indeterminate;
   // End mod
@@ -203,7 +203,7 @@
     --#{$prefix}btn-padding-end: #{$ouds-button-space-inset-icon-only};
     --#{$prefix}btn-padding-y: #{$ouds-button-space-inset-icon-only};
     --#{$prefix}btn-icon-gap: 0;
-    --#{$prefix}btn-icon-size: #{$ouds-button-size-icon-only};
+    --#{$prefix}btn-icon-size: #{px-to-rem($ouds-button-size-icon-only)};
   }
   // End mod
 }


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

Part of #3160

### Context & Motivation

Informative icons should grow with the font size

### Description

Make buttons' "icon only" and "loader" icons grow with the font size.

### Checklists

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change pass all tests
- [x] My change is compatible with a responsive display
- [ ] I have added tests (Javascript unit test or visual) to cover my changes
- [ ] My change introduces changes to the documentation that I have updated accordingly
  - [ ] Title and DOM structure is correct
  - [ ] Links have been updated (title changes impact links)
  - [ ] CSS for the documentation
- [ ] I have checked all states and combinations of the component with my change
- [ ] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [ ] The changes need to be in the migration guide
- [ ] The changes are well displayed in [Storybook](https://deploy-preview-3167--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [ ] The changes are compatible with RTL
- [ ] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3167--boosted.netlify.app/>