### PR TITLE
fix(docs): textarea resizer position

### DIFF
--- a/site/data/components-details.ts
+++ b/site/data/components-details.ts
@@ -222,7 +222,7 @@ export const componentsDetails: ComponentCardData[] = [
       <div class="text-area w-75 h-75">
         <div class="text-area-container h-100">
           <label for="exampleTextArea[[id_prefix]]">Label</label>
-          <textarea class="text-area-field h-100" id="exampleTextArea[[id_prefix]]"></textarea>
+          <textarea class="text-area-field h-100" id="exampleTextArea[[id_prefix]]" style="min-height: unset"></textarea>
         </div>
       </div>`
   },


### PR DESCRIPTION
### Description

Text area 's `textarea` default `min-height` gets in the way of the relative heights user on `.text-area` and `.text-area-container` in components list on some viewport dimensions.

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [x] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3435--boosted.netlify.app/components>
