### PR TITLE
feat(docs): add paragraph on label font size in Typography

### DIFF
--- a/site/src/content/docs/foundation/typography.mdx
+++ b/site/src/content/docs/foundation/typography.mdx
@@ -490,7 +490,7 @@ Align terms and descriptions horizontally by using our grid system’s predefine
 
 ## Text style for custom components
 
-OUDS Web introduces a specific text style for components named `label` with 4 levels: `small`, `medium`, `large` and `xlarge`, it sets `font-size`, `line-height` and `letter-spacing` css properties. We use this style for many components included in OUDS Web, if you need to develop a custom component for your project you can use this font by calling the Scss mixin `get-font-size()`. Following is an call example for this mixin.
+OUDS Web introduces a specific text style for components named `label` with 4 levels: `small`, `medium`, `large` and `xlarge`, it sets `font-size`, `line-height` and `letter-spacing` css properties. We use this style for many components included in OUDS Web, if you need to develop a custom component for your project you can use this font by calling the Scss mixin `get-font-size()`. Following is a call example for this mixin.
 
 <Example showPreview={false}  lang="scss" code={`.my-custom-component {
     @include get-font-size("label-medium");


### PR DESCRIPTION
### Related issues

Closes #3313

### Description

See issue

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3400--boosted.netlify.app/>