### PR TITLE
feat(docs): added color tables to background utilities

### DIFF
--- a/site/src/components/shortcodes/ColorTable.astro
+++ b/site/src/components/shortcodes/ColorTable.astro
@@ -18,6 +18,7 @@ interface Props {
   multiTheme?: boolean
   getUsage?: (colorName: string, colorPrefix?: string) => string
   getStyle?: (token: IColorToken, mode: string) => astroHTML.JSX.CSSProperties
+  hasBackdrop?: boolean
 }
 
 const getCustomProp = (colorName: string, colorPrefix: string) =>
@@ -38,7 +39,8 @@ const {
   tokenRegexp,
   multiTheme = true,
   getUsage = getCustomProp,
-  getStyle = getBackground
+  getStyle = getBackground,
+  hasBackdrop
 } = Astro.props
 
 const getLightDarkValuesFor = (colorName: string) => {
@@ -114,11 +116,11 @@ if (basicClasses.length) {
                 data-bs-theme={multiTheme ? 'light' : undefined}
               >
                 <figure
-                  class:list={['w-100 h-100 mb-none d-flex justify-content-center align-items-center', { ['bg-' + token.colorName!]: token.colorName }]}
+                  class:list={['w-100 h-100 mb-none d-flex justify-content-center align-items-center', basicClasses.length > 0 ? { [ getUsage(token.colorName).replace('.', '')]: token.colorName } : {}]}
                   style={getStyle(token, 'light')}
                   title={token.lightValue ?? ''}
                 >
-                  {token.backdropLight && (
+                  {(hasBackdrop || token.backdropLight) && (
                     <svg class="decorative-small-icon" aria-hidden="true" color={token.lightValue}>
                       <use
                         xlink:href={getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#accessibility-vision')}
@@ -135,11 +137,11 @@ if (basicClasses.length) {
               <td>
                 <div class="bg-primary ratio-21x9" data-bs-theme="dark">
                   <figure
-                    class:list={['w-100 h-100 mb-none d-flex justify-content-center align-items-center', { ['bg-' + token.colorName!]: token.colorName }]}
+                    class:list={['w-100 h-100 mb-none d-flex justify-content-center align-items-center', basicClasses.length > 0 ? { [ getUsage(token.colorName).replace('.', '')]: token.colorName } : {}]}
                     style={getStyle(token, 'dark')}
                     title={token.darkValue ?? ''}
                   >
-                    {token.backdropDark && (
+                    {(hasBackdrop || token.backdropDark) && (
                       <svg class="decorative-small-icon" aria-hidden="true" color={token.darkValue}>
                         <use
                           xlink:href={getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#accessibility-vision')}

--- a/site/src/components/shortcodes/ColorTable.astro
+++ b/site/src/components/shortcodes/ColorTable.astro
@@ -116,7 +116,7 @@ if (basicClasses.length) {
                 data-bs-theme={multiTheme ? 'light' : undefined}
               >
                 <figure
-                  class:list={['w-100 h-100 mb-none d-flex justify-content-center align-items-center', basicClasses.length > 0 ? { [ getUsage(token.colorName).replace('.', '')]: token.colorName } : {}]}
+                  class:list={['w-100 h-100 mb-none d-flex justify-content-center align-items-center', basicClasses.length > 0 ? { [ getUsage(token.colorName, colorPrefix).replace('.', '')]: token.colorName } : {}]}
                   style={getStyle(token, 'light')}
                   title={token.lightValue ?? ''}
                 >
@@ -137,7 +137,7 @@ if (basicClasses.length) {
               <td>
                 <div class="bg-primary ratio-21x9" data-bs-theme="dark">
                   <figure
-                    class:list={['w-100 h-100 mb-none d-flex justify-content-center align-items-center', basicClasses.length > 0 ? { [ getUsage(token.colorName).replace('.', '')]: token.colorName } : {}]}
+                    class:list={['w-100 h-100 mb-none d-flex justify-content-center align-items-center', basicClasses.length > 0 ? { [ getUsage(token.colorName, colorPrefix).replace('.', '')]: token.colorName } : {}]}
                     style={getStyle(token, 'dark')}
                     title={token.darkValue ?? ''}
                   >

--- a/site/src/components/shortcodes/ColorTable.astro
+++ b/site/src/components/shortcodes/ColorTable.astro
@@ -5,14 +5,15 @@ import { allTokens } from '@libs/sass-variables'
 
 interface IColorToken {
   colorName: string
-  lightValue: string
+  lightValue?: string
   darkValue?: string
   backdropLight?: string
   backdropDark?: string
 }
 
 interface Props {
-  tokenRegexp: RegExp
+  basicClasses?: string[]
+  tokenRegexp?: RegExp
   colorPrefix: string
   multiTheme?: boolean
   getUsage?: (colorName: string, colorPrefix?: string) => string
@@ -31,7 +32,14 @@ const getBackground = (token: IColorToken, mode: string): astroHTML.JSX.CSSPrope
         backgroundColor: token.backdropDark ? token.backdropDark : token.darkValue
       }
 
-const { colorPrefix, tokenRegexp, multiTheme = true, getUsage = getCustomProp, getStyle = getBackground } = Astro.props
+const {
+  colorPrefix,
+  basicClasses = [],
+  tokenRegexp,
+  multiTheme = true,
+  getUsage = getCustomProp,
+  getStyle = getBackground
+} = Astro.props
 
 const getLightDarkValuesFor = (colorName: string) => {
   let token = `$ouds-color-${colorName}`
@@ -45,7 +53,7 @@ const getLightDarkValuesFor = (colorName: string) => {
 }
 
 const matchAndGetValues = (colorToken: IDeclaration): IColorToken => {
-  const { colorName, backdropColorName } = colorToken.name.match(tokenRegexp)?.groups as {
+  const { colorName, backdropColorName } = colorToken.name.match(tokenRegexp!)?.groups as {
     colorName: string
     backdropColorName?: string
   }
@@ -59,6 +67,19 @@ const matchAndGetValues = (colorToken: IDeclaration): IColorToken => {
     // add both dark and light colors of backdrop (this is for `content-on` tokens)
     ...(backdropColorName ? getLightDarkValuesFor(backdropColorName) : {})
   }
+}
+
+let tokens: IColorToken[] = []
+if (basicClasses.length) {
+  tokens = basicClasses.map((className: string) => ({ colorName: className }))
+} else if (tokenRegexp) {
+  tokens = allTokens.filter((token) => tokenRegexp.test(token.name)).map(matchAndGetValues)
+} else {
+  tokens = [
+    {
+      colorName: colorPrefix ? colorPrefix.replace(/^.*\//, '') : 'custom'
+    }
+  ]
 }
 ---
 
@@ -82,64 +103,61 @@ const matchAndGetValues = (colorToken: IDeclaration): IColorToken => {
     </thead>
     <tbody>
       {
-        allTokens
-          .filter((token) => tokenRegexp.test(token.name))
-          .map(matchAndGetValues)
-          .map((token: IColorToken) => (
-            <tr class="align-middle">
-              <th class="w-50" scope="row">
-                <var>{token.colorName}</var>
-              </th>
-              <td>
-                <div
-                  class:list={['ratio-21x9', { 'bg-primary': multiTheme }]}
-                  data-bs-theme={multiTheme ? 'light' : undefined}
+        tokens.map((token: IColorToken) => (
+          <tr class="align-middle">
+            <th class="w-50" scope="row">
+              <var>{token.colorName}</var>
+            </th>
+            <td>
+              <div
+                class:list={['ratio-21x9', { 'bg-primary': multiTheme }]}
+                data-bs-theme={multiTheme ? 'light' : undefined}
+              >
+                <figure
+                  class:list={['w-100 h-100 mb-none d-flex justify-content-center align-items-center', { ['bg-' + token.colorName!]: token.colorName }]}
+                  style={getStyle(token, 'light')}
+                  title={token.lightValue ?? ''}
                 >
+                  {token.backdropLight && (
+                    <svg class="decorative-small-icon" aria-hidden="true" color={token.lightValue}>
+                      <use
+                        xlink:href={getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#accessibility-vision')}
+                      />
+                    </svg>
+                  )}
+                  <figcaption class="visually-hidden">
+                    <var>{token.lightValue}</var>
+                  </figcaption>
+                </figure>
+              </div>
+            </td>
+            {multiTheme && (
+              <td>
+                <div class="bg-primary ratio-21x9" data-bs-theme="dark">
                   <figure
-                    class="w-100 h-100 mb-none d-flex justify-content-center align-items-center"
-                    style={getStyle(token, 'light')}
-                    title={token.lightValue}
+                    class:list={['w-100 h-100 mb-none d-flex justify-content-center align-items-center', { ['bg-' + token.colorName!]: token.colorName }]}
+                    style={getStyle(token, 'dark')}
+                    title={token.darkValue ?? ''}
                   >
-                    {token.backdropLight && (
-                      <svg class="decorative-small-icon" aria-hidden="true" color={token.lightValue}>
+                    {token.backdropDark && (
+                      <svg class="decorative-small-icon" aria-hidden="true" color={token.darkValue}>
                         <use
                           xlink:href={getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#accessibility-vision')}
                         />
                       </svg>
                     )}
                     <figcaption class="visually-hidden">
-                      <var>{token.lightValue}</var>
+                      <var>{token.darkValue}</var>
                     </figcaption>
                   </figure>
                 </div>
               </td>
-              {multiTheme && (
-                <td>
-                  <div class="bg-primary ratio-21x9" data-bs-theme="dark">
-                    <figure
-                      class="w-100 h-100 mb-none d-flex justify-content-center align-items-center"
-                      style={getStyle(token, 'dark')}
-                      title={token.darkValue}
-                    >
-                      {token.backdropDark && (
-                        <svg class="decorative-small-icon" aria-hidden="true" color={token.darkValue}>
-                          <use
-                            xlink:href={getVersionedDocsPath('/assets/img/ouds-web-sprite.svg#accessibility-vision')}
-                          />
-                        </svg>
-                      )}
-                      <figcaption class="visually-hidden">
-                        <var>{token.darkValue}</var>
-                      </figcaption>
-                    </figure>
-                  </div>
-                </td>
-              )}
-              <td class="w-25 user-select-all">
-                <var>{getUsage(token.colorName, colorPrefix)}</var>
-              </td>
-            </tr>
-          ))
+            )}
+            <td class="w-25 user-select-all">
+              <var>{getUsage(token.colorName, colorPrefix)}</var>
+            </td>
+          </tr>
+        ))
       }
     </tbody>
   </table>

--- a/site/src/content/docs/utilities/background.mdx
+++ b/site/src/content/docs/utilities/background.mdx
@@ -57,15 +57,11 @@ In the following examples we always use a child element with `[data-bs-theme]` a
 
 Following are the equivalent Bootstrap background that you shouldn’t be using. Prefer using the classes below that conform to [our design system]([[config:ouds.web]]).
 
-<Example code={[
-  ...getData('theme-colors').map((themeColor) => `<div class="p-3 mb-2 bg-${themeColor.name}">.bg-${themeColor.name}</div>
-<div class="p-3 mb-2 bg-${themeColor.name}-subtle text-${themeColor.name}-emphasis">.bg-${themeColor.name}-subtle</div>`),
-  `<div class="p-3 mb-2 bg-body-secondary">.bg-body-secondary</div>
-<div class="p-3 mb-2 bg-body-tertiary">.bg-body-tertiary</div>
-<div class="p-3 mb-2 bg-body text-body">.bg-body</div>
-<div class="p-3 mb-2 bg-black text-white">.bg-black</div>
-<div class="p-3 mb-2 bg-white text-black">.bg-white</div>
-<div class="p-3 mb-2 bg-transparent text-body">.bg-transparent</div>`]} />
+
+<ColorTable
+  colorPrefix="bootstrap/theme/colors/"
+  basicClasses={[getData('theme-colors').map((themeColor) => [`${themeColor.name}`, `${themeColor.name}-subtle`]).flat(), 'body-secondary', 'body-tertiary', 'body', 'black', 'white', 'transparent'].flat()}
+  getUsage={(colorName) => `.bg-${colorName}`} />
 
 </BootstrapCompatibility>
 
@@ -77,46 +73,30 @@ Below are all the background utilities along with their recommended `[data-bs-th
   Please note that we use the `[data-bs-theme]` attribute on a child element so that the background does not adapt to the attribute but instead conforms to the color mode set by its ancestors.
 </Callout>
 
-<Example code={[
-  ...allTokens.filter(token => token.name.match(/\$ouds-color-bg-.*-light/))
-    .map(token => {
-      const bgName = token.name.match(/\$ouds-color-bg-(.*)-light/)[1]
-      const themesArray = allTokens.filter(allToken => {
-        return allToken.name.match(`modes-on-(bg-)?${bgName}-(dark|light)`)
-      }).map(token => token.compiledValue)
-      const theme = themesArray[0].includes('dark')
-        ? themesArray[1].includes('light')
-          ? 'root'
-          : 'dark'
-        : themesArray[1].includes('light')
-          ? 'light'
-          : 'root-inverted'
-      return `<p class="bg-${bgName} p-large fw-bold">${theme !== 'root' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'root' ? '</span>' : ''}</p>`
-    }),
-  ...allTokens.filter(token => token.name.match(/\$ouds-color-surface-.*-light/))
-    .map(token => {
-      const surfaceName = token.name.match(/\$ouds-color-surface-(.*)-light/)[1]
-      const bgName = `surface-${surfaceName}`
-      const themesArray = allTokens.filter(allToken => {
-        return allToken.name.match(`modes-on-(surface-)?${surfaceName}-(dark|light)`)
-      }).map(token => token.compiledValue)
-      const theme = themesArray[0].includes('dark')
-        ? themesArray[1].includes('light')
-          ? 'root'
-          : 'dark'
-        : themesArray[1].includes('light')
-          ? 'light'
-          : 'root-inverted'
-      return `<p class="bg-${bgName} p-large fw-bold">${theme !== 'root' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'root' ? '</span>' : ''}</p>`
-    }),
-  `<p class="bg-always-black p-large fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
-  <p class="bg-always-white p-large fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>
-  <p class="bg-transparent p-large fw-bold">.bg-transparent</p>`]} />
+<ColorTable
+  colorPrefix="ouds/color/bg/"
+  tokenRegexp={/\$ouds-color-(bg-(?<colorName>.*)-light)/}
+  getUsage={(colorName) => `.bg-${colorName}`} />
+<ColorTable
+  colorPrefix="ouds/color/surface/"
+  tokenRegexp={/\$ouds-color-(surface-(?<colorName>.*)-light)/}
+  getUsage={(colorName) => `.bg-surface-${colorName}`} />
+<ColorTable
+  colorPrefix="ouds/color/always/"
+  tokenRegexp={/\$ouds-color-always-(?!on-)(?<colorName>.*)/}
+  getUsage={(colorName) => `.bg-always-${colorName}`}
+  multiTheme={false} />
+<ColorTable
+  colorPrefix="ouds/color/transparent/"
+  basicClasses={['transparent']}
+  getUsage={(colorName) => `.bg-${colorName}`} />
 
 We also provide opacity-based background classes, which should be used only in specific contexts where you need to adjust background opacity to enhance text readability. In most cases, `.bg-secondary` or `.bg-surface-secondary` are the preferred alternatives.
 
-<Example code={`<p class="bg-opacity-lower p-large fw-bold">.bg-opacity-lower</p>
-  <p class="bg-opacity-lowest p-large fw-bold">.bg-opacity-lowest</p>`} />
+<ColorTable
+  colorPrefix="ouds/color/opacity/"
+  tokenRegexp={/\$ouds-color-opacity-(?<colorName>(lower|lowest))-light/}
+  getUsage={(colorName) => `.bg-opacity-${colorName}`} />
 
 ## Inside a static color mode
 
@@ -131,44 +111,35 @@ For example in a `light` color mode context, dark backgrounds like `.bg-inverse-
 <details class="mb-large px-small">
   <summary class="py-small">You’re in a static <code>light</code> context</summary>
 
-<Example class="p-none" code={[`<div class="bg-always-white p-large">
-    <div data-bs-theme="light">`,
-    ...allTokens.filter(token => token.name.match(/\$ouds-color-bg-.*-light/))
-      .map(token => {
-        const bgName = token.name.match(/\$ouds-color-bg-(.*)-light/)[1]
-        const themesArray = allTokens.filter(allToken => {
-          return allToken.name.match(`modes-on-(bg-)?${bgName}-(dark|light)`)
-        }).map(token => token.compiledValue)
-        const theme = themesArray[1].includes('light')
-          ? 'light'
-          : 'dark'
-        return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'light' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'light' ? '</span>' : ''}</p>`
-      }),
-    ...allTokens.filter(token => token.name.match(/\$ouds-color-surface-.*-light/))
-      .map(token => {
-        const surfaceName = token.name.match(/\$ouds-color-surface-(.*)-light/)[1]
-        const bgName = `surface-${surfaceName}`
-        const themesArray = allTokens.filter(allToken => {
-          return allToken.name.match(`modes-on-(surface-)?${surfaceName}-(dark|light)`)
-        }).map(token => token.compiledValue)
-        const theme = themesArray[1].includes('light')
-          ? 'light'
-          : 'dark'
-        return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'light' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'light' ? '</span>' : ''}</p>`
-      }),
-  `    <p class="bg-always-black p-large fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
-      <p class="bg-always-white p-large fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>
-      <p class="bg-transparent p-large fw-bold">.bg-transparent</p>`,
-  `  </div>
-  </div>`]} />
-
-<Example code={`<div class="bg-always-white p-large">
+  <div class="bg-always-white">
     <div data-bs-theme="light">
-      <p class="bg-opacity-lower p-large fw-bold">.bg-opacity-lower</p>
-      <p class="bg-opacity-lowest p-large fw-bold">.bg-opacity-lowest</p>
+      <ColorTable
+        colorPrefix="ouds/color/bg/"
+        tokenRegexp={/\$ouds-color-(bg-(?<colorName>.*)-light)/}
+        getUsage={(colorName) => `.bg-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/surface/"
+        tokenRegexp={/\$ouds-color-(surface-(?<colorName>.*)-light)/}
+        getUsage={(colorName) => `.bg-surface-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/always/"
+        tokenRegexp={/\$ouds-color-always-(?!on-)(?<colorName>.*)/}
+        getUsage={(colorName) => `.bg-always-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/transparent/"
+        basicClasses={['transparent']}
+        getUsage={(colorName) => `.bg-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/opacity/"
+        tokenRegexp={/\$ouds-color-opacity-(?<colorName>(lower|lowest))-light/}
+        getUsage={(colorName) => `.bg-opacity-${colorName}`}
+        multiTheme={false} />
     </div>
-  </div>`} />
-
+  </div>
 </details>
 
 With a `dark` color mode context, light backgrounds like `.bg-inverse-high` will stay light so we must add a `[data-bs-theme="light"]` child element for descendants to set the descendant in the right mode.
@@ -176,44 +147,35 @@ With a `dark` color mode context, light backgrounds like `.bg-inverse-high` will
 <details class="mb-large px-small">
   <summary class="py-small">You’re in a static <code>dark</code> context</summary>
 
-<Example class="p-none" code={[`<div class="bg-always-black p-large">
-    <div data-bs-theme="dark">`,
-    ...allTokens.filter(token => token.name.match(/\$ouds-color-bg-.*-light/))
-      .map(token => {
-        const bgName = token.name.match(/\$ouds-color-bg-(.*)-light/)[1]
-        const themesArray = allTokens.filter(allToken => {
-          return allToken.name.match(`modes-on-(bg-)?${bgName}-(dark|light)`)
-        }).map(token => token.compiledValue)
-        const theme = themesArray[0].includes('dark')
-          ? 'dark'
-          : 'light'
-        return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'dark' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'dark' ? '</span>' : ''}</p>`
-      }),
-    ...allTokens.filter(token => token.name.match(/\$ouds-color-surface-.*-light/))
-      .map(token => {
-        const surfaceName = token.name.match(/\$ouds-color-surface-(.*)-light/)[1]
-        const bgName = `surface-${surfaceName}`
-        const themesArray = allTokens.filter(allToken => {
-          return allToken.name.match(`modes-on-(surface-)?${surfaceName}-(dark|light)`)
-        }).map(token => token.compiledValue)
-        const theme = themesArray[0].includes('dark')
-          ? 'dark'
-          : 'light'
-        return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'dark' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'dark' ? '</span>' : ''}</p>`
-      }),
-  `    <p class="bg-always-black p-large fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
-      <p class="bg-always-white p-large fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>
-      <p class="bg-transparent p-large fw-bold">.bg-transparent</p>`,
-  `  </div>
-  </div>`]} />
-
-<Example code={`<div class="bg-always-black p-large">
+  <div class="bg-always-black">
     <div data-bs-theme="dark">
-      <p class="bg-opacity-lower p-large fw-bold">.bg-opacity-lower</p>
-      <p class="bg-opacity-lowest p-large fw-bold">.bg-opacity-lowest</p>
+      <ColorTable
+        colorPrefix="ouds/color/bg/"
+        tokenRegexp={/\$ouds-color-(bg-(?<colorName>.*)-light)/}
+        getUsage={(colorName) => `.bg-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/surface/"
+        tokenRegexp={/\$ouds-color-(surface-(?<colorName>.*)-light)/}
+        getUsage={(colorName) => `.bg-surface-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/always/"
+        tokenRegexp={/\$ouds-color-always-(?!on-)(?<colorName>.*)/}
+        getUsage={(colorName) => `.bg-always-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/transparent/"
+        basicClasses={['transparent']}
+        getUsage={(colorName) => `.bg-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/opacity/"
+        tokenRegexp={/\$ouds-color-opacity-(?<colorName>(lower|lowest))-light/}
+        getUsage={(colorName) => `.bg-opacity-${colorName}`}
+        multiTheme={false} />
     </div>
-  </div>`} />
-
+  </div>
 </details>
 
 ## Inside a dynamic color mode
@@ -223,88 +185,50 @@ The following examples demonstrate the proper use of `[data-bs-theme]` in dynami
 <details class="mb-large px-small">
   <summary class="py-small">You’re in a dynamic <code>root-inverted</code> context</summary>
 
-<Example class="p-none" code={[`<div class="bg-inverse-high p-large">
-    <div data-bs-theme="root-inverted">`,
-    ...allTokens.filter(token => token.name.match(/\$ouds-color-bg-.*-light/))
-      .map(token => {
-        const bgName = token.name.match(/\$ouds-color-bg-(.*)-light/)[1]
-        const themesArray = allTokens.filter(allToken => {
-          return allToken.name.match(`modes-on-(bg-)?${bgName}-(dark|light)`)
-        }).map(token => token.compiledValue)
-        const theme = themesArray[0].includes('dark')
-          ? themesArray[1].includes('light')
-            ? 'root-inverted'
-            : 'dark'
-          : themesArray[1].includes('light')
-            ? 'light'
-            : 'root'
-        return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'root-inverted' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'root-inverted' ? '</span>' : ''}</p>`
-      }),
-    ...allTokens.filter(token => token.name.match(/\$ouds-color-surface-.*-light/))
-      .map(token => {
-        const surfaceName = token.name.match(/\$ouds-color-surface-(.*)-light/)[1]
-        const bgName = `surface-${surfaceName}`
-        const themesArray = allTokens.filter(allToken => {
-          return allToken.name.match(`modes-on-(surface-)?${surfaceName}-(dark|light)`)
-        }).map(token => token.compiledValue)
-        const theme = themesArray[0].includes('dark')
-          ? themesArray[1].includes('light')
-            ? 'root-inverted'
-            : 'dark'
-          : themesArray[1].includes('light')
-            ? 'light'
-            : 'root'
-        return `    <p class="bg-${bgName} p-large fw-bold">${theme !== 'root-inverted' ? `<span data-bs-theme="${theme}">` : ''}.bg-${bgName}${theme !== 'root-inverted' ? '</span>' : ''}</p>`
-      }),
-  `    <p class="bg-always-black p-large fw-bold"><span data-bs-theme="dark">.bg-always-black</span></p>
-      <p class="bg-always-white p-large fw-bold"><span data-bs-theme="light">.bg-always-white</span></p>
-      <p class="bg-transparent p-large fw-bold">.bg-transparent</p>`,
-  `  </div>
-  </div>`]} />
-
-<Example code={`<div class="bg-inverse-high p-large">
+  <div class="bg-inverse-high">
     <div data-bs-theme="root-inverted">
-      <p class="bg-opacity-lower p-large fw-bold">.bg-opacity-lower</p>
-      <p class="bg-opacity-lowest p-large fw-bold">.bg-opacity-lowest</p>
+      <ColorTable
+        colorPrefix="ouds/color/bg/"
+        tokenRegexp={/\$ouds-color-(bg-(?<colorName>.*)-light)/}
+        getUsage={(colorName) => `.bg-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/surface/"
+        tokenRegexp={/\$ouds-color-(surface-(?<colorName>.*)-light)/}
+        getUsage={(colorName) => `.bg-surface-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/always/"
+        tokenRegexp={/\$ouds-color-always-(?!on-)(?<colorName>.*)/}
+        getUsage={(colorName) => `.bg-always-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/transparent/"
+        basicClasses={['transparent']}
+        getUsage={(colorName) => `.bg-${colorName}`}
+        multiTheme={false} />
+      <ColorTable
+        colorPrefix="ouds/color/opacity/"
+        tokenRegexp={/\$ouds-color-opacity-(?<colorName>(lower|lowest))-light/}
+        getUsage={(colorName) => `.bg-opacity-${colorName}`}
+        multiTheme={false} />
     </div>
-  </div>`} />
-
+  </div>
 </details>
 
 ## Colored backgrounds
 
 The following colored backgrounds are designed for specific use cases and can only accommodate a limited set of components, such as buttons, links, and text elements. For accessibility reasons, we need to remove the color of these components this is achieved by the colored variants of [buttons]([[docsref:/components/buttons#colored-background]]) and [links]([[docsref:/components/links#on-colored-background]]).
 
-<Example code={[
-  ...allTokens.filter(token => (token.name.match(/\$ouds-color-surface-brand.*-light/) && token.compiledValue)).map(token => {
-    const brandName = token.name.match(/\$ouds-color-surface-brand-(.*)-light/)[1]
-    const themesArray = allTokens.filter(allToken => {
-      return allToken.name.match(`modes-on-brand-${brandName}-(dark|light)`)
-    }).map(token => token.compiledValue)
-    const theme = themesArray[0].includes('dark')
-      ? themesArray[1].includes('light')
-        ? 'root'
-        : 'dark'
-      : themesArray[1].includes('light')
-        ? 'light'
-        : 'root-inverted'
-    return `<p class="bg-surface-brand-${brandName} p-large fw-bold">${theme !== 'root' ? `<span data-bs-theme="${theme}">` : ''}.bg-surface-brand-${brandName}${theme !== 'root' ? '</span>' : ''}</p>`
-  }),
-  ...allTokens.filter(token => (token.name.match(/\$ouds-color-surface-status-.*-emphasized-light/) && token.compiledValue)).map(token => {
-    const statusName = token.name.match(/\$ouds-color-surface-status-(.*)-emphasized-light/)[1]
-    const themesArray = allTokens.filter(allToken => {
-      return allToken.name.match(`modes-on-status-${statusName}`)
-    }).map(token => token.compiledValue)
-    const theme = themesArray[0].includes('dark')
-      ? themesArray[1].includes('light')
-        ? 'root'
-        : 'dark'
-      : themesArray[1].includes('light')
-        ? 'light'
-        : 'root-inverted'
-    return `<p class="bg-surface-status-${statusName}-emphasized p-large fw-bold">${theme !== 'root' ? `<span data-bs-theme="${theme}">` : ''}.bg-surface-status-${statusName}-emphasized${theme !== 'root' ? '</span>' : ''}</p>`
-  })
-  ]} />
+
+  <ColorTable
+    colorPrefix="ouds/color/surface/brand/"
+    tokenRegexp={/\$ouds-color-(surface-brand-(?<colorName>.*)-light)/}
+    getUsage={(colorName) => `.bg-surface-brand-${colorName}`} />
+  <ColorTable
+    colorPrefix="ouds/color/surface/status/"
+    tokenRegexp={/\$ouds-color-(surface-status-(?<colorName>.*)-emphasized-light)/}
+    getUsage={(colorName) => `.bg-surface-status-${colorName}-emphasized`} />
 
 ## Multiple backgrounds
 

--- a/site/src/content/docs/utilities/background.mdx
+++ b/site/src/content/docs/utilities/background.mdx
@@ -59,7 +59,7 @@ Following are the equivalent Bootstrap background that you shouldn’t be using.
 
 
 <ColorTable
-  colorPrefix="bootstrap/theme/colors/"
+  colorPrefix="bootstrap/bg/"
   basicClasses={[getData('theme-colors').map((themeColor) => [`${themeColor.name}`, `${themeColor.name}-subtle`]).flat(), 'body-secondary', 'body-tertiary', 'body', 'black', 'white', 'transparent'].flat()}
   getUsage={(colorName) => `.bg-${colorName}`} />
 
@@ -252,7 +252,10 @@ Color and background helpers combine the power of our [`.text-*` utilities]([[do
   There’s currently no support for a CSS-native `color-contrast` function, so we use our own via Sass. This means that customizing our theme colors via CSS variables may cause color contrast issues with these utilities.
 </Callout>
 
-<Example buttonLabel="text and background colors (Bootstrap compatibility)" code={[
-  ...getData('theme-colors').map((themeColor) => `<div class="text-bg-${themeColor.name} p-3">${themeColor.title} with contrasting color</div>`)
-]} />
+<ColorTable
+  colorPrefix="bootstrap/text/bg/"
+  basicClasses={[...getData('theme-colors').map((themeColor) => themeColor.name)]}
+  getUsage={(colorName) => `.text-bg-${colorName}`}
+  hasBackdrop={true} />
+
 </BootstrapCompatibility>


### PR DESCRIPTION
### Related issues

Closes #3489 

### Description

Improves background documentation by displaying them in color tables like in color utilities docs.

### Checklists

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/ouds/main/.github/CONTRIBUTING.md)
- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/wiki/Developer-guide)
- [x] My change follows the page structure defined in #3045
- [x] Title and DOM structure is correct
- [x] Links have been updated (title change impacts links for example)

### Progression (for Core Team only)

- [ ] Code review
- [ ] Commit on `ouds/main` following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)

### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-3782--boosted.netlify.app/>