### PR TITLE
feat(docs): reorder states and layout sections in components documentation

### DIFF
--- a/site/data/sidebar-getting-started.yml
+++ b/site/data/sidebar-getting-started.yml
@@ -10,7 +10,6 @@
     - title: Browsers & devices
     - title: Accessibility
     - title: Sass
-      coming_soon: true
     - title: JavaScript
     - title: Optimize
       coming_soon: true

--- a/site/src/content/docs/components/checkbox.mdx
+++ b/site/src/content/docs/components/checkbox.mdx
@@ -305,7 +305,7 @@ To display an invalid checkbox, add `.is-invalid` to a `.form-check-input`.
 
 #### Horizontal
 
-If the layout is horizontal, the `<fieldset>` must enclose the flex containers so the error message is displayed under the first item.
+If the [layout is horizontal](#horizontal-1), the `<fieldset>` must enclose the flex containers so the error message is displayed under the first item.
 
 <Example buttonLabel="invalid checkboxes in an horizontal layout" code={`<fieldset class="control-items-list">
     <div class="d-flex flex-row gap-small w-50">

--- a/site/src/content/docs/components/checkbox.mdx
+++ b/site/src/content/docs/components/checkbox.mdx
@@ -152,204 +152,6 @@ To display a description text, add a `.control-item-description` as a sibling of
     </div>
   </fieldset>`} />
 
-## Layout
-
-### Default
-
-It's recommended to keep checkbox label to no more than three words. When space is limited or when a long label or description text is required, the text can wrap, as this is preferable to truncation. The checkbox indicator and the icon will remain vertically centered, until the `.control-item-assets-container` reaches a defined maximum height.
-
-<Example buttonLabel="checkboxes with long texts" code={`<div class="row">
-    <div class="col-8 md:col-6 xl:col-5">
-      <fieldset class="control-items-list">
-        <div class="checkbox-item control-item-divider">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayout1" aria-describedby="checkboxLayout1Description" />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="checkboxLayout1">Label</label>
-            <p class="control-item-description" id="checkboxLayout1Description">Description text</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </div>
-        <div class="checkbox-item control-item-divider">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayout2" aria-describedby="checkboxLayout2Description" />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="checkboxLayout2">A short label</label>
-            <p class="control-item-description" id="checkboxLayout2Description">A longer description text that can wrap to another line to show the behaviour</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </div>
-        <div class="checkbox-item control-item-divider">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayout3" aria-describedby="checkboxLayout3Description" checked />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="checkboxLayout3">A longer label for showing behavior in this case, checkbox indicator and icon will stick to the top area of the component</label>
-            <p class="control-item-description" id="checkboxLayout3Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-  </div>`} />
-
-### Reverse
-
-To reverse the component, simply add `.control-item-reverse` to a `.checkbox-item`.
-
-<Example buttonLabel="reversed checkboxes" code={`<div class="row">
-    <div class="col-8 md:col-6 xl:col-5">
-      <fieldset class="control-items-list">
-        <div class="checkbox-item control-item-divider control-item-reverse">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayoutRev1" aria-describedby="checkboxLayoutRev1Description" />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="checkboxLayoutRev1">Label with reverse layout</label>
-            <p class="control-item-description" id="checkboxLayoutRev1Description">Description text</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </div>
-        <div class="checkbox-item control-item-divider control-item-reverse">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayoutRev2" aria-describedby="checkboxLayoutRev2Description" checked />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="checkboxLayoutRev2">A longer label with reverse layout for showing behavior in this case, checkbox indicator and icon will stick to the top area of the component</label>
-            <p class="control-item-description" id="checkboxLayoutRev2Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-  </div>`} />
-
-<BootstrapCompatibility>
-
-Put your checkboxes on the opposite side with the `.form-check-reverse` modifier class.
-
-<Example buttonLabel="Bootstrap compatibility: reversed checkboxes" code={`<div class="form-check form-check-reverse">
-    <input class="form-check-input" type="checkbox" value="" id="reverseCheck" checked />
-    <label class="form-check-label" for="reverseCheck">
-      Checked reverse checkbox (Bootstrap compatible)
-    </label>
-  </div>`} />
-</BootstrapCompatibility>
-
-### Horizontal
-
-You can align horizontally up to three checkboxes if their labels are short, add sufficient space (for example by using `.gap-small`) between the controls to ensure a clear association of each labels with their corresponding indicator.
-
-<Example buttonLabel="horizontal checkboxes" code={`<fieldset class="control-items-list">
-    <div class="lg:d-flex flex-row gap-small">
-      <div class="checkbox-item flex-fill">
-        <div class="control-item-assets-container">
-          <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayoutRow1" />
-        </div>
-        <div class="control-item-text-container">
-          <label class="control-item-label" for="checkboxLayoutRow1">Option 1</label>
-        </div>
-      </div>
-      <div class="checkbox-item flex-fill">
-        <div class="control-item-assets-container">
-          <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayoutRow2" checked />
-        </div>
-        <div class="control-item-text-container">
-          <label class="control-item-label" for="checkboxLayoutRow2">Option 2</label>
-        </div>
-      </div>
-      <div class="checkbox-item flex-fill">
-        <div class="control-item-assets-container">
-          <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayoutRow3" checked />
-        </div>
-        <div class="control-item-text-container">
-          <label class="control-item-label" for="checkboxLayoutRow3">Option 3</label>
-        </div>
-      </div>
-    </div>
-  </fieldset>`} />
-
-### Max width
-
-By default, checkboxes will span the whole width of their parent container, to limit the width of the checkbox on wider parent container, add a `.component-max-width` to the `.checkbox-item` container. More information on checkbox sizing in the [design guidelines](https://r.orange.fr/r/S-ouds-doc-checkbox-responsiveness).
-
-<Example buttonLabel="checkboxes max width" code={`<fieldset class="control-items-list">
-    <div class="checkbox-item component-max-width">
-      <div class="control-item-assets-container">
-        <input class="control-item-indicator" type="checkbox" aria-describedby="checkboxMWDescription" id="checkboxWithMaxWidth" value="" />
-      </div>
-      <div class="control-item-text-container">
-        <label class="control-item-label" for="checkboxWithMaxWidth">Default checkbox</label>
-        <p class="control-item-description" id="checkboxMWDescription">Description text</p>
-      </div>
-    </div>
-    <div class="checkbox-item component-max-width">
-      <div class="control-item-assets-container">
-        <input class="control-item-indicator" type="checkbox" aria-describedby="checkboxWithMaxWidth2Description" id="checkboxWithMaxWidth2" value="" checked />
-      </div>
-      <div class="control-item-text-container">
-        <label class="control-item-label" for="checkboxWithMaxWidth2">Checked checkbox</label>
-        <p class="control-item-description" id="checkboxWithMaxWidth2Description">Description text</p>
-      </div>
-    </div>
-  </fieldset>`} />
-
-## Indeterminate
-
-This is often used to indicate a partial selection within a group of choices. For instance, in a nested (hierarchical) list, a parent checkbox can be indeterminate if some, but not all, sub-options are selected. [Learn more about nesting in the design guidelines](https://r.orange.fr/r/S-ouds-doc-checkbox-indeterminate).
-
-Users cannot set a checkbox as indeterminate directly. This must be calculated by the system and set via JavaScript (there is no available HTML attribute available for specifying it). Then, checkboxes use the `:indeterminate` pseudo class for styling.
-
-Indeterminate state can be used in conjunction with all the other states below.
-
-<Example buttonLabel="indeterminate checkbox" class="bd-example-indeterminate" addStackblitzJs code={`<fieldset class="control-items-list">
-    <div class="checkbox-item">
-      <div class="control-item-assets-container">
-        <input class="control-item-indicator" type="checkbox" value="" id="checkboxIndeterminate" />
-      </div>
-      <div class="control-item-text-container">
-        <label class="control-item-label" for="checkboxIndeterminate">Indeterminate checkbox</label>
-      </div>
-    </div>
-  </fieldset>`} />
-
-Here is the associated JavaScript to set a checkbox as indeterminate.
-
-<Code buttonLabel="JavaScript to set a checkbox as indeterminate" lang="js" code={`const checkbox = document.getElementById('checkboxIndeterminate')
-
-  checkbox.indeterminate = true`} />
-
-<BootstrapCompatibility>
-  <Example buttonLabel="Bootstrap compatibility: indeterminate checkbox" class="bd-example-indeterminate" addStackblitzJs code={`<div class="form-check">
-    <input class="form-check-input" type="checkbox" value="" id="checkIndeterminate" />
-    <label class="form-check-label" for="checkIndeterminate">
-      Indeterminate checkbox (Bootstrap compatible)
-    </label>
-  </div>`} />
-</BootstrapCompatibility>
-
 ## States
 
 ### Disabled
@@ -593,6 +395,204 @@ If you have a checkbox that is not part of a group but needs validation control,
       </div>
     </div>
   </div>`} />
+
+## Layout
+
+### Default
+
+It's recommended to keep checkbox label to no more than three words. When space is limited or when a long label or description text is required, the text can wrap, as this is preferable to truncation. The checkbox indicator and the icon will remain vertically centered, until the `.control-item-assets-container` reaches a defined maximum height.
+
+<Example buttonLabel="checkboxes with long texts" code={`<div class="row">
+    <div class="col-8 md:col-6 xl:col-5">
+      <fieldset class="control-items-list">
+        <div class="checkbox-item control-item-divider">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayout1" aria-describedby="checkboxLayout1Description" />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="checkboxLayout1">Label</label>
+            <p class="control-item-description" id="checkboxLayout1Description">Description text</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </div>
+        <div class="checkbox-item control-item-divider">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayout2" aria-describedby="checkboxLayout2Description" />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="checkboxLayout2">A short label</label>
+            <p class="control-item-description" id="checkboxLayout2Description">A longer description text that can wrap to another line to show the behaviour</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </div>
+        <div class="checkbox-item control-item-divider">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayout3" aria-describedby="checkboxLayout3Description" checked />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="checkboxLayout3">A longer label for showing behavior in this case, checkbox indicator and icon will stick to the top area of the component</label>
+            <p class="control-item-description" id="checkboxLayout3Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>`} />
+
+### Reverse
+
+To reverse the component, simply add `.control-item-reverse` to a `.checkbox-item`.
+
+<Example buttonLabel="reversed checkboxes" code={`<div class="row">
+    <div class="col-8 md:col-6 xl:col-5">
+      <fieldset class="control-items-list">
+        <div class="checkbox-item control-item-divider control-item-reverse">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayoutRev1" aria-describedby="checkboxLayoutRev1Description" />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="checkboxLayoutRev1">Label with reverse layout</label>
+            <p class="control-item-description" id="checkboxLayoutRev1Description">Description text</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </div>
+        <div class="checkbox-item control-item-divider control-item-reverse">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayoutRev2" aria-describedby="checkboxLayoutRev2Description" checked />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="checkboxLayoutRev2">A longer label with reverse layout for showing behavior in this case, checkbox indicator and icon will stick to the top area of the component</label>
+            <p class="control-item-description" id="checkboxLayoutRev2Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>`} />
+
+<BootstrapCompatibility>
+
+Put your checkboxes on the opposite side with the `.form-check-reverse` modifier class.
+
+<Example buttonLabel="Bootstrap compatibility: reversed checkboxes" code={`<div class="form-check form-check-reverse">
+    <input class="form-check-input" type="checkbox" value="" id="reverseCheck" checked />
+    <label class="form-check-label" for="reverseCheck">
+      Checked reverse checkbox (Bootstrap compatible)
+    </label>
+  </div>`} />
+</BootstrapCompatibility>
+
+### Horizontal
+
+You can align horizontally up to three checkboxes if their labels are short, add sufficient space (for example by using `.gap-small`) between the controls to ensure a clear association of each labels with their corresponding indicator.
+
+<Example buttonLabel="horizontal checkboxes" code={`<fieldset class="control-items-list">
+    <div class="lg:d-flex flex-row gap-small">
+      <div class="checkbox-item flex-fill">
+        <div class="control-item-assets-container">
+          <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayoutRow1" />
+        </div>
+        <div class="control-item-text-container">
+          <label class="control-item-label" for="checkboxLayoutRow1">Option 1</label>
+        </div>
+      </div>
+      <div class="checkbox-item flex-fill">
+        <div class="control-item-assets-container">
+          <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayoutRow2" checked />
+        </div>
+        <div class="control-item-text-container">
+          <label class="control-item-label" for="checkboxLayoutRow2">Option 2</label>
+        </div>
+      </div>
+      <div class="checkbox-item flex-fill">
+        <div class="control-item-assets-container">
+          <input class="control-item-indicator" type="checkbox" value="" id="checkboxLayoutRow3" checked />
+        </div>
+        <div class="control-item-text-container">
+          <label class="control-item-label" for="checkboxLayoutRow3">Option 3</label>
+        </div>
+      </div>
+    </div>
+  </fieldset>`} />
+
+### Max width
+
+By default, checkboxes will span the whole width of their parent container, to limit the width of the checkbox on wider parent container, add a `.component-max-width` to the `.checkbox-item` container. More information on checkbox sizing in the [design guidelines](https://r.orange.fr/r/S-ouds-doc-checkbox-responsiveness).
+
+<Example buttonLabel="checkboxes max width" code={`<fieldset class="control-items-list">
+    <div class="checkbox-item component-max-width">
+      <div class="control-item-assets-container">
+        <input class="control-item-indicator" type="checkbox" aria-describedby="checkboxMWDescription" id="checkboxWithMaxWidth" value="" />
+      </div>
+      <div class="control-item-text-container">
+        <label class="control-item-label" for="checkboxWithMaxWidth">Default checkbox</label>
+        <p class="control-item-description" id="checkboxMWDescription">Description text</p>
+      </div>
+    </div>
+    <div class="checkbox-item component-max-width">
+      <div class="control-item-assets-container">
+        <input class="control-item-indicator" type="checkbox" aria-describedby="checkboxWithMaxWidth2Description" id="checkboxWithMaxWidth2" value="" checked />
+      </div>
+      <div class="control-item-text-container">
+        <label class="control-item-label" for="checkboxWithMaxWidth2">Checked checkbox</label>
+        <p class="control-item-description" id="checkboxWithMaxWidth2Description">Description text</p>
+      </div>
+    </div>
+  </fieldset>`} />
+
+## Indeterminate
+
+This is often used to indicate a partial selection within a group of choices. For instance, in a nested (hierarchical) list, a parent checkbox can be indeterminate if some, but not all, sub-options are selected. [Learn more about nesting in the design guidelines](https://r.orange.fr/r/S-ouds-doc-checkbox-indeterminate).
+
+Users cannot set a checkbox as indeterminate directly. This must be calculated by the system and set via JavaScript (there is no available HTML attribute available for specifying it). Then, checkboxes use the `:indeterminate` pseudo class for styling.
+
+Indeterminate state can be used in conjunction with all the other states below.
+
+<Example buttonLabel="indeterminate checkbox" class="bd-example-indeterminate" addStackblitzJs code={`<fieldset class="control-items-list">
+    <div class="checkbox-item">
+      <div class="control-item-assets-container">
+        <input class="control-item-indicator" type="checkbox" value="" id="checkboxIndeterminate" />
+      </div>
+      <div class="control-item-text-container">
+        <label class="control-item-label" for="checkboxIndeterminate">Indeterminate checkbox</label>
+      </div>
+    </div>
+  </fieldset>`} />
+
+Here is the associated JavaScript to set a checkbox as indeterminate.
+
+<Code buttonLabel="JavaScript to set a checkbox as indeterminate" lang="js" code={`const checkbox = document.getElementById('checkboxIndeterminate')
+
+  checkbox.indeterminate = true`} />
+
+<BootstrapCompatibility>
+  <Example buttonLabel="Bootstrap compatibility: indeterminate checkbox" class="bd-example-indeterminate" addStackblitzJs code={`<div class="form-check">
+    <input class="form-check-input" type="checkbox" value="" id="checkIndeterminate" />
+    <label class="form-check-label" for="checkIndeterminate">
+      Indeterminate checkbox (Bootstrap compatible)
+    </label>
+  </div>`} />
+</BootstrapCompatibility>
 
 ## Fieldset `<legend>`
 

--- a/site/src/content/docs/components/radio-button.mdx
+++ b/site/src/content/docs/components/radio-button.mdx
@@ -201,158 +201,6 @@ To display outlined radio buttons, add `.radio-button-item-outlined` to a `.radi
     </div>
   </fieldset>`} />
 
-## Layout
-
-### Default
-
-It's recommended to keep radio button label to no more than three words. When space is limited or when a long label, extra label or description text is required, the text can wrap, as this is preferable to truncation. The radio button indicator and the icon will remain vertically centered, until the `.control-item-assets-container` reaches a defined maximum height.
-
-<Example buttonLabel="radio buttons with long texts" code={`<div class="row">
-    <div class="col-8 md:col-6 xl:col-5">
-      <fieldset class="control-items-list">
-        <div class="radio-button-item control-item-divider">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="radio" value="" id="radioLayout1" name="radioLayout" aria-describedby="radioLayout1ExtraLabel radioLayout1Description" />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="radioLayout1">Label</label>
-            <p class="radio-button-extra-label" id="radioLayout1ExtraLabel">Extra label</p>
-            <p class="control-item-description" id="radioLayout1Description">Description text</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </div>
-        <div class="radio-button-item control-item-divider">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="radio" value="" id="radioLayout2" name="radioLayout"  aria-describedby="radioLayout2ExtraLabel radioLayout2Description" checked />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="radioLayout2">A longer label for showing behavior in this case</label>
-            <p class="radio-button-extra-label" id="radioLayout2ExtraLabel">Radio button indicator and icon will stick to the top area of the component</p>
-            <p class="control-item-description" id="radioLayout2Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-  </div>`} />
-
-### Reverse
-
-To reverse the component, simply add `.control-item-reverse` to a `.radio-button-item`.
-
-<Example buttonLabel="reversed radio buttons" code={`<div class="row">
-    <div class="col-8 md:col-6 xl:col-5">
-      <fieldset class="control-items-list">
-        <div class="radio-button-item control-item-divider control-item-reverse">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="radio" value="" id="radioLayoutRev1" name="radioLayoutRev" aria-describedby="radioLayoutRev1ExtraLabel radioLayoutRev1Description" />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="radioLayoutRev1">Label with reverse layout</label>
-            <p class="radio-button-extra-label" id="radioLayoutRev1ExtraLabel">Extra label</p>
-            <p class="control-item-description" id="radioLayoutRev1Description">Description text</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </div>
-        <div class="radio-button-item control-item-divider control-item-reverse">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="radio" value="" id="radioLayoutRev2" name="radioLayoutRev"  aria-describedby="radioLayoutRev2ExtraLabel radioLayoutRev2Description" checked />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="radioLayoutRev2">A longer label with reverse layout for showing behavior in this case</label>
-            <p class="radio-button-extra-label" id="radioLayoutRev2ExtraLabel">Radio button indicator and icon will stick to the top area of the component</p>
-            <p class="control-item-description" id="radioLayoutRev2Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-  </div>`} />
-
-<BootstrapCompatibility>
-
-Put your radio buttons on the opposite side with the `.form-check-reverse` modifier class.
-
-<Example buttonLabel="Bootstrap compatibility: reversed radio buttons" code={`<div class="form-check form-check-reverse">
-    <input class="form-check-input" type="radio" value="" id="reverseCheck1" name="radioReverseBs" />
-    <label class="form-check-label" for="reverseCheck1">
-      Default reverse radio button (Bootstrap compatible)
-    </label>
-  </div>
-  <div class="form-check form-check-reverse">
-    <input class="form-check-input" type="radio" value="" id="reverseCheck2" name="radioReverseBs" checked />
-    <label class="form-check-label" for="reverseCheck2">
-      Checked reverse radio button (Bootstrap compatible)
-    </label>
-  </div>`} />
-</BootstrapCompatibility>
-
-### Horizontal
-
-You can align horizontally up to three radio buttons if their labels are short, add sufficient space (for example by using `.gap-small`) between the controls to ensure a clear association of each labels with their corresponding indicator.
-
-<Example buttonLabel="horizontal radio buttons" code={`<fieldset class="control-items-list">
-    <div class="d-flex flex-row gap-small w-50">
-      <div class="radio-button-item flex-fill">
-        <div class="control-item-assets-container">
-          <input class="control-item-indicator" type="radio" value="" id="radioLayoutRow1" name="radioLayoutRow" />
-        </div>
-        <div class="control-item-text-container">
-          <label class="control-item-label" for="radioLayoutRow1">Option 1</label>
-        </div>
-      </div>
-      <div class="radio-button-item flex-fill">
-        <div class="control-item-assets-container">
-          <input class="control-item-indicator" type="radio" value="" id="radioLayoutRow2" name="radioLayoutRow" checked />
-        </div>
-        <div class="control-item-text-container">
-          <label class="control-item-label" for="radioLayoutRow2">Option 2</label>
-        </div>
-      </div>
-    </div>
-  </fieldset>`} />
-
-### Max width
-
-By default, radio buttons will span the whole width of their parent container, to limit the width of the radio button on wider parent container, add a `.component-max-width` to the `.radio-button-item` container. More information on radio button sizing in the [design guidelines](https://r.orange.fr/r/S-ouds-doc-radio-button-responsiveness).
-
-<Example buttonLabel="radio buttons max width" code={`<fieldset class="control-items-list">
-    <div class="radio-button-item component-max-width">
-      <div class="control-item-assets-container">
-        <input class="control-item-indicator" type="radio" aria-describedby="radioMWDescription" id="radioWithMaxWidth" value="" name="radioMaxWidth" />
-      </div>
-      <div class="control-item-text-container">
-        <label class="control-item-label" for="radioWithMaxWidth">Default radio</label>
-        <p class="control-item-description" id="radioMWDescription">Description text</p>
-      </div>
-    </div>
-    <div class="radio-button-item component-max-width">
-      <div class="control-item-assets-container">
-        <input class="control-item-indicator" type="radio" aria-describedby="radioWithMaxWidth2Description" id="radioWithMaxWidth2" value="" name="radioMaxWidth" checked />
-      </div>
-      <div class="control-item-text-container">
-        <label class="control-item-label" for="radioWithMaxWidth2">Checked radio</label>
-        <p class="control-item-description" id="radioWithMaxWidth2Description">Description text</p>
-      </div>
-    </div>
-  </fieldset>`} />
-
 ## States
 
 ### Disabled
@@ -539,6 +387,158 @@ If the layout is horizontal, the `<fieldset>` must enclose the flex containers s
       </div>
     </fieldset>
   </div>`} />
+
+## Layout
+
+### Default
+
+It's recommended to keep radio button label to no more than three words. When space is limited or when a long label, extra label or description text is required, the text can wrap, as this is preferable to truncation. The radio button indicator and the icon will remain vertically centered, until the `.control-item-assets-container` reaches a defined maximum height.
+
+<Example buttonLabel="radio buttons with long texts" code={`<div class="row">
+    <div class="col-8 md:col-6 xl:col-5">
+      <fieldset class="control-items-list">
+        <div class="radio-button-item control-item-divider">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="radio" value="" id="radioLayout1" name="radioLayout" aria-describedby="radioLayout1ExtraLabel radioLayout1Description" />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="radioLayout1">Label</label>
+            <p class="radio-button-extra-label" id="radioLayout1ExtraLabel">Extra label</p>
+            <p class="control-item-description" id="radioLayout1Description">Description text</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </div>
+        <div class="radio-button-item control-item-divider">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="radio" value="" id="radioLayout2" name="radioLayout"  aria-describedby="radioLayout2ExtraLabel radioLayout2Description" checked />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="radioLayout2">A longer label for showing behavior in this case</label>
+            <p class="radio-button-extra-label" id="radioLayout2ExtraLabel">Radio button indicator and icon will stick to the top area of the component</p>
+            <p class="control-item-description" id="radioLayout2Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>`} />
+
+### Reverse
+
+To reverse the component, simply add `.control-item-reverse` to a `.radio-button-item`.
+
+<Example buttonLabel="reversed radio buttons" code={`<div class="row">
+    <div class="col-8 md:col-6 xl:col-5">
+      <fieldset class="control-items-list">
+        <div class="radio-button-item control-item-divider control-item-reverse">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="radio" value="" id="radioLayoutRev1" name="radioLayoutRev" aria-describedby="radioLayoutRev1ExtraLabel radioLayoutRev1Description" />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="radioLayoutRev1">Label with reverse layout</label>
+            <p class="radio-button-extra-label" id="radioLayoutRev1ExtraLabel">Extra label</p>
+            <p class="control-item-description" id="radioLayoutRev1Description">Description text</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </div>
+        <div class="radio-button-item control-item-divider control-item-reverse">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="radio" value="" id="radioLayoutRev2" name="radioLayoutRev"  aria-describedby="radioLayoutRev2ExtraLabel radioLayoutRev2Description" checked />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="radioLayoutRev2">A longer label with reverse layout for showing behavior in this case</label>
+            <p class="radio-button-extra-label" id="radioLayoutRev2ExtraLabel">Radio button indicator and icon will stick to the top area of the component</p>
+            <p class="control-item-description" id="radioLayoutRev2Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg width="1rem" height="1rem" fill="currentColor" aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>`} />
+
+<BootstrapCompatibility>
+
+Put your radio buttons on the opposite side with the `.form-check-reverse` modifier class.
+
+<Example buttonLabel="Bootstrap compatibility: reversed radio buttons" code={`<div class="form-check form-check-reverse">
+    <input class="form-check-input" type="radio" value="" id="reverseCheck1" name="radioReverseBs" />
+    <label class="form-check-label" for="reverseCheck1">
+      Default reverse radio button (Bootstrap compatible)
+    </label>
+  </div>
+  <div class="form-check form-check-reverse">
+    <input class="form-check-input" type="radio" value="" id="reverseCheck2" name="radioReverseBs" checked />
+    <label class="form-check-label" for="reverseCheck2">
+      Checked reverse radio button (Bootstrap compatible)
+    </label>
+  </div>`} />
+</BootstrapCompatibility>
+
+### Horizontal
+
+You can align horizontally up to three radio buttons if their labels are short, add sufficient space (for example by using `.gap-small`) between the controls to ensure a clear association of each labels with their corresponding indicator.
+
+<Example buttonLabel="horizontal radio buttons" code={`<fieldset class="control-items-list">
+    <div class="d-flex flex-row gap-small w-50">
+      <div class="radio-button-item flex-fill">
+        <div class="control-item-assets-container">
+          <input class="control-item-indicator" type="radio" value="" id="radioLayoutRow1" name="radioLayoutRow" />
+        </div>
+        <div class="control-item-text-container">
+          <label class="control-item-label" for="radioLayoutRow1">Option 1</label>
+        </div>
+      </div>
+      <div class="radio-button-item flex-fill">
+        <div class="control-item-assets-container">
+          <input class="control-item-indicator" type="radio" value="" id="radioLayoutRow2" name="radioLayoutRow" checked />
+        </div>
+        <div class="control-item-text-container">
+          <label class="control-item-label" for="radioLayoutRow2">Option 2</label>
+        </div>
+      </div>
+    </div>
+  </fieldset>`} />
+
+### Max width
+
+By default, radio buttons will span the whole width of their parent container, to limit the width of the radio button on wider parent container, add a `.component-max-width` to the `.radio-button-item` container. More information on radio button sizing in the [design guidelines](https://r.orange.fr/r/S-ouds-doc-radio-button-responsiveness).
+
+<Example buttonLabel="radio buttons max width" code={`<fieldset class="control-items-list">
+    <div class="radio-button-item component-max-width">
+      <div class="control-item-assets-container">
+        <input class="control-item-indicator" type="radio" aria-describedby="radioMWDescription" id="radioWithMaxWidth" value="" name="radioMaxWidth" />
+      </div>
+      <div class="control-item-text-container">
+        <label class="control-item-label" for="radioWithMaxWidth">Default radio</label>
+        <p class="control-item-description" id="radioMWDescription">Description text</p>
+      </div>
+    </div>
+    <div class="radio-button-item component-max-width">
+      <div class="control-item-assets-container">
+        <input class="control-item-indicator" type="radio" aria-describedby="radioWithMaxWidth2Description" id="radioWithMaxWidth2" value="" name="radioMaxWidth" checked />
+      </div>
+      <div class="control-item-text-container">
+        <label class="control-item-label" for="radioWithMaxWidth2">Checked radio</label>
+        <p class="control-item-description" id="radioWithMaxWidth2Description">Description text</p>
+      </div>
+    </div>
+  </fieldset>`} />
 
 ## Fieldset `<legend>`
 

--- a/site/src/content/docs/components/radio-button.mdx
+++ b/site/src/content/docs/components/radio-button.mdx
@@ -339,7 +339,7 @@ This also works for outlined variant of the component.
 
 #### Horizontal
 
-If the layout is horizontal, the `<fieldset>` must enclose the flex containers so the error message is displayed under the first item.
+If the [layout is horizontal](#horizontal-1), the `<fieldset>` must enclose the flex containers so the error message is displayed under the first item.
 
 <Example buttonLabel="invalid radio buttons in an horizontal layout" code={`<fieldset class="control-items-list">
     <div class="d-flex flex-row gap-small w-50">

--- a/site/src/content/docs/components/select-input.mdx
+++ b/site/src/content/docs/components/select-input.mdx
@@ -214,27 +214,6 @@ To display a helper link below selects, use a standard small link [with `.link` 
     </a>
   </div>`} />
 
-## Layout
-
-### Max width
-
-By default, select inputs will span the whole width of their parent container, to limit the width of the select input on wider parent container, add a `.component-max-width` to the `.select-input` container.
-
-<Example buttonLabel="select inputs max width" code={`<div class="select-input component-max-width">
-    <div class="select-input-container">
-      <label for="exampleSelectMaxWidth">Select example max width</label>
-      <select class="select-input-field" id="exampleSelectMaxWidth" aria-describedby="selectMaxWidthHelper">
-        <option value="" disabled selected></option>
-        <option value="1">One</option>
-        <option value="2">Two</option>
-        <option value="3">Three</option>
-      </select>
-    </div>
-    <p id="selectMaxWidthHelper" class="helper-text">
-      Helper text.
-    </p>
-  </div>`} />
-
 ## States
 
 Apart if specified, these states should be exclusive among each others.
@@ -518,6 +497,27 @@ The `size` attribute is supported:
       </select>
     </div>
   </div>`} /> */}
+
+## Layout
+
+### Max width
+
+By default, select inputs will span the whole width of their parent container, to limit the width of the select input on wider parent container, add a `.component-max-width` to the `.select-input` container.
+
+<Example buttonLabel="select inputs max width" code={`<div class="select-input component-max-width">
+  <div class="select-input-container">
+    <label for="exampleSelectMaxWidth">Select example max width</label>
+    <select class="select-input-field" id="exampleSelectMaxWidth" aria-describedby="selectMaxWidthHelper">
+      <option value="" disabled selected></option>
+      <option value="1">One</option>
+      <option value="2">Two</option>
+      <option value="3">Three</option>
+    </select>
+  </div>
+  <p id="selectMaxWidthHelper" class="helper-text">
+    Helper text.
+  </p>
+</div>`} />
 
 ## Optgroup
 

--- a/site/src/content/docs/components/switch.mdx
+++ b/site/src/content/docs/components/switch.mdx
@@ -150,111 +150,6 @@ To display a description text, add a `.control-item-description` as a sibling of
     </li>
   </ul>`} />
 
-## Layout
-
-### Default
-
-It's recommended to keep switch label to no more than three words. When space is limited or when a long label or description text is required, the text can wrap, as this is preferable to truncation. The switch indicator and the icon will remain vertically centered, until the `.control-item-assets-container` reaches a defined maximum height.
-
-<Example buttonLabel="switches with long texts" code={`<div class="row">
-    <div class="col-8 md:col-6 xl:col-5">
-      <ul class="control-items-list">
-        <li class="switch-item control-item-divider">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchLayout1" aria-describedby="switchLayout1Description" />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="switchLayout1">Label</label>
-            <p class="control-item-description" id="switchLayout1Description">Description text</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </li>
-        <li class="switch-item control-item-divider">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchLayout2" checked aria-describedby="switchLayout2Description" />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="switchLayout2">A longer label for showing behavior in this case, switch indicator and icon will stick to the top area of the component</label>
-            <p class="control-item-description" id="switchLayout2Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </div>`} />
-
-### Reverse
-
-To reverse the component, simply add `.control-item-reverse` to a `.switch-item`.
-
-<Example buttonLabel="reversed switches" code={`<div class="row">
-    <div class="col-8 md:col-6 xl:col-5">
-      <ul class="control-items-list">
-        <li class="switch-item control-item-divider control-item-reverse">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchLayoutRev1" aria-describedby="switchLayoutRev1Description" />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="switchLayoutRev1">Label with reverse layout</label>
-            <p class="control-item-description" id="switchLayoutRev1Description">Description text</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </li>
-        <li class="switch-item control-item-divider control-item-reverse">
-          <div class="control-item-assets-container">
-            <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchLayoutRev2" checked aria-describedby="switchLayoutRev2Description" />
-          </div>
-          <div class="control-item-text-container">
-            <label class="control-item-label" for="switchLayoutRev2">A longer label with reverse layout for showing behavior in this case, switch indicator and icon will stick to the top area of the component</label>
-            <p class="control-item-description" id="switchLayoutRev2Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
-          </div>
-          <div class="control-item-assets-container">
-            <svg aria-hidden="true">
-              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
-            </svg>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </div>`} />
-
-<BootstrapCompatibility>
-Put your switches on the opposite side with the `.form-check-reverse` modifier class.
-
-<Example buttonLabel="Bootstrap compatibility: reversed switches" code={`<div class="form-check form-switch form-check-reverse">
-    <input class="form-check-input" type="checkbox" role="switch" id="switchCheckReverse" checked />
-    <label class="form-check-label" for="switchCheckReverse">Reverse switch (Bootstrap compatible)</label>
-  </div>`} />
-</BootstrapCompatibility>
-
-### Max width
-
-By default, switches will span the whole width of their parent container, to limit the width of the switch on wider parent container, add a `.component-max-width` to the `.switch-item` container. More information on switch sizing in the [design guidelines](https://r.orange.fr/r/S-ouds-doc-switch-responsiveness).
-
-<Example buttonLabel="switches max width" code={`<div class="switch-item component-max-width">
-    <div class="control-item-assets-container">
-      <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchMaxWidth" checked />
-    </div>
-    <div class="control-item-text-container">
-      <label class="control-item-label" for="switchMaxWidth">Checked switch with max width</label>
-    </div>
-    <div class="control-item-assets-container">
-      <span class="icon si si-settings" aria-hidden="true"></span>
-    </div>
-  </div>`} />
-
 ## States
 
 ### Disabled
@@ -418,6 +313,111 @@ If the switch items list is part of a form, add a `<fieldset>` with the class `.
       <div class="control-item-text-container">
         <label class="control-item-label" for="switchSkeleton">Skeleton switch</label>
       </div>
+    </div>
+  </div>`} />
+
+## Layout
+
+### Default
+
+It's recommended to keep switch label to no more than three words. When space is limited or when a long label or description text is required, the text can wrap, as this is preferable to truncation. The switch indicator and the icon will remain vertically centered, until the `.control-item-assets-container` reaches a defined maximum height.
+
+<Example buttonLabel="switches with long texts" code={`<div class="row">
+    <div class="col-8 md:col-6 xl:col-5">
+      <ul class="control-items-list">
+        <li class="switch-item control-item-divider">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchLayout1" aria-describedby="switchLayout1Description" />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="switchLayout1">Label</label>
+            <p class="control-item-description" id="switchLayout1Description">Description text</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </li>
+        <li class="switch-item control-item-divider">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchLayout2" checked aria-describedby="switchLayout2Description" />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="switchLayout2">A longer label for showing behavior in this case, switch indicator and icon will stick to the top area of the component</label>
+            <p class="control-item-description" id="switchLayout2Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>`} />
+
+### Reverse
+
+To reverse the component, simply add `.control-item-reverse` to a `.switch-item`.
+
+<Example buttonLabel="reversed switches" code={`<div class="row">
+    <div class="col-8 md:col-6 xl:col-5">
+      <ul class="control-items-list">
+        <li class="switch-item control-item-divider control-item-reverse">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchLayoutRev1" aria-describedby="switchLayoutRev1Description" />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="switchLayoutRev1">Label with reverse layout</label>
+            <p class="control-item-description" id="switchLayoutRev1Description">Description text</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </li>
+        <li class="switch-item control-item-divider control-item-reverse">
+          <div class="control-item-assets-container">
+            <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchLayoutRev2" checked aria-describedby="switchLayoutRev2Description" />
+          </div>
+          <div class="control-item-text-container">
+            <label class="control-item-label" for="switchLayoutRev2">A longer label with reverse layout for showing behavior in this case, switch indicator and icon will stick to the top area of the component</label>
+            <p class="control-item-description" id="switchLayoutRev2Description">Also a longer description text, it will also wrap at some point depending on the component width</p>
+          </div>
+          <div class="control-item-assets-container">
+            <svg aria-hidden="true">
+              <use xlink:href="${getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#heart-empty')}" />
+            </svg>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>`} />
+
+<BootstrapCompatibility>
+Put your switches on the opposite side with the `.form-check-reverse` modifier class.
+
+<Example buttonLabel="Bootstrap compatibility: reversed switches" code={`<div class="form-check form-switch form-check-reverse">
+    <input class="form-check-input" type="checkbox" role="switch" id="switchCheckReverse" checked />
+    <label class="form-check-label" for="switchCheckReverse">Reverse switch (Bootstrap compatible)</label>
+  </div>`} />
+</BootstrapCompatibility>
+
+### Max width
+
+By default, switches will span the whole width of their parent container, to limit the width of the switch on wider parent container, add a `.component-max-width` to the `.switch-item` container. More information on switch sizing in the [design guidelines](https://r.orange.fr/r/S-ouds-doc-switch-responsiveness).
+
+<Example buttonLabel="switches max width" code={`<div class="switch-item component-max-width">
+    <div class="control-item-assets-container">
+      <input class="control-item-indicator" type="checkbox" role="switch" value="" id="switchMaxWidth" checked />
+    </div>
+    <div class="control-item-text-container">
+      <label class="control-item-label" for="switchMaxWidth">Checked switch with max width</label>
+    </div>
+    <div class="control-item-assets-container">
+      <span class="icon si si-settings" aria-hidden="true"></span>
     </div>
   </div>`} />
 

--- a/site/src/content/docs/components/text-area.mdx
+++ b/site/src/content/docs/components/text-area.mdx
@@ -119,22 +119,6 @@ To display a helper link below text areas, use a standard small link [with `.lin
     </a>
   </div>`} />
 
-## Layout
-
-### Max width
-
-By default, text areas will span the whole width of their parent container, to limit the width of the text area on wider parent container, add a `.component-max-width` to the `.text-input` container.
-
-<Example buttonLabel="text areas max width" code={`<div class="text-area component-max-width">
-    <div class="text-area-container">
-      <label for="textAreaWithMaxWidth">Additional comments</label>
-      <textarea id="textAreaWithMaxWidth" class="text-area-field" aria-describedby="textAreaWithMaxWidthText"></textarea>
-    </div>
-    <p id="textAreaWithMaxWidthText" class="helper-text">
-      Please be concise and limit your comment to <strong>180</strong> characters.
-    </p>
-  </div>`} />
-
 ## States
 
 ### Disabled
@@ -222,6 +206,22 @@ To manually mark a  text area as invalid, add `aria-invalid="true"` to a `.text-
         <textarea class="text-area-field" id="skeletonTextArea"></textarea>
       </div>
     </div>
+  </div>`} />
+
+## Layout
+
+### Max width
+
+By default, text areas will span the whole width of their parent container, to limit the width of the text area on wider parent container, add a `.component-max-width` to the `.text-input` container.
+
+<Example buttonLabel="text areas max width" code={`<div class="text-area component-max-width">
+    <div class="text-area-container">
+      <label for="textAreaWithMaxWidth">Additional comments</label>
+      <textarea id="textAreaWithMaxWidth" class="text-area-field" aria-describedby="textAreaWithMaxWidthText"></textarea>
+    </div>
+    <p id="textAreaWithMaxWidthText" class="helper-text">
+      Please be concise and limit your comment to <strong>180</strong> characters.
+    </p>
   </div>`} />
 
 ## Mandatory field indication

--- a/site/src/content/docs/components/text-input.mdx
+++ b/site/src/content/docs/components/text-input.mdx
@@ -319,30 +319,6 @@ A textual prefix or suffix can be added to an input by wrapping the `<input>` in
     </p>
   </div>`} />
 
-## Layout
-
-### Max width
-
-By default, text inputs will span the whole width of their parent container, to limit the width of the text input on wider parent container, add a `.component-max-width` to the `.text-input` container.
-
-<Example buttonLabel="text inputs max width" code={`<div class="text-input component-max-width mb-medium">
-    <div class="text-input-container">
-      <label for="exampleTextInputWithMaxWidth">Email address</label>
-      <input type="email" autocomplete="email" class="text-input-field" id="exampleTextInputWithMaxWidth" placeholder=" ">
-    </div>
-  </div>
-  <div class="text-input component-max-width mb-medium">
-    <div class="text-input-container">
-      <label for="exampleTextInputWithMaxWidthSuffix">Price</label>
-      <div class="input-container" data-bs-prefix="£" data-bs-suffix=".00">
-        <input type="text" id="exampleTextInputWithMaxWidthSuffix" aria-describedby="prefixSuffixTextHelpBlockMW" class="text-input-field" placeholder="Enter amount">
-      </div>
-    </div>
-    <p id="prefixSuffixTextHelpBlockMW" class="helper-text">
-      Enter your price in Pounds (£) without decimals.
-    </p>
-  </div>`} />
-
 ## States
 
 Apart if specified, these states should be exclusive among each others.
@@ -705,6 +681,30 @@ You may also set the [trailing action on loading]([[docsref:/components/buttons#
         <input type="email" autocomplete="email" class="text-input-field" id="exampleTextInputSkeleton" placeholder=" ">
       </div>
     </div>
+  </div>`} />
+
+## Layout
+
+### Max width
+
+By default, text inputs will span the whole width of their parent container, to limit the width of the text input on wider parent container, add a `.component-max-width` to the `.text-input` container.
+
+<Example buttonLabel="text inputs max width" code={`<div class="text-input component-max-width mb-medium">
+    <div class="text-input-container">
+      <label for="exampleTextInputWithMaxWidth">Email address</label>
+      <input type="email" autocomplete="email" class="text-input-field" id="exampleTextInputWithMaxWidth" placeholder=" ">
+    </div>
+  </div>
+  <div class="text-input component-max-width mb-medium">
+    <div class="text-input-container">
+      <label for="exampleTextInputWithMaxWidthSuffix">Price</label>
+      <div class="input-container" data-bs-prefix="£" data-bs-suffix=".00">
+        <input type="text" id="exampleTextInputWithMaxWidthSuffix" aria-describedby="prefixSuffixTextHelpBlockMW" class="text-input-field" placeholder="Enter amount">
+      </div>
+    </div>
+    <p id="prefixSuffixTextHelpBlockMW" class="helper-text">
+      Enter your price in Pounds (£) without decimals.
+    </p>
   </div>`} />
 
 ## Mandatory field indication


### PR DESCRIPTION
### Related issues

Closes #3447 

### Description

- Reordered States and Layout sections so States section comes first
- Removed coming soon flag to Sass sidebar item in Getting Started section

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [x] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3601--boosted.netlify.app/>