### PR TITLE
feat: update text input to 1.4 select input to 1.3 and password input to 1.3

### DIFF
--- a/scss/forms/_labels.scss
+++ b/scss/forms/_labels.scss
@@ -18,7 +18,7 @@
 
 .is-required::after {
   position: absolute;
-  margin-left: 4px;
+  margin-left: $ouds-text-input-space-column-gap-label-asterisk;
   font-weight: $ouds-font-weight-system-web-strong;
   color: $ouds-color-content-status-negative;
   content: "*";

--- a/scss/forms/_text-input.scss
+++ b/scss/forms/_text-input.scss
@@ -207,11 +207,12 @@
           position: relative;
           width: fit-content;
           max-width: 100%;
-          padding-right: 7px;
+          // 5px is the width of the asterisk
+          padding-right: calc(5px + $ouds-text-input-space-column-gap-label-small-asterisk);
 
           &::after {
             right: 0;
-            margin-left: 3px;
+            margin-left: $ouds-text-input-space-column-gap-label-small-asterisk;
           }
         }
       }

--- a/site/data/_components-versions.yml
+++ b/site/data/_components-versions.yml
@@ -51,7 +51,7 @@
 - name: 'radio-button'
   value: '1.4.0'
 - name: 'select-input'
-  value: '1.3.0'
+  value: '1.2.0'
 - name: 'skeleton'
   value: '1.0.0'
 - name: 'suggestion-chip'


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

Closes #3538 #3536 #3537  

### Context & Motivation

Tokens update to 2.4.0

### Description

- Use new tokens for the label's star spacing (for `.is-required` fields)

### Checklists

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change pass all tests
- [x] My change is compatible with a responsive display
- [ ] I have added tests (Javascript unit test or visual) to cover my changes
- [ ] My change introduces changes to the documentation that I have updated accordingly
  - [ ] Title and DOM structure is correct
  - [ ] Links have been updated (title changes impact links)
  - [ ] CSS for the documentation
- [ ] I have checked all states and combinations of the component with my change
- [ ] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [ ] The changes need to be in the migration guide
- [ ] The changes are well displayed in [Storybook](https://deploy-preview-3576--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [ ] The changes are compatible with RTL
- [ ] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3576--boosted.netlify.app/docs/components/badges>
