### PR TITLE
Fix invalid control hover state

### DIFF
--- a/scss/forms/_control-item.scss
+++ b/scss/forms/_control-item.scss
@@ -113,6 +113,7 @@
     font-size: $ouds-control-item-size-icon;
     line-height: 1;
     color: var(--#{$prefix}control-item-label-color);
+    pointer-events: none;
     background-color: currentcolor;
     mask: var(--#{$prefix}error-icon) no-repeat center;
   }

--- a/scss/tests/snapshot-tests/__snapshots__/ouds-web-bootstrap.css
+++ b/scss/tests/snapshot-tests/__snapshots__/ouds-web-bootstrap.css
@@ -5889,6 +5889,7 @@ textarea.form-control-lg {
   font-size: 28px;
   line-height: 1;
   color: var(--bs-control-item-label-color);
+  pointer-events: none;
   background-color: currentcolor;
   -webkit-mask: var(--bs-error-icon) no-repeat center;
   mask: var(--bs-error-icon) no-repeat center;

--- a/scss/tests/snapshot-tests/__snapshots__/ouds-web.css
+++ b/scss/tests/snapshot-tests/__snapshots__/ouds-web.css
@@ -3989,6 +3989,7 @@ textarea.form-control-lg {
   font-size: 28px;
   line-height: 1;
   color: var(--bs-control-item-label-color);
+  pointer-events: none;
   background-color: currentcolor;
   -webkit-mask: var(--bs-error-icon) no-repeat center;
   mask: var(--bs-error-icon) no-repeat center;


### PR DESCRIPTION
### Types of change

- [x] Non-breaking change
- [ ] Breaking change (fix or feature that would change existing functionality and usage)

### Related issues

Closes #3606

### Context & Motivation

The invalid-state error icon is rendered by an absolutely positioned `::after` pseudo-element. It receives pointer hit testing over the icon area, preventing the underlying control label from receiving hover and click interactions there.

### Description

- Ignore pointer events on the decorative invalid-state error icon.
- Refresh the two CSS snapshot fixtures that cover the generated rule.

### Validation

- `npm run css-test` (45 specs)
- `npm run css-lint`
- `npm run dist`
- `npm run css-snapshot-test` (2 tests)
- `npm run test`
- Local browser verification on the invalid radio example

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change pass all tests
- [x] My change is compatible with a responsive display
- [x] I have added tests (Javascript unit test or visual) to cover my changes
- [ ] My change introduces changes to the documentation that I have updated accordingly
  - [ ] Title and DOM structure is correct
  - [ ] Links have been updated (title changes impact links)
  - [ ] CSS for the documentation
- [x] I have checked all states and combinations of the component with my change
- [x] I have checked all the impacts for the other components and core behavior (grid, reboot, utilities)

### Checklist (for Core Team only)

- [ ] The changes need to be in the migration guide
- [ ] The changes are well displayed in [Storybook](https://deploy-preview-3692--boosted.netlify.app/storybook) (be careful if example order has changed for DSM)
- [ ] The changes are compatible with RTL
- [ ] Manually test browser compatibility with BrowserStack (Chrome 120, Firefox 121, Edge 120, Safari 15.6, iOS Safari, Chrome & Firefox on Android)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Design review
- [ ] A11y review
- [ ] Commit on `main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

- Existing invalid radio example: `/orange/docs/1.4/components/radio-button/#invalid`