### PR TITLE
fix: add a11y on changelog link in components versioning page

### DIFF
--- a/site/src/content/docs/getting-started/component-versioning.mdx
+++ b/site/src/content/docs/getting-started/component-versioning.mdx
@@ -40,7 +40,7 @@ You can find [the components matrix here](https://unified-design-system.orange.c
           </td>
           <td>
             {component.version.value} (<a href={`https://r.orange.fr/r/S-ouds-doc-${component.slug ?? component.name.toLowerCase()}_changelog`}>
-              changelog
+              changelog<span class="visually-hidden">for {component.name}</span>
             </a>)
           </td>
         </tr>


### PR DESCRIPTION
### Related issues

Closes #3414

### Description

Add a hidden text on changelog link in versioning page

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [x] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3416--boosted.netlify.app/>