### PR TITLE
Add missing `aria-pressed="false" type="button"` to "show password" button

### DIFF
--- a/site/src/content/docs/foundation/form-validation.mdx
+++ b/site/src/content/docs/foundation/form-validation.mdx
@@ -319,7 +319,7 @@ If there is only one field in the form, or if the mandatory nature of the fields
       <div class="text-input-container">
         <label for="passwd">Password</label>
         <input type="password" id="passwd" class="text-input-field" autocomplete="new-password" placeholder=" " required>
-        <button class="btn btn-minimal btn-icon">
+        <button class="btn btn-minimal btn-icon" aria-pressed="false" type="button">
           <svg aria-hidden="true">
             <use xlink:href="${getVersionedDocsPath("/assets/img/ouds-web-sprite.svg#accessibility-vision")}"/>
           </svg>


### PR DESCRIPTION
### Related issues

Closes #3771 

### Description

Add missing `aria-pressed="false" type="button"` to "show password" button (
- `aria-pressed=false` is needed to indicate it is atoggle button, even when it is not pressed
- `type="button"` is needed to prevent from submitting the form

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [x] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3773--boosted.netlify.app/docs/foundation/form-validation/#single-field-forms-or-obvious-mandatory-fields>
