### PR TITLE
[OUDS] Tag: Fix assets paddings after design review

### DIFF
--- a/scss/_tags.scss
+++ b/scss/_tags.scss
@@ -132,7 +132,9 @@
   }
 
   .tag-status-icon {
-    padding: var(--#{$prefix}tag-icon-padding);
+    width: calc(var(--#{$prefix}tag-size-asset) - (2 * var(--#{$prefix}tag-icon-padding))); // stylelint-disable-line function-disallowed-list
+    height: calc(var(--#{$prefix}tag-size-asset) - (2 * var(--#{$prefix}tag-icon-padding))); // stylelint-disable-line function-disallowed-list
+    margin: var(--#{$prefix}tag-icon-padding);
     vertical-align: middle;
     background-color: var(--#{$prefix}tag-asset-color);
     background-size: contain;
@@ -168,8 +170,8 @@
       top: 0;
       left: 0;
       display: inline-block;
-      width: var(--#{$prefix}tag-size-asset);
-      height: var(--#{$prefix}tag-size-asset);
+      width: calc(var(--#{$prefix}tag-size-asset) - (2 * var(--#{$prefix}tag-icon-padding))); // stylelint-disable-line function-disallowed-list
+      height: calc(var(--#{$prefix}tag-size-asset) - (2 * var(--#{$prefix}tag-icon-padding))); // stylelint-disable-line function-disallowed-list
       content: "";
       background-repeat: no-repeat;
       background-size: contain;
@@ -202,6 +204,8 @@
   .tag-loader { // TODO partially copied from button loader, should be factorized as much as possible
     --#{$prefix}tag-asset-color: currentcolor;
     display: block;
+    width: var(--#{$prefix}tag-size-asset);
+    height: var(--#{$prefix}tag-size-asset);
     padding: var(--#{$prefix}tag-loader-padding);
     margin: 0;
     font-size: var(--#{$prefix}tag-size-asset);


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

Closes #3174 

### Context & Motivation

Bug viewed at design review

### Description

Fix assets paddings:
- Set correct *left padding for tags with icon, bullet and loader, in normal and small sizes*, by using correctly `--bs-tag-asset-padding` for default and small sizes (reduced padding on the left of the asset)
- Set correct *inset padding (asset container) for small tag with icon* by adding `--bs-tag-icon-padding` (padding inside icon container, setting the remaining place for the icon)
- Set correct inset padding (asset container) for tag loader default and small, by jusing correctly `--bs-tag-loader-padding` (padding inside loader container)
- Set correct inset padding (asset container) for tag bullet small, by jusing correctly `--bs-tag-bullet-padding` (padding inside bullet container)
- reorganize variables to make the file easier to review

### Checklists

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change pass all tests
- [ ] My change is compatible with a responsive display
- [ ] I have added tests (Javascript unit test or visual) to cover my changes
- [ ] My change introduces changes to the documentation that I have updated accordingly
  - [ ] Title and DOM structure is correct
  - [ ] Links have been updated (title changes impact links)
  - [ ] CSS for the documentation
- [ ] I have checked all states and combinations of the component with my change
- [ ] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [ ] The changes need to be in the migration guide
- [ ] The changes are well displayed in [Storybook](https://deploy-preview-3240--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [ ] The changes are compatible with RTL
- [ ] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3240--boosted.netlify.app/orange/docs/0.5/components/tags/#non-functional>
- <https://deploy-preview-3240--boosted.netlify.app/orange/docs/0.5/components/tags/#functional>
- <https://deploy-preview-3240--boosted.netlify.app/orange/docs/0.5/components/tags/#bullet>
- <https://deploy-preview-3240--boosted.netlify.app/orange/docs/0.5/components/tags/#loading>
- <https://deploy-preview-3240--boosted.netlify.app/orange/docs/0.5/components/tags/#sizes>
