### PR TITLE
feat(docs): add some docs CSS to examples

### DIFF
--- a/site/src/assets/examples/loading-buttons/index.astro
+++ b/site/src/assets/examples/loading-buttons/index.astro
@@ -112,7 +112,7 @@ export const aliases = [
         </button>
       </h2>
       <div id="collapseOne" class="accordion-collapse collapse" data-bs-parent="#code-accordion">
-        <div class="accordion-body border border-subtle p-none">
+        <div class="accordion-body p-none mt-large mb-scaled-3xlarge">
           <JsDocs name="live-loading-buttons" file="site/src/assets/examples/loading-buttons/loading-buttons.js" />
         </div>
       </div>

--- a/site/src/assets/examples/loading-buttons/loading-buttons.css
+++ b/site/src/assets/examples/loading-buttons/loading-buttons.css
@@ -1,15 +1,3 @@
 .accordion-item {
   max-width: 55rem;
 }
-
-.accordion-body {
-  margin-bottom: 5rem;
-}
-
-.accordion-body .highlight {
-  padding: 24px 24px 0;
-}
-
-.accordion-collapse {
-  background-color: var(--bs-color-bg-secondary);
-}

--- a/site/src/layouts/ExamplesLayout.astro
+++ b/site/src/layouts/ExamplesLayout.astro
@@ -44,6 +44,19 @@ const htmlProps: HTMLAttributes<'html'> = direction === 'rtl' ? { lang: 'ar', di
     <Stylesheet direction={direction} layout="examples" />
     <Favicons />
 
+    <style is:global lang="scss">
+      @import '../../../scss/config';
+      @import '../../../scss/functions';
+      @import '../../../packages/orange/scss/tokens';
+      @import '../../../scss/variables';
+      @import '../../../scss/variables-dark';
+      @import '../../../scss/maps';
+      @import '../../../scss/mixins';
+      @import '../scss/variables';
+      @import '../scss/component-examples';
+      @import '../scss/syntax';
+    </style>
+
     <style is:global>
       .bd-placeholder-img {
         font-size: 1.125rem;


### PR DESCRIPTION
### Related issues

NA

### Description

Add a way to document and color our code in our examples.

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [x] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3434--boosted.netlify.app/docs/examples/loading-buttons>