### PR TITLE
fix(docs): Add aliases and typos to dual mode page

### DIFF
--- a/site/src/content/docs/dual-mode.mdx
+++ b/site/src/content/docs/dual-mode.mdx
@@ -1,15 +1,17 @@
 ---
-title: Dual mode explanation
+title: Dual Mode explanation
 description: This is a tutorial for the dual-mode using Boosted and OUDS Web.
 aliases:
   - "/docs/[[config:docs_version]]/bi-mode/"
+  - "/docs/dual-mode/"
   - "/dual-mode/"
+  - "/bi-mode/"
 toc: true
 ---
 
 ## Preamble
 
-Dual-mode is a way to early and gradually migrate a Boosted project to OUDS.
+Dual-Mode is a way to early and gradually migrate a Boosted project to OUDS.
 
 This page is for people that want to try the dual-mode combining Boosted and OUDS Web. It also works as a tutorial to implement OUDS Web gradually inside your website. Be careful, we will support this in a “best-effort” way ; this feature is supposed to be mainly used by pre-selected projects. If you need any assistance, please [contact us]([[docsref:/about/team]]).
 This page is not to be used alone, but is complementary to [OUDS Web documentation](https://web.unified-design-system.orange.com/) and [Boosted documentation](https://boosted.orange.com/).


### PR DESCRIPTION
### Related issues

Closes #3331.

### Description

Add the aliases that where previously here.
Change the Dual Mode typos to be aligned.

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [x] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3354--boosted.netlify.app/bi-mode>
- <https://deploy-preview-3354--boosted.netlify.app/docs/dual-mode>