### PR TITLE
[OUDS] Add Teams and discussion contacts and deactivate search

### DIFF
--- a/site/src/components/footer/Footer.astro
+++ b/site/src/components/footer/Footer.astro
@@ -205,6 +205,17 @@ const { title } = Astro.props
                   Discussions
                 </a>
               </li>
+              <li>
+                <a
+                  class="nav-link"
+                  href="https://teams.microsoft.com/l/channel/19%3Aed6a64c0c22d4b2084d304d0e33a1168%40thread.tacv2/PR04%20-%20%F0%9F%96%A5%EF%B8%8F%20Web%20Browsing?groupId=a9581e9e-6775-46f5-9e4a-3ce57096e6be&tenantId=90c7a20a-f34b-40bf-bc48-b9253b6f5d20"
+                  aria-describedby="headingCommunity"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  Teams channel
+                </a>
+              </li>
             </ul>
           </div>
         </div>

--- a/site/src/components/header/Navigation.astro
+++ b/site/src/components/header/Navigation.astro
@@ -93,10 +93,11 @@ const { addedIn, layout, title } = Astro.props
             <GitHubIcon height={16} width={16} />
             <span class="visually-hidden">GitHub</span>
           </LinkItem>
-          <li class="nav-item">
-            <div class="bd-search nav-link nav-icon" id="docsearch" data-bd-docs-version={getConfig().docs_version}>
-            </div>
-          </li>
+          <!-- search deactivated -->
+          <!-- <li class="nav-item">-->
+          <!--  <div class="bd-search nav-link nav-icon" id="docsearch" data-bd-docs-version={getConfig().docs_version}>-->
+          <!--  </div>-->
+          <!--</li>-->
 
           <Versions layout={layout} addedIn={addedIn} />
         </ul>

--- a/site/src/content/docs/about/team.mdx
+++ b/site/src/content/docs/about/team.mdx
@@ -22,7 +22,7 @@ OUDS Web is maintained by the core team and a small group of invaluable core con
   })}
 </div>
 
-Get involved with OUDS Web development by [opening an issue]([[config:repo]]/issues/new/choose) or submitting a pull request. Read our [contributing guidelines]([[config:repo]]/blob/v[[config:current_version]]-ouds-web/.github/CONTRIBUTING.md) for information on how we develop.
+Get involved with OUDS Web development by [opening an issue]([[config:repo]]/issues/new/choose) or submitting a pull request. Contact us by [opening a discussion]([[config:repo]]/discussions) or [chat in Teams (internal Orange link)](https://teams.microsoft.com/l/channel/19%3Aed6a64c0c22d4b2084d304d0e33a1168%40thread.tacv2/PR04%20-%20%F0%9F%96%A5%EF%B8%8F%20Web%20Browsing?groupId=a9581e9e-6775-46f5-9e4a-3ce57096e6be&tenantId=90c7a20a-f34b-40bf-bc48-b9253b6f5d20). Read our [contributing guidelines]([[config:repo]]/blob/v[[config:current_version]]-ouds-web/.github/CONTRIBUTING.md) for information on how we develop.
 
 <Callout type="info">
 ## Bootstrap team


### PR DESCRIPTION
### Related issues

Closes #

### Description

- hide search icon in header
- add contacts (discussion and Teams) in footer and team page

### Checklists

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/>
