### PR TITLE
[OUDS] Enhance DSM links typography

### DIFF
--- a/site/src/content/docs/forms/password-input.mdx
+++ b/site/src/content/docs/forms/password-input.mdx
@@ -9,8 +9,7 @@ toc: true
 import { getVersionedDocsPath } from '@libs/path'
 
 <Callout type="info">
-{/* TODO: set the right url for design documentation */}
-You can find here the [OUDS password input design guidelines](https://r.orange.fr/r/S-ouds-doc-password-input).
+  You can find here the OUDS [password input design guidelines](https://r.orange.fr/r/S-ouds-doc-password-input).
 </Callout>
 
 ## Overview

--- a/site/src/content/docs/forms/select-input.mdx
+++ b/site/src/content/docs/forms/select-input.mdx
@@ -10,7 +10,7 @@ toc: true
 import { getVersionedDocsPath } from '@libs/path'
 
 <Callout type="info">
-You can find here the [OUDS select input design guidelines](https://r.orange.fr/r/S-ouds-doc-select-input).
+  You can find here the OUDS [select input design guidelines](https://r.orange.fr/r/S-ouds-doc-select-input).
 </Callout>
 
 ## Overview


### PR DESCRIPTION
### Related issues

Closes #

### Description

Enhance pwd input and select input DSM links typography after demo: 
- change DSM links typo in password-input and select-input
- remove useless TODO in password-input

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3285--boosted.netlify.app/>
