### PR TITLE
fix(docs): prevent Scss placeholder to appear as skeleton in Scss code snippets

### DIFF
--- a/site/src/scss/_component-examples.scss
+++ b/site/src/scss/_component-examples.scss
@@ -404,16 +404,6 @@
     color: var(--#{$prefix}color-content-default); // OUDS mod: instead of `var(--bs-body-color)`
     word-wrap: normal;
   }
-
-  // no skeleton in code snippets (necessary for Scss placeholder that get a .placeholder class)
-  .placeholder {
-    display: inline;
-    color: inherit;
-    &::after,
-    &::before {
-      display: none;
-    }
-  }
 }
 
 .bd-example-snippet .highlight pre {

--- a/site/src/scss/_component-examples.scss
+++ b/site/src/scss/_component-examples.scss
@@ -404,6 +404,16 @@
     color: var(--#{$prefix}color-content-default); // OUDS mod: instead of `var(--bs-body-color)`
     word-wrap: normal;
   }
+
+  // no skeleton in code snippets (necessary for Scss placeholder that get a .placeholder class)
+  .placeholder {
+    display: inline;
+    color: inherit;
+    &::after,
+    &::before {
+      display: none;
+    }
+  }
 }
 
 .bd-example-snippet .highlight pre {

--- a/site/src/scss/_syntax.scss
+++ b/site/src/scss/_syntax.scss
@@ -39,6 +39,19 @@
   user-select: none;
 }
 
+// no skeleton in SCSS snippets (necessary for SCSS placeholder that get a .placeholder class from PrismJS)
+.language-scss {
+  .placeholder {
+    display: inline;
+    color: inherit;
+
+    &::after,
+    &::before {
+      display: none;
+    }
+  }
+}
+
 // Token styles
 .token {
   &.tag {


### PR DESCRIPTION
### Related issues

Closes #3561

### Description

Reset skeleton (`.placeholder`) properties when the `.placeholer` class is inside a `.highlight` element as it is a code snippet generated for Scss code example and should not appear as a skeleton

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [ ] Title and DOM structure is correct
- [ ] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3716--boosted.netlify.app/>
