### PR TITLE
ci: remove coveralls as a failing step

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -53,3 +53,4 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           path-to-lcov: "./js/coverage/lcov.info"
+          fail-on-error: false


### PR DESCRIPTION
Add an option for coveralls so the CI is not failing if this step is in error.