### PR TITLE
fix(docs): wording improvement on chips a11y

### DIFF
--- a/site/src/content/docs/components/chips.mdx
+++ b/site/src/content/docs/components/chips.mdx
@@ -59,7 +59,7 @@ Chip components are always displayed in a containing list with a `ul.chip-contai
 
 ### Accessibility
 
-Visually impaired and blind users will lack the visual context that permits to understand the chips list purpose on the page especially if chips' labels are not self-explanatory. Thus it's mandatory to *add a semantically informative title to describe the chips' list purpose* if possible, otherwise an `aria-label` on the containing `ul` must be added. To improve accessibility and denote the chips' list uniqueness of purpose, it's possible to add `role=group` on a parent container (but not the `ul` as it would not work).
+Visually impaired and blind users will lack the visual context that permits to understand the chips list purpose on the page especially if chips' labels are not self-explanatory. Thus it's mandatory to *add a semantically informative title to describe the chips' list purpose* if possible, otherwise an `aria-label` on the containing `ul` must be added. To improve accessibility and denote the chips' list uniqueness of purpose, it's possible to add `role=group` on a parent container (but not the `ul` as it would lose its semantics).
 
 Several examples are provided below but they will need to be adapted for actual use cases.
 


### PR DESCRIPTION
### Related issues

Closes #2844 (https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/issues/2844#issuecomment-3400948288)

### Description

Wording change on chips a11y paragraph

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3180--boosted.netlify.app/>