### PR TITLE
fix: backgrounds listing generate errors in dev shell

### DIFF
--- a/site/src/content/docs/utilities/background.mdx
+++ b/site/src/content/docs/utilities/background.mdx
@@ -8,7 +8,7 @@ toc: true
 
 import { getConfig } from '@libs/config'
 import { getData } from '@libs/data'
-import { allTokens, scssMaps, hasToken } from '@libs/sass-variables'
+import { allTokens, hasToken } from '@libs/sass-variables'
 
 <Callout type="info" name="warning-color-assistive-technologies" />
 
@@ -45,19 +45,11 @@ Please note that we use `[data-bs-theme]` attribute on a child element to avoid 
 </Callout>
 
 <Example code={[
-  ...scssMaps.find(token => token.name === '$ouds-backgrounds').mapValue
-    .filter(bgToken =>
-      // remove backgrounds that have specific documentation
-      !['transparent', 'opacity-lowest', 'opacity-lower', 'always-black', 'always-white'].includes(bgToken.name)
-    )
-    .filter(bgToken => {
-      // remove backgrounds that are conditional
-      const conditionalBgMatches = bgToken.value.match(/variable-exists\(([^\)]*)/)
-      return !conditionalBgMatches || hasToken(`$${conditionalBgMatches[1]}`);
-    })
+  ...allTokens.filter(token => token.name.match(/\$ouds-color-surface-.*-light/))
     .map(token => {
+      const bgName = token.name.match(/\$ouds-color-surface-(.*)-light/)[1]
       const themesArray = allTokens.filter(allToken => {
-        return allToken.name.match(`modes-on-(bg-)?${token.name}-(dark|light)`)
+        return allToken.name.match(`modes-on-(bg-)?${bgName}-(dark|light)`)
       }).map(token => token.compiledValue)
       const theme = themesArray[0].includes('dark')
         ? themesArray[1].includes('light')
@@ -66,7 +58,7 @@ Please note that we use `[data-bs-theme]` attribute on a child element to avoid 
         : themesArray[1].includes('light')
           ? 'light'
           : 'root-inverted'
-      return `<p class="bg-${token.name} p-large fw-bold">${theme !== 'root' ? `<span data-bs-theme="${theme}">` : ''}.bg-${token.name}${theme !== 'root' ? '</span>' : ''}</p>`
+      return `<p class="bg-${bgName} p-large fw-bold">${theme !== 'root' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'root' ? '</span>' : ''}</p>`
     }),
   `<p class="bg-always-black p-large fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
   <p class="bg-always-white p-large fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>
@@ -86,24 +78,16 @@ Here is a more complex example to understand how to use `[data-bs-theme]` in spe
 
 <Example class="p-none" code={[`<div class="bg-always-white p-large">
     <div data-bs-theme="light">`,
-    ...scssMaps.find(token => token.name === '$ouds-backgrounds').mapValue
-      .filter(bgToken =>
-        // remove backgrounds that have specific documentation
-        !['transparent', 'opacity-lowest', 'opacity-lower', 'always-black', 'always-white'].includes(bgToken.name)
-      )
-      .filter(bgToken => {
-        // remove backgrounds that are conditional
-        const conditionalBgMatches = bgToken.value.match(/variable-exists\(([^\)]*)/)
-        return !conditionalBgMatches || hasToken(`$${conditionalBgMatches[1]}`);
-      })
+    ...allTokens.filter(token => token.name.match(/\$ouds-color-surface-.*-light/))
       .map(token => {
+        const bgName = token.name.match(/\$ouds-color-surface-(.*)-light/)[1]
         const themesArray = allTokens.filter(allToken => {
-          return allToken.name.match(`modes-on-(bg-)?${token.name}-(dark|light)`)
+          return allToken.name.match(`modes-on-(bg-)?${bgName}-(dark|light)`)
         }).map(token => token.compiledValue)
         const theme = themesArray[1].includes('light')
           ? 'light'
           : 'dark'
-        return `    <p class="bg-${token.name} p-large fw-bold">${theme !== 'light' ? `<span data-bs-theme="${theme}">` : ''}.bg-${token.name}${theme !== 'light' ? '</span>' : ''}</p>`
+        return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'light' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'light' ? '</span>' : ''}</p>`
       }),
   `    <p class="bg-always-black p-large fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
       <p class="bg-always-white p-large fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>
@@ -127,24 +111,16 @@ We also provide some opacity backgrounds that should only be used in very specif
 
 <Example class="p-none" code={[`<div class="bg-always-black p-large">
     <div data-bs-theme="dark">`,
-    ...scssMaps.find(token => token.name === '$ouds-backgrounds').mapValue
-      .filter(bgToken =>
-        // remove backgrounds that have specific documentation
-        !['transparent', 'opacity-lowest', 'opacity-lower', 'always-black', 'always-white'].includes(bgToken.name)
-      )
-      .filter(bgToken => {
-        // remove backgrounds that are conditional
-        const conditionalBgMatches = bgToken.value.match(/variable-exists\(([^\)]*)/)
-        return !conditionalBgMatches || hasToken(`$${conditionalBgMatches[1]}`);
-      })
+    ...allTokens.filter(token => token.name.match(/\$ouds-color-surface-.*-light/))
       .map(token => {
+        const bgName = token.name.match(/\$ouds-color-surface-(.*)-light/)[1]
         const themesArray = allTokens.filter(allToken => {
-          return allToken.name.match(`modes-on-(bg-)?${token.name}-(dark|light)`)
+          return allToken.name.match(`modes-on-(bg-)?${bgName}-(dark|light)`)
         }).map(token => token.compiledValue)
         const theme = themesArray[0].includes('dark')
           ? 'dark'
           : 'light'
-        return `    <p class="bg-${token.name} p-large fw-bold">${theme !== 'dark' ? `<span data-bs-theme="${theme}">` : ''}.bg-${token.name}${theme !== 'dark' ? '</span>' : ''}</p>`
+        return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'dark' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'dark' ? '</span>' : ''}</p>`
       }),
   `    <p class="bg-always-black p-large fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
       <p class="bg-always-white p-large fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>
@@ -172,19 +148,11 @@ Here is a more complex example to understand how to use `[data-bs-theme]` in spe
 
 <Example class="p-none" code={[`<div class="bg-inverse-high p-large">
     <div data-bs-theme="root-inverted">`,
-    ...scssMaps.find(token => token.name === '$ouds-backgrounds').mapValue
-      .filter(bgToken =>
-        // remove backgrounds that have specific documentation
-        !['transparent', 'opacity-lowest', 'opacity-lower', 'always-black', 'always-white'].includes(bgToken.name)
-      )
-      .filter(bgToken => {
-        // remove backgrounds that are conditional
-        const conditionalBgMatches = bgToken.value.match(/variable-exists\(([^\)]*)/)
-        return !conditionalBgMatches || hasToken(`$${conditionalBgMatches[1]}`);
-      })
+    ...allTokens.filter(token => token.name.match(/\$ouds-color-surface-.*-light/))
       .map(token => {
+        const bgName = token.name.match(/\$ouds-color-surface-(.*)-light/)[1]
         const themesArray = allTokens.filter(allToken => {
-          return allToken.name.match(`modes-on-(bg-)?${token.name}-(dark|light)`)
+          return allToken.name.match(`modes-on-(bg-)?${bgName}-(dark|light)`)
         }).map(token => token.compiledValue)
         const theme = themesArray[0].includes('dark')
           ? themesArray[1].includes('light')
@@ -193,7 +161,7 @@ Here is a more complex example to understand how to use `[data-bs-theme]` in spe
           : themesArray[1].includes('light')
             ? 'light'
             : 'root'
-        return `    <p class="bg-${token.name} p-large fw-bold">${theme !== 'root-inverted' ? `<span data-bs-theme="${theme}">` : ''}.bg-${token.name}${theme !== 'root-inverted' ? '</span>' : ''}</p>`
+        return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'root-inverted' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'root-inverted' ? '</span>' : ''}</p>`
       }),
   `    <p class="bg-always-black p-large fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
       <p class="bg-always-white p-large fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>

--- a/site/src/libs/sass-variables.ts
+++ b/site/src/libs/sass-variables.ts
@@ -8,13 +8,6 @@ const options = {
 
 export const allTokens = exporter(options).getArray()
 
-const optionsMaps = {
-  inputFiles: [`scss/_maps.scss`],
-  includePaths: []
-}
-
-export const scssMaps = exporter(optionsMaps).getArray()
-
 /**
  * This function returns the current theme depending on the parameter passed (light, dark, root, root-inverted). You need to use a name containing 'modes-on' and it should exist in the _semantic.scss file.
  * @param regex


### PR DESCRIPTION
### Description

Go back to only seeking backgrounds in `$ouds-color-surface-***` tokens instead of using the maps which has issue with `sass-export`

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3232--boosted.netlify.app/orange/docs/0.5/utilities/background/>
