### PR TITLE
fix(lib): use font-weight tokens instead of hard coded values

### DIFF
--- a/scss/_chips.scss
+++ b/scss/_chips.scss
@@ -42,7 +42,7 @@
   min-height: $ouds-chip-size-min-height;
   padding: calc(var(--#{$prefix}chip-padding-block) - var(--#{$prefix}chip-border-width)) calc(var(--#{$prefix}chip-padding-end) - var(--#{$prefix}chip-border-width)) calc(var(--#{$prefix}chip-padding-block) - var(--#{$prefix}chip-border-width)) calc(var(--#{$prefix}chip-padding-start) - var(--#{$prefix}chip-border-width));
   @include get-font-size("label-medium");
-  font-weight: 700;
+  font-weight: $ouds-font-weight-web-label-strong;
   color: var(--#{$prefix}chip-color);
   background-color: var(--#{$prefix}chip-bg);
   border: var(--#{$prefix}chip-border-width) solid var(--#{$prefix}chip-border-color);

--- a/scss/_tags.scss
+++ b/scss/_tags.scss
@@ -32,7 +32,7 @@
   min-height: var(--#{$prefix}tag-min-height);
   padding: calc(var(--#{$prefix}tag-padding-y) - var(--#{$prefix}tag-border-width)) calc(var(--#{$prefix}tag-padding-end) - var(--#{$prefix}tag-border-width)) calc(var(--#{$prefix}tag-padding-y) - var(--#{$prefix}tag-border-width)) calc(var(--#{$prefix}tag-padding-start) - var(--#{$prefix}tag-border-width));
   margin: 0;
-  font-weight: 700;
+  font-weight: $ouds-font-weight-web-label-strong;
   color: var(--#{$prefix}tag-color);
   white-space: nowrap;
   background-color: var(--#{$prefix}tag-background-color);

--- a/site/src/scss/_sidebar.scss
+++ b/site/src/scss/_sidebar.scss
@@ -52,11 +52,11 @@
   margin-top: .125rem;
   margin-left: 1.375rem; // OUDS mod: changed value
   @include get-font-size("body-medium"); // OUDS mod: instead of `1rem`
-  font-weight: 400; // OUDS mod: no 'bold' for the sidebar links
+  font-weight: $ouds-font-weight-web-body-default; // OUDS mod: no 'bold' for the sidebar links
   // OUDS mod: no `color`
   text-decoration: if($link-decoration == none, null, none);
 
   &.active {
-    font-weight: 600;
+    font-weight: $ouds-font-weight-system-web-strong;
   }
 }


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

Closes #3599 

### Context & Motivation

<!-- Describe the actual behavior (and how to reproduce it). -->

### Description

Updated Chips, Tags and Sidebar components to use tokens instead of hard coded font-weight.

### Checklists

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change pass all tests
- [x] My change is compatible with a responsive display
- [ ] I have added tests (Javascript unit test or visual) to cover my changes
- [ ] My change introduces changes to the documentation that I have updated accordingly
  - [ ] Title and DOM structure is correct
  - [ ] Links have been updated (title changes impact links)
  - [ ] CSS for the documentation
- [x] I have checked all states and combinations of the component with my change
- [ ] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [ ] The changes need to be in the migration guide
- [ ] The changes are well displayed in [Storybook](https://deploy-preview-3602--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [ ] The changes are compatible with RTL
- [ ] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3602--boosted.netlify.app/>
