### PR TITLE
fix: prevent browser password saving on component list

### DIFF
--- a/site/data/components-details.ts
+++ b/site/data/components-details.ts
@@ -133,20 +133,22 @@ export const componentsDetails: ComponentCardData[] = [
     slug: 'password-input',
     category: 'Control',
     snippet: `
-      <div class="text-input w-75">
-        <div class="text-input-container" style="min-width: unset">
-          <label for="passwordInput[[id_prefix]]">Label</label>
-          <div class="input-container">
-            <input type="password" id="passwordInput[[id_prefix]]" class="text-input-field" placeholder=" " value="xxxxxx">
+      <form class="w-75">
+        <div class="text-input">
+          <div class="text-input-container" style="min-width: unset">
+            <label for="passwordInput[[id_prefix]]">Label</label>
+            <div class="input-container">
+              <input type="password" id="passwordInput[[id_prefix]]" class="text-input-field" placeholder=" " value="xxxxxx">
+            </div>
+            <button class="btn btn-minimal btn-icon">
+              <svg aria-hidden="true">
+                <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#accessibility-vision')}"/>
+              </svg>
+              <span class="visually-hidden">Show password</span>
+            </button>
           </div>
-          <button class="btn btn-minimal btn-icon">
-            <svg aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#accessibility-vision')}"/>
-            </svg>
-            <span class="visually-hidden">Show password</span>
-          </button>
         </div>
-      </div>`
+      </form>` // form element is used here to prevent the browser from asking to save the password when leaving the page
   },
   {
     name: 'Radio button',


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

Closes #3450

### Context & Motivation

Adding a form element around the password field, make the browser stop from thinking the password was sent when navigating to another page.

### Checklists

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change pass all tests
- [ ] My change is compatible with a responsive display
- [ ] I have added tests (Javascript unit test or visual) to cover my changes
- [ ] My change introduces changes to the documentation that I have updated accordingly
  - [ ] Title and DOM structure is correct
  - [ ] Links have been updated (title changes impact links)
  - [ ] CSS for the documentation
- [ ] I have checked all states and combinations of the component with my change
- [ ] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [ ] The changes need to be in the migration guide
- [ ] The changes are well displayed in [Storybook](https://deploy-preview-3451--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [ ] The changes are compatible with RTL
- [ ] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3451--boosted.netlify.app/>