### PR TITLE
fix(docs): Update charts library URL

### DIFF
--- a/site/src/pages/resources.astro
+++ b/site/src/pages/resources.astro
@@ -55,7 +55,7 @@ export function getStaticPaths() {
           <img src={`/${getConfig().brand}/docs/${getConfig().docs_version}/assets/img/ouds-web-home-desktop.png`} alt="" class="w-100" />
         </div>
         <div class="card-body">
-          <a href="https://ods-charts.netlify.app/" target="_blank" rel="noopener" class="stretched-link">
+          <a href="https://charts.unified-design-system.orange.com/" target="_blank" rel="noopener" class="stretched-link">
             Charts library
           </a>
         </div>


### PR DESCRIPTION
### Related issues

NA

### Description

Update the ODS Charts library link the actual one.

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [x] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3432--boosted.netlify.app/resources>