### PR TITLE
fix(lib): change tag min-width

### DIFF
--- a/packages/orange-compact/scss/tokens/_component.scss
+++ b/packages/orange-compact/scss/tokens/_component.scss
@@ -405,8 +405,8 @@ $ouds-tag-size-asset-small: $ouds-size-icon-with-label-small-size-small !default
 $ouds-tag-size-min-height-default: $ouds-dimension-xsmall !default;
 $ouds-tag-size-min-height-interactive-area: $ouds-size-min-interactive-area !default;
 $ouds-tag-size-min-height-small: $ouds-dimension-3xsmall !default;
-$ouds-tag-size-min-width-default: $ouds-dimension-xlarge !default;
-$ouds-tag-size-min-width-small: $ouds-dimension-large !default;
+$ouds-tag-size-min-width-default: $ouds-dimension-xsmall !default; // Manually changed to take design decision in advance
+$ouds-tag-size-min-width-small: $ouds-dimension-2xsmall !default; // Manually changed to take design decision in advance
 $ouds-tag-space-column-gap-default: $ouds-space-column-gap-2xsmall !default;
 $ouds-tag-space-column-gap-small: $ouds-space-column-gap-2xsmall !default;
 $ouds-tag-space-inset-bullet-default: $core-ouds-dimension-out-of-system-75 !default;

--- a/packages/orange/scss/tokens/_component.scss
+++ b/packages/orange/scss/tokens/_component.scss
@@ -405,8 +405,8 @@ $ouds-tag-size-asset-small: $ouds-size-icon-with-label-small-size-small !default
 $ouds-tag-size-min-height-default: $ouds-dimension-xsmall !default;
 $ouds-tag-size-min-height-interactive-area: $ouds-size-min-interactive-area !default;
 $ouds-tag-size-min-height-small: $ouds-dimension-3xsmall !default;
-$ouds-tag-size-min-width-default: $ouds-dimension-xlarge !default;
-$ouds-tag-size-min-width-small: $ouds-dimension-large !default;
+$ouds-tag-size-min-width-default: $ouds-dimension-xsmall !default; // Manually changed to take design decision in advance
+$ouds-tag-size-min-width-small: $ouds-dimension-3xsmall !default; // Manually changed to take design decision in advance
 $ouds-tag-space-column-gap-default: $ouds-space-column-gap-2xsmall !default;
 $ouds-tag-space-column-gap-small: $ouds-space-column-gap-2xsmall !default;
 $ouds-tag-space-inset-bullet-default: $core-ouds-dimension-out-of-system-75 !default;

--- a/packages/sosh/scss/tokens/_component.scss
+++ b/packages/sosh/scss/tokens/_component.scss
@@ -405,8 +405,8 @@ $ouds-tag-size-asset-small: $ouds-size-icon-with-label-small-size-small !default
 $ouds-tag-size-min-height-default: $ouds-dimension-xsmall !default;
 $ouds-tag-size-min-height-interactive-area: $ouds-size-min-interactive-area !default;
 $ouds-tag-size-min-height-small: $ouds-dimension-3xsmall !default;
-$ouds-tag-size-min-width-default: $ouds-dimension-xlarge !default;
-$ouds-tag-size-min-width-small: $ouds-dimension-large !default;
+$ouds-tag-size-min-width-default: $ouds-dimension-xsmall !default; // Manually changed to take design decision in advance
+$ouds-tag-size-min-width-small: $ouds-dimension-3xsmall !default; // Manually changed to take design decision in advance
 $ouds-tag-space-column-gap-default: $ouds-space-column-gap-2xsmall !default;
 $ouds-tag-space-column-gap-small: $ouds-space-column-gap-2xsmall !default;
 $ouds-tag-space-inset-bullet-default: $core-ouds-dimension-out-of-system-75 !default;

--- a/site/src/content/docs/foundation/colors.mdx
+++ b/site/src/content/docs/foundation/colors.mdx
@@ -232,6 +232,6 @@ export const opacityBackgroundStyle = "repeating-conic-gradient(var(--bs-color-b
 
 ## Decorative
 
-<Callout type="info" title="Coming soon">
-  Decorative colors are not yet implemented in OUDS Web.
+<Callout type="info" title="For design only">
+  Decorative colors are used for illustrations design purpose only, they should not be needed in OUDS Web. Please contact us if you need to use it in your project.
 </Callout>

--- a/site/src/content/docs/foundation/colors.mdx
+++ b/site/src/content/docs/foundation/colors.mdx
@@ -233,5 +233,5 @@ export const opacityBackgroundStyle = "repeating-conic-gradient(var(--bs-color-b
 ## Decorative
 
 <Callout type="info" title="For design only">
-  Decorative colors are used for illustrations design purpose only, they should not be needed in OUDS Web. Please contact us if you need to use it in your project.
+  Decorative colors are used for coloring illustrations only and should not be needed in OUDS Web. Please contact us if you need to use them in your project.
 </Callout>

--- a/site/src/content/docs/getting-started/migration.mdx
+++ b/site/src/content/docs/getting-started/migration.mdx
@@ -35,7 +35,7 @@ toc: true
 
 #### Colors
 
-- <span class="tag tag-small rounded-none tag-positive">New</span> We replaced the color palette page with a new and improved colors page, it lists all existing semantic colors available in OUDS Web. Read more in our [colors page]([[docsref:/foundation/colors]]).
+- <span class="tag tag-small tag-positive">New</span> We replaced the color palette page with a new and improved colors page, it lists all existing semantic colors available in OUDS Web. Read more in our [colors page]([[docsref:/foundation/colors]]).
 
 ### Dual mode
 


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

NA

### Context & Motivation

Be updated before the token are delivered.
Fix the doc

### Description

The min-width of the tag is too high for short text. Validated with lead designers, limit will evolve in next token release with the following values : 
- for Orange and Sosh : 32px in regular version, 24px in small (like the component height)
- for Orange Compact : 28px in regular version, 24px in small (like the component height)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3516--boosted.netlify.app/>
