### PR TITLE
fix(docs): remove inexistant color utilities

### DIFF
--- a/site/src/content/docs/utilities/color.mdx
+++ b/site/src/content/docs/utilities/color.mdx
@@ -32,7 +32,9 @@ The `.text-brand-primary` color on dark background (`#ff7900`) can be used in an
 
 Here are some compliant combinations examples for texts:
 
-<Example code={[...allTokens.filter(token => token.name.match(/\$ouds-color-content-/) && !token.name.match(/-action-/) && token.name.match(/-light/) && token.compiledValue).map(token => {
+<Example code={[...allTokens
+  .filter(token => token.name.match(/\$ouds-color-content-/) && !token.name.match(/-action-/) && !token.name.match(/-status-inverse-/) && token.name.match(/-light/) && token.compiledValue)
+  .map(token => {
     if (token.name.match(/-on-/)) {
       return `<p class="bg-surface-${token.name.split('-').slice(4, -1).join('-')} text-${token.name.split('-').slice(3, -1).join('-')} p-small fs-hl">Text ${token.name.split('-').slice(3, -1).join('-')}</p>`
     }

--- a/site/src/content/docs/utilities/color.mdx
+++ b/site/src/content/docs/utilities/color.mdx
@@ -33,7 +33,7 @@ The `.text-brand-primary` color on dark background (`#ff7900`) can be used in an
 Here are some compliant combinations examples for texts:
 
 <Example code={[...allTokens
-  .filter(token => token.name.match(/\$ouds-color-content-/) && !token.name.match(/-action-/) && !token.name.match(/-status-inverse-/) && token.name.match(/-light/) && token.compiledValue)
+  .filter(token => token.name.match(/\$ouds-color-content-/) && !token.name.match(/-action-/) && !token.name.match(/-inverse-/) && token.name.match(/-light/) && token.compiledValue)
   .map(token => {
     if (token.name.match(/-on-/)) {
       return `<p class="bg-surface-${token.name.split('-').slice(4, -1).join('-')} text-${token.name.split('-').slice(3, -1).join('-')} p-small fs-hl">Text ${token.name.split('-').slice(3, -1).join('-')}</p>`


### PR DESCRIPTION
### Related issues

Closes #3668

### Description

Filter out color content tokens that we do not generate utilities for.

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [ ] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3704--boosted.netlify.app/>