### PR TITLE
fix(docs): some tags were without icons in migration

### DIFF
--- a/site/src/content/docs/getting-started/migration.mdx
+++ b/site/src/content/docs/getting-started/migration.mdx
@@ -65,7 +65,7 @@ toc: true
 
 #### Chips
 
-- <span class="tag tag-small rounded-none tag-warning">Warning</span> Since filter and suggestion chips can be used inside forms, the chips buttons should have the `type="button"` attribute. We have added this to our examples. Read more in our [chips page]([[docsref:/components/chips]]).
+- <span class="tag tag-small tag-warning"><span class="tag-status-icon"></span>Warning</span> Since filter and suggestion chips can be used inside forms, the chips buttons should have the `type="button"` attribute. We have added this to our examples. Read more in our [chips page]([[docsref:/components/chips]]).
 
 #### Footer
 
@@ -81,8 +81,8 @@ toc: true
 
 #### Password input
 
-- <span class="tag tag-small rounded-none tag-warning">Warning</span> Since password inputs are usually used inside forms, the "show password" button should have the `type="button"` attribute. We have added this to our examples. Read more in our [password input page]([[docsref:/components/password-input]]).
-- <span class="tag tag-small rounded-none tag-positive">New</span> A new live example about how to handle show/hide password buttons has been added. Read more in our [password input page]([[docsref:/components/password-input#live-example]]).
+- <span class="tag tag-small tag-warning"><span class="tag-status-icon"></span>Warning</span> Since password inputs are usually used inside forms, the "show password" button should have the `type="button"` attribute. We have added this to our examples. Read more in our [password input page]([[docsref:/components/password-input]]).
+- <span class="tag tag-small tag-positive"><span class="tag-status-icon"></span>New</span> A new live example about how to handle show/hide password buttons has been added. Read more in our [password input page]([[docsref:/components/password-input#live-example]]).
 
 #### Skeleton
 
@@ -90,7 +90,7 @@ toc: true
 
 #### Text input
 
-- <span class="tag tag-small rounded-none tag-warning">Warning</span> Since text inputs are usually used inside forms, the trailing action button should have the `type="button"` attribute. We have added this to our examples. Read more in our [text input page]([[docsref:/components/text-input]]).
+- <span class="tag tag-small tag-warning"><span class="tag-status-icon"></span>Warning</span> Since text inputs are usually used inside forms, the trailing action button should have the `type="button"` attribute. We have added this to our examples. Read more in our [text input page]([[docsref:/components/text-input]]).
 
 ### Foundations
 


### PR DESCRIPTION

### Description

Fix some tags in migration that were not rounded with an icon

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3578--boosted.netlify.app/>