### PR TITLE
fix(docs): text area invalid label issue ids

### DIFF
--- a/site/src/content/docs/components/text-area.mdx
+++ b/site/src/content/docs/components/text-area.mdx
@@ -211,7 +211,7 @@ To manually mark a  text area as invalid, add `aria-invalid="true"` to a `.text-
 
 <Example buttonLabel="invalid text areas" code={`<div class="text-area mb-medium">
     <div class="text-area-container">
-      <label id="labelTextAreaInvalid" for="exampleTextAreaInvalid">Additional comments</label>
+      <label for="exampleTextAreaInvalid">Additional comments</label>
       <textarea class="text-area-field" aria-invalid="true" id="exampleTextAreaInvalid" aria-describedby="commentFeedback" placeholder=" "></textarea>
     </div>
     <p id="commentTextHelpBlock" class="helper-text">
@@ -223,8 +223,8 @@ To manually mark a  text area as invalid, add `aria-invalid="true"` to a `.text-
   </div>
   <div class="text-area">
     <div class="text-area-container text-area-container-outlined">
-      <label for="labelTextAreaOutlinedInvalid">Additional comments</label>
-      <textarea class="text-area-field" aria-invalid="true" id="labelTextAreaOutlinedInvalid" aria-describedby="commentFeedbackOutlined" placeholder=" ">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer viverra nisi turpis, vel dignissim enim imperdiet eu. Ut quis mollis erat. Pellentesque id leo pellentesque urna volutpat placerat non nec sem. Integer mauris eros, congue nec magna sit amet, pulvinar laoreet diam. Nam tristique nisl ac nisi aliquet, et molestie turpis maximus.</textarea>
+      <label id="labelTextAreaOutlinedInvalid" for="exampleTextAreaOutlinedInvalid">Additional comments</label>
+      <textarea class="text-area-field" aria-invalid="true" id="exampleTextAreaOutlinedInvalid" aria-describedby="commentFeedbackOutlined" placeholder=" ">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer viverra nisi turpis, vel dignissim enim imperdiet eu. Ut quis mollis erat. Pellentesque id leo pellentesque urna volutpat placerat non nec sem. Integer mauris eros, congue nec magna sit amet, pulvinar laoreet diam. Nam tristique nisl ac nisi aliquet, et molestie turpis maximus.</textarea>
     </div>
     <p id="commentTextHelpBlockOutlined" class="helper-text">
       Please be concise and limit your comment to <strong>180</strong> characters.


### PR DESCRIPTION
### Related issues

Closes #3657

### Description

Fix the labels ids on invalid text area

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3658--boosted.netlify.app/>