### PR TITLE
Update Chips to 1.4.0

### DIFF
--- a/scss/_chips.scss
+++ b/scss/_chips.scss
@@ -87,8 +87,8 @@
   svg,
   img,
   .icon {
-    width: 1em;
-    height: 1em;
+    width: $ouds-chip-size-icon;
+    height: $ouds-chip-size-icon;
     overflow: hidden;
     font-size: $ouds-chip-size-icon;
     line-height: 1;
@@ -195,6 +195,8 @@
   svg,
   img,
   .icon {
+    width: px-to-rem($ouds-chip-size-icon);
+    height: px-to-rem($ouds-chip-size-icon);
     font-size: px-to-rem($ouds-chip-size-icon);
   }
 }

--- a/scss/_chips.scss
+++ b/scss/_chips.scss
@@ -42,7 +42,7 @@
   min-height: $ouds-chip-size-min-height;
   padding: calc(var(--#{$prefix}chip-padding-block) - var(--#{$prefix}chip-border-width)) calc(var(--#{$prefix}chip-padding-end) - var(--#{$prefix}chip-border-width)) calc(var(--#{$prefix}chip-padding-block) - var(--#{$prefix}chip-border-width)) calc(var(--#{$prefix}chip-padding-start) - var(--#{$prefix}chip-border-width));
   @include get-font-size("label-medium");
-  font-weight: 700;
+  font-weight: 500;
   color: var(--#{$prefix}chip-color);
   background-color: var(--#{$prefix}chip-bg);
   border: var(--#{$prefix}chip-border-width) solid var(--#{$prefix}chip-border-color);


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

Closes #3539

### Context & Motivation

Tokens update to 2.4.0

### Description

- The text reference of the label changes from a bold weight (font-weight-label-strong) to a medium weight (font-weight-label-moderate).
- Change decorative icon size to px not to grow when text is zoomed

### Checklists

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change pass all tests
- [ ] My change is compatible with a responsive display
- [ ] I have added tests (Javascript unit test or visual) to cover my changes
- [ ] My change introduces changes to the documentation that I have updated accordingly
  - [ ] Title and DOM structure is correct
  - [ ] Links have been updated (title changes impact links)
  - [ ] CSS for the documentation
- [ ] I have checked all states and combinations of the component with my change
- [ ] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [ ] The changes need to be in the migration guide
- [ ] The changes are well displayed in [Storybook](https://deploy-preview-{your_pr_number}--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [ ] The changes are compatible with RTL
- [ ] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--boosted.netlify.app/docs/components/chips>
