### PR TITLE
fix(docs): right data-bs-theme on light static context in background utilities page

### DIFF
--- a/site/src/content/docs/utilities/background.mdx
+++ b/site/src/content/docs/utilities/background.mdx
@@ -108,7 +108,7 @@ Here is a more complex example to understand how to use `[data-bs-theme]` in spe
         const themesArray = allTokens.filter(allToken => {
           return allToken.name.match(`modes-on-(bg-)?${bgName}-(dark|light)`)
         }).map(token => token.compiledValue)
-        const theme = themesArray[0].includes('light')
+        const theme = themesArray[1].includes('light')
           ? 'light'
           : 'dark'
         return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'light' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'light' ? '</span>' : ''}</p>`
@@ -120,7 +120,7 @@ Here is a more complex example to understand how to use `[data-bs-theme]` in spe
         const themesArray = allTokens.filter(allToken => {
           return allToken.name.match(`modes-on-(surface-)?${surfaceName}-(dark|light)`)
         }).map(token => token.compiledValue)
-        const theme = themesArray[0].includes('light')
+        const theme = themesArray[1].includes('light')
           ? 'light'
           : 'dark'
         return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'light' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'light' ? '</span>' : ''}</p>`


### PR DESCRIPTION
### Related issues

Closes #3403

### Description

Use the right mode on background utilities in light static context

### Checklists

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3409--boosted.netlify.app/>