### PR TITLE
fix(doc): correct bg color on position utilities examples

### DIFF
--- a/site/src/scss/_component-examples.scss
+++ b/site/src/scss/_component-examples.scss
@@ -306,7 +306,7 @@
   .position-absolute {
     width: 2rem;
     height: 2rem;
-    background-color: var(--#{$prefix}color-bg-emphasized);
+    background-color: var(--#{$prefix}color-bg-inverse-high);
     @include border-radius();
   }
 }


### PR DESCRIPTION
### Related issues

Closes #3359

### Description

Use right custom prop for position utilities example

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3379--boosted.netlify.app/>