### PR TITLE
fix(docs): updated navbar Utilities item active condition

### DIFF
--- a/site/src/components/header/Navigation.astro
+++ b/site/src/components/header/Navigation.astro
@@ -93,7 +93,7 @@ const { addedIn, layout, title } = Astro.props
             Components
           </LinkItem>
           <LinkItem
-            active={layout === 'docs' && Astro.url.pathname.includes('/utilities')}
+            active={title === 'Utilities' && Astro.url.pathname.includes('/utilities')}
             href={getVersionedDocsPath('utilities')}
             onclick="dataLayer.push({'event': 'clic', 'site_name':'accessibility-boosted', 'phase':'prod', 'track_category':'navbar', 'track_name':'utilities'});"
           >


### PR DESCRIPTION
### Related issues

Closes #3570 

### Description

Updated navbar utilities item to be set as active only when the page title is "Utilities".

### Checklists

- [X] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [X] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [X] My change follows the page structure defined in #3045
- [X] Title and DOM structure is correct
- [X] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3603--boosted.netlify.app/>